### PR TITLE
Language Server picker

### DIFF
--- a/package.json
+++ b/package.json
@@ -1386,6 +1386,11 @@
                     "description": "If enabled, the 'BrightScript Log' output channel will be focused as soon as this extension is initialized",
                     "default": false,
                     "scope": "resource"
+                },
+                "brightscript.bsdk": {
+                    "type": "string",
+                    "description": "Path to the BrighterScript module to use for the BrightScript and BrighterScript language features",
+                    "scope": "resource"
                 }
             }
         },
@@ -1538,6 +1543,11 @@
                 "title": "Restart Language Server",
                 "category": "BrightScript",
                 "icon": "$(refresh)"
+            },
+            {
+                "command": "extension.brightscript.languageServer.info",
+                "title": "View BrighterScript LanguageServer Info",
+                "category": "BrightScript"
             }
         ],
         "keybindings": [

--- a/src/BrightScriptCommands.ts
+++ b/src/BrightScriptCommands.ts
@@ -3,6 +3,7 @@ import * as vscode from 'vscode';
 import BrightScriptFileUtils from './BrightScriptFileUtils';
 import { GlobalStateManager } from './GlobalStateManager';
 import { brighterScriptPreviewCommand } from './commands/BrighterScriptPreviewCommand';
+import { languageServerInfoCommand } from './commands/LanguageServerInfoCommand';
 
 export class BrightScriptCommands {
 
@@ -18,6 +19,7 @@ export class BrightScriptCommands {
         this.context = context;
 
         brighterScriptPreviewCommand.register(context);
+        languageServerInfoCommand.register(context);
 
         let subscriptions = context.subscriptions;
 

--- a/src/LanguageServerManager.spec.ts
+++ b/src/LanguageServerManager.spec.ts
@@ -2,14 +2,20 @@
 /* tslint:disable:no-var-requires */
 /* tslint:disable:no-string-literal */
 import { createSandbox } from 'sinon';
-let Module = require('module');
 import { vscode, vscodeLanguageClient } from './mockVscode.spec';
 import { LanguageServerManager } from './LanguageServerManager';
 import { expect } from 'chai';
 import { DefinitionRepository } from './DefinitionRepository';
 import { DeclarationProvider } from './DeclarationProvider';
 import { ExtensionContext } from 'vscode';
+import Uri from 'vscode-uri';
+import * as path from 'path';
+import { standardizePath as s } from 'brighterscript';
+import * as fsExtra from 'fs-extra';
+import URI from 'vscode-uri';
+import { languageServerInfoCommand } from './commands/LanguageServerInfoCommand';
 
+const Module = require('module');
 const sinon = createSandbox();
 
 //override the "require" call to mock certain items
@@ -23,6 +29,8 @@ Module.prototype.require = function hijacked(file) {
         return oldRequire.apply(this, arguments);
     }
 };
+
+const tempDir = s`${process.cwd()}/.tmp`;
 
 describe('extension', () => {
     let context: any;
@@ -49,6 +57,7 @@ describe('extension', () => {
 
     afterEach(() => {
         sinon.restore();
+        fsExtra.removeSync(tempDir);
     });
 
     it('registers referenceProvider', async () => {
@@ -100,6 +109,161 @@ describe('extension', () => {
                 error = e;
             }
             expect(error?.message).to.eql('failed for test');
+        });
+    });
+
+    describe('getBsdkPath', () => {
+        const embeddedPath = path.resolve(s`${__dirname}/../node_modules/brighterscript`);
+
+        function setConfig(filePath: string, settings: any) {
+            if (filePath.endsWith('.code-workspace')) {
+                fsExtra.outputJsonSync(filePath, {
+                    settings: settings
+                });
+            } else {
+                fsExtra.outputJsonSync(filePath, settings);
+            }
+            vscode.workspace._configuration = settings;
+        }
+
+        it('returns embedded version when not in workspace and no settings exist', async () => {
+            expect(
+                s(await languageServerManager['getBsdkPath']())
+            ).to.eql(embeddedPath);
+        });
+
+        it('returns embedded version when in a workspace and no settings exist', async () => {
+            vscode.workspace.workspaceFile = Uri.file(s`${tempDir}/workspace.code-workspace`);
+            fsExtra.outputFileSync(vscode.workspace.workspaceFile.fsPath, '');
+
+            expect(
+                s(await languageServerManager['getBsdkPath']())
+            ).to.eql(embeddedPath);
+        });
+
+        it('returns embedded version when folder has no brightscript config option', async () => {
+            vscode.workspace.workspaceFolders.push({
+                index: 0,
+                name: 'app1',
+                uri: URI.file(`${tempDir}/app1`)
+            });
+
+            expect(
+                s(await languageServerManager['getBsdkPath']())
+            ).to.eql(embeddedPath);
+        });
+
+        it('returns embedded version when in a workspace and "embedded" value exists', async () => {
+            vscode.workspace.workspaceFile = Uri.file(s`${tempDir}/workspace.code-workspace`);
+            setConfig(vscode.workspace.workspaceFile.fsPath, {
+                'brightscript.bsdk': 'embedded'
+            });
+
+            expect(
+                s(await languageServerManager['getBsdkPath']())
+            ).to.eql(embeddedPath);
+        });
+
+        it('returns embedded version when in a folder without workspace and "embedded" value exists', async () => {
+            vscode.workspace.workspaceFolders.push({
+                index: 0,
+                name: 'app1',
+                uri: URI.file(`${tempDir}/app1`)
+            });
+            setConfig(`${vscode.workspace.workspaceFolders[0].uri.fsPath}/.vscode/settings.json`, {
+                'brightscript.bsdk': 'embedded'
+            });
+
+            expect(
+                s(await languageServerManager['getBsdkPath']())
+            ).to.eql(embeddedPath);
+        });
+
+        it('returns value from worksapce when specified', async () => {
+            vscode.workspace.workspaceFile = Uri.file(s`${tempDir}/workspace.code-workspace`);
+
+            setConfig(vscode.workspace.workspaceFile.fsPath, {
+                'brightscript.bsdk': 'relative/path'
+            });
+
+            expect(
+                s(await languageServerManager['getBsdkPath']())
+            ).to.eql(
+                path.resolve(
+                    s`${tempDir}/relative/path`
+                )
+            );
+        });
+
+        it('returns folder version when not in a workspace', async () => {
+            vscode.workspace.workspaceFolders.push({
+                index: 0,
+                name: 'app1',
+                uri: URI.file(`${tempDir}/app1`)
+            });
+            setConfig(`${vscode.workspace.workspaceFolders[0].uri.fsPath}/.vscode/settings.json`, {
+                'brightscript.bsdk': 'folder/path'
+            });
+
+            expect(
+                s(await languageServerManager['getBsdkPath']())
+            ).to.eql(
+                path.resolve(
+                    s`${tempDir}/app1/folder/path`
+                )
+            );
+        });
+
+        it('returns folder version when in a workspace but no workspace version exists', async () => {
+            vscode.workspace.workspaceFile = Uri.file(s`${tempDir}/workspace.code-workspace`);
+
+            vscode.workspace.workspaceFolders.push({
+                index: 0,
+                name: 'app1',
+                uri: URI.file(`${tempDir}/app1`)
+            });
+            setConfig(`${vscode.workspace.workspaceFolders[0].uri.fsPath}/.vscode/settings.json`, {
+                'brightscript.bsdk': 'folder/path'
+            });
+
+            expect(
+                s(await languageServerManager['getBsdkPath']())
+            ).to.eql(
+                path.resolve(
+                    s`${tempDir}/app1/folder/path`
+                )
+            );
+        });
+
+        it('prompts user for which version to use when multiple folders have value', async () => {
+            sinon.stub(vscode.workspace, 'getConfiguration').callsFake((name, resource: any) => {
+                let value: any;
+                if (resource?.name === 'app1') {
+                    value = 'node_modules/customBs1';
+                } else if (resource?.name === 'app2') {
+                    value = 'node_modules/customBs2';
+                } else {
+                    value = null;
+                }
+                return {
+                    get: x => value
+                };
+            });
+            vscode.workspace.workspaceFolders.push({
+                index: 0,
+                name: 'app1',
+                uri: URI.file(`${tempDir}/app1`)
+            }, {
+                index: 1,
+                name: 'app2',
+                uri: URI.file(`${tempDir}/app2`)
+            });
+            const stub = sinon.stub(languageServerInfoCommand, 'selectBrighterScriptVersion').returns(Promise.resolve(null));
+            const bsdkPath = await languageServerManager['getBsdkPath']();
+            expect(stub.called).to.be.true;
+
+            //should get null since that's what the 'selectBrighterScriptVersion' function returns from our stub
+            expect(bsdkPath).to.eql(null);
         });
     });
 });

--- a/src/LanguageServerRunner.ts
+++ b/src/LanguageServerRunner.ts
@@ -1,4 +1,5 @@
 //this runs in a separate process without the vscode module support
-import { LanguageServer } from 'brighterscript';
-let server = new LanguageServer();
+const pathToBrighterScript = process.argv[2];
+const LanguageServer = require(pathToBrighterScript).LanguageServer;
+const server = new LanguageServer();
 server.run();

--- a/src/commands/BrighterScriptPreviewCommand.ts
+++ b/src/commands/BrighterScriptPreviewCommand.ts
@@ -12,13 +12,6 @@ export const FILE_SCHEME = 'bs-preview';
 export class BrighterScriptPreviewCommand {
     public static SELECTION_SYNC_DELAY = 300;
 
-    /**
-     * Register commands:
-     * - `brighterscript.showPreview`
-     * - `brighterscript.showPreviewToSide`
-     *
-     * Register custom TextDocumentProvider
-     */
     public register(context: vscode.ExtensionContext) {
 
         context.subscriptions.push(vscode.commands.registerCommand('brighterscript.showPreview', async (uri: vscode.Uri) => {

--- a/src/commands/LanguageServerInfoCommand.ts
+++ b/src/commands/LanguageServerInfoCommand.ts
@@ -2,8 +2,6 @@ import * as vscode from 'vscode';
 import { languageServerManager } from '../LanguageServerManager';
 import * as path from 'path';
 
-export const FILE_SCHEME = 'bs-preview';
-
 export class LanguageServerInfoCommand {
     public static commandName = 'extension.brightscript.languageServer.info';
 
@@ -11,7 +9,7 @@ export class LanguageServerInfoCommand {
     public register(context: vscode.ExtensionContext) {
         this.context = context;
 
-        context.subscriptions.push(vscode.commands.registerCommand('extension.brightscript.languageServer.info', async () => {
+        context.subscriptions.push(vscode.commands.registerCommand(LanguageServerInfoCommand.commandName, async () => {
             const commands = [{
                 label: `Select BrighterScript Version`,
                 description: `(current v${languageServerManager.selectedBscInfo.version})`,

--- a/src/commands/LanguageServerInfoCommand.ts
+++ b/src/commands/LanguageServerInfoCommand.ts
@@ -15,16 +15,17 @@ export class LanguageServerInfoCommand {
             const commands = [{
                 label: `Select BrighterScript Version`,
                 description: `(current v${languageServerManager.selectedBscInfo.version})`,
-                command: () => {
-                    this.selectBrighterScriptVersion();
-                    languageServerManager.syncVersionAndTryRun();
-                }
+                command: this.selectBrighterScriptVersion.bind(this)
             }];
             let selection = await vscode.window.showQuickPick(commands, { placeHolder: `BrighterScript Project Info` });
-            selection?.command();
+            await selection?.command();
         }));
     }
 
+    /**
+     * If this changes the user/folder/workspace settings, that will trigger a reload of the language server so there's no need to 
+     * call the reload manually
+     */
     public async selectBrighterScriptVersion() {
         const versions = [{
             label: `Use VS Code's version`,
@@ -32,7 +33,6 @@ export class LanguageServerInfoCommand {
             detail: undefined as string //require.resolve('brighterscript')
         }];
 
-        const cwd = process.cwd();
         //look for brighterscript in all workspace folders
         vscode.workspace.workspaceFolders.forEach(workspaceFolder => {
             const workspaceOrFolderPath = this.getWorkspaceOrFolderPath(workspaceFolder.uri.fsPath);

--- a/src/commands/LanguageServerInfoCommand.ts
+++ b/src/commands/LanguageServerInfoCommand.ts
@@ -1,0 +1,84 @@
+import * as vscode from 'vscode';
+import { languageServerManager } from '../LanguageServerManager';
+import * as path from 'path';
+
+export const FILE_SCHEME = 'bs-preview';
+
+export class LanguageServerInfoCommand {
+    public static commandName = 'extension.brightscript.languageServer.info';
+
+    private context: vscode.ExtensionContext;
+    public register(context: vscode.ExtensionContext) {
+        this.context = context;
+
+        context.subscriptions.push(vscode.commands.registerCommand('extension.brightscript.languageServer.info', async () => {
+            const commands = [{
+                label: `Select BrighterScript Version`,
+                description: `(current v${languageServerManager.selectedBscInfo.version})`,
+                command: () => {
+                    this.selectBrighterScriptVersion();
+                    languageServerManager.syncVersionAndTryRun();
+                }
+            }];
+            let selection = await vscode.window.showQuickPick(commands, { placeHolder: `BrighterScript Project Info` });
+            selection?.command();
+        }));
+    }
+
+    public async selectBrighterScriptVersion() {
+        const versions = [{
+            label: `Use VS Code's version`,
+            description: languageServerManager.embeddedBscInfo.version,
+            detail: undefined as string //require.resolve('brighterscript')
+        }];
+
+        const cwd = process.cwd();
+        //look for brighterscript in all workspace folders
+        vscode.workspace.workspaceFolders.forEach(workspaceFolder => {
+            const workspaceOrFolderPath = this.getWorkspaceOrFolderPath(workspaceFolder.uri.fsPath);
+            try {
+                let bscPath = require.resolve('brighterscript', {
+                    paths: [workspaceFolder.uri.fsPath]
+                });
+                //require.resolve returns a bsc script path, so remove that to get the root of brighterscript folder
+                if (bscPath) {
+                    bscPath = bscPath.replace(/[\\\/]dist[\\\/]index.js/i, '');
+                    const version = require(`${bscPath}/package.json`).version;
+                    //make the path relative to the workspace folder
+                    bscPath = path.relative(workspaceOrFolderPath, bscPath);
+
+                    versions.push({
+                        label: 'Use Workspace Version',
+                        description: version,
+                        detail: bscPath
+                    });
+                }
+            } finally { }
+        });
+        let selection = await vscode.window.showQuickPick(versions, { placeHolder: `Select the BrighterScript version used for BrightScript and BrighterScript language features` });
+        if (selection) {
+            const config = vscode.workspace.getConfiguration('brightscript');
+            //if the user picked "use embedded version", then remove the setting
+            if (versions.indexOf(selection) === 0) {
+                //setting to undefined means "remove"
+                config.update('bsdk', 'embedded');
+                return 'embedded';
+            } else {
+                //save this to workspace/folder settings (vscode automatically decides if it goes into the code-workspace settings or the folder settings
+                config.update('bsdk', selection.detail);
+                return selection.detail;
+            }
+        }
+    }
+
+    private getWorkspaceOrFolderPath(workspaceFolder: string) {
+        const workspaceFile = vscode.workspace.workspaceFile;
+        if (workspaceFile) {
+            return path.dirname(workspaceFile.fsPath);
+        } else {
+            return workspaceFolder;
+        }
+    }
+}
+
+export const languageServerInfoCommand = new LanguageServerInfoCommand();

--- a/src/mockVscode.spec.ts
+++ b/src/mockVscode.spec.ts
@@ -1,4 +1,9 @@
-import { Command, Range, TreeDataProvider, TreeItemCollapsibleState, Uri, Position } from 'vscode';
+import { Command, Range, TreeDataProvider, TreeItemCollapsibleState, Uri, WorkspaceFolder, ConfigurationScope } from 'vscode';
+
+afterEach(() => {
+    delete vscode.workspace.workspaceFile;
+    delete vscode.workspace._configuration;
+});
 
 export let vscode = {
     CompletionItem: class { },
@@ -50,7 +55,8 @@ export let vscode = {
         asAbsolutePath: function() { }
     },
     workspace: {
-        workspaceFolders: [],
+        workspaceFolders: [] as WorkspaceFolder[],
+        workspaceFile: undefined as Uri,
         createFileSystemWatcher: () => {
             return {
                 onDidCreate: () => {
@@ -64,9 +70,12 @@ export let vscode = {
                 }
             };
         },
-        getConfiguration: function() {
+        _configuration: {} as any,
+        getConfiguration: function(configurationName: string, scope?: ConfigurationScope | null) {
             return {
-                get: function() { }
+                get: (name: string) => {
+                    return this._configuration?.[`${configurationName}.${name}`];
+                }
             };
         },
         onDidChangeConfiguration: () => { },


### PR DESCRIPTION
Adds ability to pick from a locally-installed version of brighterscript to use for the language server.

Notable changes:
1. remove the purple flame icon in favor of ![image](https://user-images.githubusercontent.com/2544493/112376039-5a328c80-8cba-11eb-814f-698f42a9b0c3.png)
2. Clicking the new language server button will prompt the user to pick the version of BrighterScript to use for the language server. The embedded version is always an option, and then every workspace folder is scanned for `node_modules/brighterscript`. 
3. Adds new workspace setting `brightscript.bsdk` (named after [typescript.tsdk](https://code.visualstudio.com/docs/typescript/typescript-compiling#_using-the-workspace-version-of-typescript)) allows the user to persist the language server path choice to either folder settings or workspace settings. It will work in user settings but must then be an absolute path.
4. dynamically reload the language server anytime the `brightscript.bsdk` workspace/folder setting changes.


Example usage:

![07c8aa9d-105c-4a73-aa9f-45a60e122c98](https://user-images.githubusercontent.com/2544493/112375950-3e2eeb00-8cba-11eb-8c0d-98005b15d4d0.gif)
