### PR TITLE
fixes broken document links on windows.

### DIFF
--- a/src/LogDocumentLinkProvider.ts
+++ b/src/LogDocumentLinkProvider.ts
@@ -83,22 +83,15 @@ export class LogDocumentLinkProvider implements vscode.DocumentLinkProvider {
 
     public addCustomFileLink(customLink: CustomDocumentLink) {
         let range = new Range(new Position(customLink.outputLine, customLink.startChar), new Position(customLink.outputLine, customLink.startChar + customLink.length));
-        let uri = vscode.Uri.file(customLink.pkgPath);
-        if (customLink.lineNumber) {
-            uri = uri.with({ fragment: customLink.lineNumber.toString().trim() });
-        }
-
+        let uri = vscode.Uri.parse(`vscode://rokucommunity.brightscript/openFile/${customLink.pkgPath}#${customLink.lineNumber}`)
         this.customLinks.push(new DocumentLink(range, uri));
     }
 
     public addCustomPkgLink(customLink: CustomDocumentLink) {
         let fileMap = this.getFileMap(customLink.pkgPath);
         if (fileMap) {
-            let uri = vscode.Uri.file(fileMap.src);
-            if (customLink.lineNumber) {
-                uri = uri.with({ fragment: customLink.lineNumber.toString().trim() });
-            }
             let range = new Range(new Position(customLink.outputLine, customLink.startChar), new Position(customLink.outputLine, customLink.startChar + customLink.length));
+             let uri = vscode.Uri.parse(`vscode://rokucommunity.brightscript/openFile/${customLink.pkgPath}#${customLink.lineNumber}`)
             this.customLinks.push(new DocumentLink(range, uri));
         } else {
             console.log('could not find matching file for link with path ' + customLink.pkgPath);

--- a/src/LogDocumentLinkProvider.ts
+++ b/src/LogDocumentLinkProvider.ts
@@ -83,7 +83,7 @@ export class LogDocumentLinkProvider implements vscode.DocumentLinkProvider {
 
     public addCustomFileLink(customLink: CustomDocumentLink) {
         let range = new Range(new Position(customLink.outputLine, customLink.startChar), new Position(customLink.outputLine, customLink.startChar + customLink.length));
-        let uri = vscode.Uri.parse(`vscode://rokucommunity.brightscript/openFile/${customLink.pkgPath}#${customLink.lineNumber}`)
+        let uri = vscode.Uri.parse(`vscode://rokucommunity.brightscript/openFile/${customLink.pkgPath}#${customLink.lineNumber}`);
         this.customLinks.push(new DocumentLink(range, uri));
     }
 
@@ -91,7 +91,7 @@ export class LogDocumentLinkProvider implements vscode.DocumentLinkProvider {
         let fileMap = this.getFileMap(customLink.pkgPath);
         if (fileMap) {
             let range = new Range(new Position(customLink.outputLine, customLink.startChar), new Position(customLink.outputLine, customLink.startChar + customLink.length));
-             let uri = vscode.Uri.parse(`vscode://rokucommunity.brightscript/openFile/${customLink.pkgPath}#${customLink.lineNumber}`)
+            let uri = vscode.Uri.parse(`vscode://rokucommunity.brightscript/openFile/${customLink.pkgPath}#${customLink.lineNumber}`);
             this.customLinks.push(new DocumentLink(range, uri));
         } else {
             console.log('could not find matching file for link with path ' + customLink.pkgPath);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -83,7 +83,7 @@ export class Extension {
         );
 
         vscode.window.registerUriHandler({
-            async handleUri(uri: vscode.Uri) {
+            handleUri: async function(uri: vscode.Uri) {
                 if (uri.path.startsWith('/openFile/')) {
                     let docUri = vscode.Uri.file(uri.path.substr(10));
                     let doc = await vscode.workspace.openTextDocument(docUri);

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -96,7 +96,6 @@ export class Extension {
                         at: 'center'
                     });
                 }
-
             }
         });
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -82,6 +82,24 @@ export class Extension {
             vscode.languages.registerDocumentLinkProvider({ language: 'Log' }, docLinkProvider)
         );
 
+        vscode.window.registerUriHandler({
+            async handleUri(uri: vscode.Uri) {
+                if (uri.path.startsWith('/openFile/')) {
+                    let docUri = vscode.Uri.file(uri.path.substr(10));
+                    let doc = await vscode.workspace.openTextDocument(docUri);
+                    await vscode.window.showTextDocument(doc, { preview: false });
+                    let editor = vscode.window.activeTextEditor;
+                    let lineNumber = Number(uri.fragment) ? Number(uri.fragment) - 1 : 0;
+                    editor.selection = new vscode.Selection(lineNumber, 0, lineNumber, 0);
+                    vscode.commands.executeCommand('revealLine', {
+                        lineNumber: lineNumber,
+                        at: 'center'
+                    });
+                }
+
+            }
+        });
+
         //give the launch config to the link provider any time we launch the app
         vscode.debug.onDidReceiveDebugSessionCustomEvent(async (e) => {
             if (e.event === 'BSLaunchStartEvent') {

--- a/src/mockVscode.spec.ts
+++ b/src/mockVscode.spec.ts
@@ -100,7 +100,8 @@ export let vscode = {
         activeTextEditor: {
             document: undefined
         },
-        onDidChangeTextEditorSelection: () => { }
+        onDidChangeTextEditorSelection: () => { },
+        registerUriHandler: () => { }
     },
     CompletionItemKind: {
         Function: 2
@@ -266,7 +267,8 @@ export let vscode = {
                     return {};
                 }
             };
-        }
+        },
+        parse: () => { }
     },
     SnippetString: class {
         constructor(value: string = null) {


### PR DESCRIPTION
This pr fixes the issue here: https://github.com/microsoft/vscode/issues/81520

This has likely _always_ been broken, while I've been in click happy link bliss on ubuntu/mac.

I use @TwitchBronBron suggested fix here, of registering a link provider, works perfect, as the gif attests:

![linkfix](https://user-images.githubusercontent.com/1214545/105206983-44cca500-5b47-11eb-8787-f21eba87aad2.gif)
