### PR TITLE
Add command to restart language server

### DIFF
--- a/package.json
+++ b/package.json
@@ -1532,6 +1532,12 @@
                     "light": "./images/preview-right-light.svg",
                     "dark": "./images/preview-right-dark.svg"
                 }
+            },
+            {
+                "command": "extension.brightscript.languageServer.restart",
+                "title": "Restart Language Server",
+                "category": "BrightScript",
+                "icon": "$(refresh)"
             }
         ],
         "keybindings": [

--- a/src/LanguageServerManager.ts
+++ b/src/LanguageServerManager.ts
@@ -3,7 +3,6 @@ import {
     LanguageClientOptions,
     ServerOptions,
     TransportKind,
-    ExecuteCommandOptions,
     ExecuteCommandParams
 } from 'vscode-languageclient';
 import * as vscode from 'vscode';
@@ -22,7 +21,7 @@ import { BrightScriptDocumentSymbolProvider } from './BrightScriptDocumentSymbol
 import { BrightScriptReferenceProvider } from './BrightScriptReferenceProvider';
 import BrightScriptSignatureHelpProvider from './BrightScriptSignatureHelpProvider';
 import { DefinitionRepository } from './DefinitionRepository';
-import { DeclarationProvider } from './DeclarationProvider';
+import { util } from './util';
 
 export class LanguageServerManager {
     constructor() {
@@ -180,12 +179,23 @@ export class LanguageServerManager {
         }
     }
 
+    /**
+     * Stop and then start the language server.
+     * This is a noop if the language server is currently disabled
+     */
+    public async restart() {
+        this.disableLanguageServer();
+        await util.delay(1);
+        await this.enableLanguageServer();
+    }
+
     private disableLanguageServer() {
         if (this.client) {
             this.client.stop();
             this.buildStatusStatusBar.dispose();
             this.buildStatusStatusBar = undefined;
             this.client = undefined;
+            this.deferred = new Deferred();
         }
         //enable the simple providers (since there is no language server)
         this.enableSimpleProviders();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -59,6 +59,10 @@ export class Extension {
             vscode.debug.activeDebugSession.customRequest('rendezvous.clearHistory');
         }));
 
+        context.subscriptions.push(vscode.commands.registerCommand('extension.brightscript.languageServer.restart', async () => {
+            await languageServerManager.restart();
+        }));
+
         //register the code formatter
         context.subscriptions.push(
             vscode.languages.registerDocumentRangeFormattingEditProvider({


### PR DESCRIPTION
Adds command to restart the language server from within vscode. This eliminates the need to completely reload vscode.