### PR TITLE
fix-to-port-in-use-detection

### DIFF
--- a/src/BrightScriptDebugSession.ts
+++ b/src/BrightScriptDebugSession.ts
@@ -493,7 +493,7 @@ export class BrightScriptDebugSession extends DebugSession {
             // #endregion
 
             // prepare static file hosting
-            this.componentLibraryServer.startStaticFileHosting(this.componentLibrariesOutDir, port, (message) => { this.sendDebugLogLine(message); });
+            await this.componentLibraryServer.startStaticFileHosting(this.componentLibrariesOutDir, port, (message) => { this.sendDebugLogLine(message); });
         }
     }
 

--- a/src/ComponentLibraryServer.ts
+++ b/src/ComponentLibraryServer.ts
@@ -10,10 +10,10 @@ export class ComponentLibraryServer {
 
     public componentLibrariesOutDir: string;
 
-    public startStaticFileHosting(componentLibrariesOutDir: string, port: number, sendDebugLogLine) {
+    public async startStaticFileHosting(componentLibrariesOutDir: string, port: number, sendDebugLogLine) {
 
         // Make sure the requested port is not already being used by another service
-        if (util.isPortInUse(port)) {
+        if (await util.isPortInUse(port)) {
             throw new Error(`Could not host component library files.\nPort ${port} is currently occupied.`);
         }
 


### PR DESCRIPTION
Fixed an issue where every port was being flagged as is use in the ComponentLibraryServer.

Related to issue #204 and pr #205 