### PR TITLE
Enables replacement of all ${env:VARIABLE} replacements

### DIFF
--- a/src/DebugConfigurationProvider.ts
+++ b/src/DebugConfigurationProvider.ts
@@ -295,22 +295,6 @@ export class BrightScriptDebugConfigurationProvider implements DebugConfiguratio
             }
 
             config = JSON.parse(configString);
-
-            // apply any default values to env placeholders
-            for (let key in config) {
-                let configValue = config[key];
-                let match: RegExpMatchArray;
-                //replace all environment variable placeholders with their values
-                while (match = regexp.exec(configValue)) {
-                    let environmentVariableName = match[1];
-                    let environmentVariableValue = envConfig[environmentVariableName];
-                    if (!environmentVariableValue) {
-                        configValue = this.configDefaults[key];
-                        console.log(`The configuration value for ${key} was not found in the env file under the name ${environmentVariableName}. Defaulting the value to: ${configValue}`);
-                    }
-                }
-                config[key] = configValue;
-            }
         }
         return config;
     }

--- a/src/DebugConfigurationProvider.ts
+++ b/src/DebugConfigurationProvider.ts
@@ -295,6 +295,22 @@ export class BrightScriptDebugConfigurationProvider implements DebugConfiguratio
             }
 
             config = JSON.parse(configString);
+
+            // apply any default values to env placeholders
+            for (let key in config) {
+                let configValue = config[key];
+                let match: RegExpMatchArray;
+                //replace all environment variable placeholders with their values
+                while (match = regexp.exec(configValue)) {
+                    let environmentVariableName = match[1];
+                    let environmentVariableValue = envConfig[environmentVariableName];
+                    if (!environmentVariableValue) {
+                        configValue = this.configDefaults[key];
+                        console.log(`The configuration value for ${key} was not found in the env file under the name ${environmentVariableName}. Defaulting the value to: ${configValue}`);
+                    }
+                }
+                config[key] = configValue;
+            }
         }
         return config;
     }

--- a/src/DebugConfigurationProvider.ts
+++ b/src/DebugConfigurationProvider.ts
@@ -279,18 +279,33 @@ export class BrightScriptDebugConfigurationProvider implements DebugConfiguratio
             //parse the .env file
             let envConfig = dotenv.parse(await this.fsExtra.readFile(envFilePath));
 
-            //replace any env placeholders
+            // temporarily convert entire config to string for any envConfig replacements.
+            let configString = JSON.stringify(config)
+            
+            let match: RegExpMatchArray;
+            let regexp = /\$\{env:([\w\d_]*)\}/g;
+            
+            // apply any defined values to env placeholders
+            while (match = regexp.exec(configString)) {
+                let environmentVariableName = match[1];
+                let environmentVariableValue = envConfig[environmentVariableName];
+                
+                if (environmentVariableValue) {
+                    configString = configString.replace(match[0], environmentVariableValue);
+                }
+            }
+
+            config = JSON.parse(configString);
+            
+            // apply any default values to env placeholders
             for (let key in config) {
                 let configValue = config[key];
                 let match: RegExpMatchArray;
-                let regexp = /\$\{env:([\w\d_]*)\}/g;
                 //replace all environment variable placeholders with their values
                 while (match = regexp.exec(configValue)) {
                     let environmentVariableName = match[1];
                     let environmentVariableValue = envConfig[environmentVariableName];
-                    if (environmentVariableValue) {
-                        configValue = configValue.replace(match[0], environmentVariableValue);
-                    } else {
+                    if (!environmentVariableValue) {
                         configValue = this.configDefaults[key];
                         console.log(`The configuration value for ${key} was not found in the env file under the name ${environmentVariableName}. Defaulting the value to: ${configValue}`);
                     }
@@ -298,7 +313,6 @@ export class BrightScriptDebugConfigurationProvider implements DebugConfiguratio
                 config[key] = configValue;
             }
         }
-
         return config;
     }
 

--- a/src/DebugConfigurationProvider.ts
+++ b/src/DebugConfigurationProvider.ts
@@ -280,23 +280,22 @@ export class BrightScriptDebugConfigurationProvider implements DebugConfiguratio
             let envConfig = dotenv.parse(await this.fsExtra.readFile(envFilePath));
 
             // temporarily convert entire config to string for any envConfig replacements.
-            let configString = JSON.stringify(config)
-            
+            let configString = JSON.stringify(config);
             let match: RegExpMatchArray;
             let regexp = /\$\{env:([\w\d_]*)\}/g;
-            
+
             // apply any defined values to env placeholders
             while (match = regexp.exec(configString)) {
                 let environmentVariableName = match[1];
                 let environmentVariableValue = envConfig[environmentVariableName];
-                
+
                 if (environmentVariableValue) {
                     configString = configString.replace(match[0], environmentVariableValue);
                 }
             }
 
             config = JSON.parse(configString);
-            
+
             // apply any default values to env placeholders
             for (let key in config) {
                 let configValue = config[key];


### PR DESCRIPTION
Now handles all env variable replacements for launch.json configs.

Even if you use them in your `bsconfig.json` file they will replace - which is a nice side effect for some of the projects I'm part of right now actually.

I left the existing piece that was setting default values based on config keys that you put in the env file but I'm not sure how applicable that is so you can let me know if that needs to just get scrapped now.

Let me know if anything sounds like it might break something else but it appears to be working as intended as of right now.