### PR TITLE
Syntax highlighting for embedded brs in scenegraph

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,8 @@
         "clean": "rimraf dist",
         "install-local": "node scripts/install-local.js",
         "install-pull-local": "node scripts/install-local.js --pull",
-        "uninstall-local": "node scripts/uninstall-local.js"
+        "uninstall-local": "node scripts/uninstall-local.js",
+        "sync-syntaxes": "node scripts/sync-scenegraph-tmlanguage.js"
     },
     "dependencies": {
         "array-sort": "^1.0.0",

--- a/package.json
+++ b/package.json
@@ -182,6 +182,9 @@
             },
             {
                 "language": "brighterscript"
+            },
+            {
+                "language": "scenegraph"
             }
         ],
         "debuggers": [
@@ -583,6 +586,16 @@
                 "configuration": "./language-configuration.json"
             },
             {
+                "id": "scenegraph",
+                "extensions": [
+                    ".xml"
+                ],
+                "aliases": [
+                    "SceneGraph"
+                ],
+                "configuration": "./language-configuration.json"
+            },
+            {
                 "id": "Log",
                 "aliases": [
                     "log"
@@ -620,6 +633,11 @@
                 "language": "brighterscript",
                 "scopeName": "source.brs",
                 "path": "./syntaxes/brightscript.tmLanguage.json"
+            },
+            {
+                "language": "scenegraph",
+                "scopeName": "scenegraph.xml",
+                "path": "./syntaxes/scenegraph.tmLanguage.json"
             }
         ],
         "snippets": [

--- a/scripts/sync-scenegraph-tmlanguage.js
+++ b/scripts/sync-scenegraph-tmlanguage.js
@@ -1,0 +1,17 @@
+const fetch = require('node-fetch');
+var fsExtra = require('fs-extra');
+(async () => {
+    const json = await (await fetch('https://raw.githubusercontent.com/microsoft/vscode/main/extensions/xml/syntaxes/xml.tmLanguage.json')).json()
+    json.scopeName = 'scenegraph.xml';
+    json.name = 'scenegraph';
+    json.fileTypes = ['xml'];
+    delete json.information_for_contributors;
+    delete json.version;
+    //find the CDATA pattern
+    var pattern = json.patterns.find(x => x.name === 'string.unquoted.cdata.xml');
+    pattern.name = 'source.brighterscript.embedded.scenegraph';
+    pattern.patterns = [{
+        include: "source.brs"
+    }];
+    fsExtra.outputFileSync(`${__dirname}/../syntaxes/scenegraph.tmLanguage.json`, JSON.stringify(json, null, 4));
+})().catch(e => console.error(e));

--- a/syntaxes/scenegraph.tmLanguage.json
+++ b/syntaxes/scenegraph.tmLanguage.json
@@ -1,9 +1,6 @@
 {
-    "scopeName": "scenegraph.xml",
     "name": "scenegraph",
-    "fileTypes": [
-        "xml"
-    ],
+    "scopeName": "scenegraph.xml",
     "patterns": [
         {
             "begin": "(<\\?)\\s*([-_a-zA-Z0-9]+)",
@@ -191,7 +188,7 @@
                     "name": "punctuation.definition.string.end.xml"
                 }
             },
-            "name": "source.brighterscript.embedded.xml",
+            "name": "source.brighterscript.embedded.scenegraph",
             "patterns": [
                 {
                     "include": "source.brs"
@@ -341,7 +338,7 @@
                             "name": "entity.other.attribute-name.localname.xml"
                         }
                     },
-                    "match": "(?:^|\\s+)(?:([-\\w.]+)((:)))?([-\\w.:]+)="
+                    "match": "(?:^|\\s+)(?:([-\\w.]+)((:)))?([-\\w.:]+)\\s*="
                 },
                 {
                     "include": "#doublequotedString"
@@ -352,15 +349,41 @@
             ]
         },
         "comments": {
-            "begin": "<[!%]--",
-            "captures": {
-                "0": {
-                    "name": "punctuation.definition.comment.xml"
+            "patterns": [
+                {
+                    "begin": "<%--",
+                    "captures": {
+                        "0": {
+                            "name": "punctuation.definition.comment.xml"
+                        },
+                        "end": "--%>",
+                        "name": "comment.block.xml"
+                    }
+                },
+                {
+                    "begin": "<!--",
+                    "captures": {
+                        "0": {
+                            "name": "punctuation.definition.comment.xml"
+                        }
+                    },
+                    "end": "-->",
+                    "name": "comment.block.xml",
+                    "patterns": [
+                        {
+                            "begin": "--(?!>)",
+                            "captures": {
+                                "0": {
+                                    "name": "invalid.illegal.bad-comments-or-CDATA.xml"
+                                }
+                            }
+                        }
+                    ]
                 }
-            },
-            "end": "--%?>",
-            "name": "comment.block.xml"
+            ]
         }
     },
-    "version": "https://github.com/atom/language-xml/commit/f461d428fb87040cb8a52d87d0b95151b9d3c0cc"
+    "fileTypes": [
+        "xml"
+    ]
 }

--- a/syntaxes/scenegraph.tmLanguage.json
+++ b/syntaxes/scenegraph.tmLanguage.json
@@ -1,0 +1,366 @@
+{
+    "scopeName": "scenegraph.xml",
+    "name": "scenegraph",
+    "fileTypes": [
+        "xml"
+    ],
+    "patterns": [
+        {
+            "begin": "(<\\?)\\s*([-_a-zA-Z0-9]+)",
+            "captures": {
+                "1": {
+                    "name": "punctuation.definition.tag.xml"
+                },
+                "2": {
+                    "name": "entity.name.tag.xml"
+                }
+            },
+            "end": "(\\?>)",
+            "name": "meta.tag.preprocessor.xml",
+            "patterns": [
+                {
+                    "match": " ([a-zA-Z-]+)",
+                    "name": "entity.other.attribute-name.xml"
+                },
+                {
+                    "include": "#doublequotedString"
+                },
+                {
+                    "include": "#singlequotedString"
+                }
+            ]
+        },
+        {
+            "begin": "(<!)(DOCTYPE)\\s+([:a-zA-Z_][:a-zA-Z0-9_.-]*)",
+            "captures": {
+                "1": {
+                    "name": "punctuation.definition.tag.xml"
+                },
+                "2": {
+                    "name": "keyword.other.doctype.xml"
+                },
+                "3": {
+                    "name": "variable.language.documentroot.xml"
+                }
+            },
+            "end": "\\s*(>)",
+            "name": "meta.tag.sgml.doctype.xml",
+            "patterns": [
+                {
+                    "include": "#internalSubset"
+                }
+            ]
+        },
+        {
+            "include": "#comments"
+        },
+        {
+            "begin": "(<)((?:([-_a-zA-Z0-9]+)(:))?([-_a-zA-Z0-9:]+))(?=(\\s[^>]*)?></\\2>)",
+            "beginCaptures": {
+                "1": {
+                    "name": "punctuation.definition.tag.xml"
+                },
+                "2": {
+                    "name": "entity.name.tag.xml"
+                },
+                "3": {
+                    "name": "entity.name.tag.namespace.xml"
+                },
+                "4": {
+                    "name": "punctuation.separator.namespace.xml"
+                },
+                "5": {
+                    "name": "entity.name.tag.localname.xml"
+                }
+            },
+            "end": "(>)(</)((?:([-_a-zA-Z0-9]+)(:))?([-_a-zA-Z0-9:]+))(>)",
+            "endCaptures": {
+                "1": {
+                    "name": "punctuation.definition.tag.xml"
+                },
+                "2": {
+                    "name": "punctuation.definition.tag.xml"
+                },
+                "3": {
+                    "name": "entity.name.tag.xml"
+                },
+                "4": {
+                    "name": "entity.name.tag.namespace.xml"
+                },
+                "5": {
+                    "name": "punctuation.separator.namespace.xml"
+                },
+                "6": {
+                    "name": "entity.name.tag.localname.xml"
+                },
+                "7": {
+                    "name": "punctuation.definition.tag.xml"
+                }
+            },
+            "name": "meta.tag.no-content.xml",
+            "patterns": [
+                {
+                    "include": "#tagStuff"
+                }
+            ]
+        },
+        {
+            "begin": "(</?)(?:([-\\w\\.]+)((:)))?([-\\w\\.:]+)",
+            "captures": {
+                "1": {
+                    "name": "punctuation.definition.tag.xml"
+                },
+                "2": {
+                    "name": "entity.name.tag.namespace.xml"
+                },
+                "3": {
+                    "name": "entity.name.tag.xml"
+                },
+                "4": {
+                    "name": "punctuation.separator.namespace.xml"
+                },
+                "5": {
+                    "name": "entity.name.tag.localname.xml"
+                }
+            },
+            "end": "(/?>)",
+            "name": "meta.tag.xml",
+            "patterns": [
+                {
+                    "include": "#tagStuff"
+                }
+            ]
+        },
+        {
+            "include": "#entity"
+        },
+        {
+            "include": "#bare-ampersand"
+        },
+        {
+            "begin": "<%@",
+            "beginCaptures": {
+                "0": {
+                    "name": "punctuation.section.embedded.begin.xml"
+                }
+            },
+            "end": "%>",
+            "endCaptures": {
+                "0": {
+                    "name": "punctuation.section.embedded.end.xml"
+                }
+            },
+            "name": "source.java-props.embedded.xml",
+            "patterns": [
+                {
+                    "match": "page|include|taglib",
+                    "name": "keyword.other.page-props.xml"
+                }
+            ]
+        },
+        {
+            "begin": "<%[!=]?(?!--)",
+            "beginCaptures": {
+                "0": {
+                    "name": "punctuation.section.embedded.begin.xml"
+                }
+            },
+            "end": "(?!--)%>",
+            "endCaptures": {
+                "0": {
+                    "name": "punctuation.section.embedded.end.xml"
+                }
+            },
+            "name": "source.java.embedded.xml",
+            "patterns": [
+                {
+                    "include": "source.java"
+                }
+            ]
+        },
+        {
+            "begin": "<!\\[CDATA\\[",
+            "beginCaptures": {
+                "0": {
+                    "name": "punctuation.definition.string.begin.xml"
+                }
+            },
+            "end": "]]>",
+            "endCaptures": {
+                "0": {
+                    "name": "punctuation.definition.string.end.xml"
+                }
+            },
+            "name": "source.brighterscript.embedded.xml",
+            "patterns": [
+                {
+                    "include": "source.brs"
+                }
+            ]
+        }
+    ],
+    "repository": {
+        "EntityDecl": {
+            "begin": "(<!)(ENTITY)\\s+(%\\s+)?([:a-zA-Z_][:a-zA-Z0-9_.-]*)(\\s+(?:SYSTEM|PUBLIC)\\s+)?",
+            "captures": {
+                "1": {
+                    "name": "punctuation.definition.tag.xml"
+                },
+                "2": {
+                    "name": "keyword.other.entity.xml"
+                },
+                "3": {
+                    "name": "punctuation.definition.entity.xml"
+                },
+                "4": {
+                    "name": "variable.language.entity.xml"
+                },
+                "5": {
+                    "name": "keyword.other.entitytype.xml"
+                }
+            },
+            "end": "(>)",
+            "patterns": [
+                {
+                    "include": "#doublequotedString"
+                },
+                {
+                    "include": "#singlequotedString"
+                }
+            ]
+        },
+        "bare-ampersand": {
+            "match": "&",
+            "name": "invalid.illegal.bad-ampersand.xml"
+        },
+        "doublequotedString": {
+            "begin": "\"",
+            "beginCaptures": {
+                "0": {
+                    "name": "punctuation.definition.string.begin.xml"
+                }
+            },
+            "end": "\"",
+            "endCaptures": {
+                "0": {
+                    "name": "punctuation.definition.string.end.xml"
+                }
+            },
+            "name": "string.quoted.double.xml",
+            "patterns": [
+                {
+                    "include": "#entity"
+                },
+                {
+                    "include": "#bare-ampersand"
+                }
+            ]
+        },
+        "entity": {
+            "captures": {
+                "1": {
+                    "name": "punctuation.definition.constant.xml"
+                },
+                "3": {
+                    "name": "punctuation.definition.constant.xml"
+                }
+            },
+            "match": "(&)([:a-zA-Z_][:a-zA-Z0-9_.-]*|#[0-9]+|#x[0-9a-fA-F]+)(;)",
+            "name": "constant.character.entity.xml"
+        },
+        "internalSubset": {
+            "begin": "(\\[)",
+            "captures": {
+                "1": {
+                    "name": "punctuation.definition.constant.xml"
+                }
+            },
+            "end": "(\\])",
+            "name": "meta.internalsubset.xml",
+            "patterns": [
+                {
+                    "include": "#EntityDecl"
+                },
+                {
+                    "include": "#parameterEntity"
+                },
+                {
+                    "include": "#comments"
+                }
+            ]
+        },
+        "parameterEntity": {
+            "captures": {
+                "1": {
+                    "name": "punctuation.definition.constant.xml"
+                },
+                "3": {
+                    "name": "punctuation.definition.constant.xml"
+                }
+            },
+            "match": "(%)([:a-zA-Z_][:a-zA-Z0-9_.-]*)(;)",
+            "name": "constant.character.parameter-entity.xml"
+        },
+        "singlequotedString": {
+            "begin": "'",
+            "beginCaptures": {
+                "0": {
+                    "name": "punctuation.definition.string.begin.xml"
+                }
+            },
+            "end": "'",
+            "endCaptures": {
+                "0": {
+                    "name": "punctuation.definition.string.end.xml"
+                }
+            },
+            "name": "string.quoted.single.xml",
+            "patterns": [
+                {
+                    "include": "#entity"
+                },
+                {
+                    "include": "#bare-ampersand"
+                }
+            ]
+        },
+        "tagStuff": {
+            "patterns": [
+                {
+                    "captures": {
+                        "1": {
+                            "name": "entity.other.attribute-name.namespace.xml"
+                        },
+                        "2": {
+                            "name": "entity.other.attribute-name.xml"
+                        },
+                        "3": {
+                            "name": "punctuation.separator.namespace.xml"
+                        },
+                        "4": {
+                            "name": "entity.other.attribute-name.localname.xml"
+                        }
+                    },
+                    "match": "(?:^|\\s+)(?:([-\\w.]+)((:)))?([-\\w.:]+)="
+                },
+                {
+                    "include": "#doublequotedString"
+                },
+                {
+                    "include": "#singlequotedString"
+                }
+            ]
+        },
+        "comments": {
+            "begin": "<[!%]--",
+            "captures": {
+                "0": {
+                    "name": "punctuation.definition.comment.xml"
+                }
+            },
+            "end": "--%?>",
+            "name": "comment.block.xml"
+        }
+    },
+    "version": "https://github.com/atom/language-xml/commit/f461d428fb87040cb8a52d87d0b95151b9d3c0cc"
+}


### PR DESCRIPTION
This adds syntax highlighting support for embedded brightscript/brighterscript code in CDATA tags within scenegraph xml files.

Before:
![image](https://user-images.githubusercontent.com/2544493/123194695-ea789d00-d474-11eb-88d3-a6e5c270486c.png)

After:
![image](https://user-images.githubusercontent.com/2544493/123194723-f49a9b80-d474-11eb-9bbb-dd487525bc94.png)

**NOTE:** this might prevent xml formatters from working properly. 