### PR TITLE
Better logging

### DIFF
--- a/package.json
+++ b/package.json
@@ -1492,6 +1492,11 @@
                     "type": "string",
                     "description": "Path to the BrighterScript module to use for the BrightScript and BrighterScript language features",
                     "scope": "resource"
+                },
+                "brightscript.extensionLogfilePath": {
+                    "type": "string",
+                    "description": "File where the 'BrightScript Extension' output panel (i.e. debug logs for the extension) will be appended. If omitted, no file logging will be done. ${workspaceFolder} is supported and will point to the first workspace found.",
+                    "scope": "resource"
                 }
             }
         },

--- a/package.json
+++ b/package.json
@@ -546,6 +546,20 @@
                             "enableDebugProtocol": {
                                 "type": "boolean",
                                 "description": "If true, the debugger will use the new BrightScript debug protocol, and will disable the telnet debugger. See this link for more details: https://developer.roku.com/en-ca/docs/developer-program/debugging/socket-based-debugger.md"
+                            },
+                            "logLevel": {
+                                "type": "string",
+                                "enum": [
+                                    "off",
+                                    "error",
+                                    "warn",
+                                    "log",
+                                    "info",
+                                    "debug",
+                                    "trace"
+                                ],
+                                "default": "log",
+                                "description": "The level of logging that should be done during a debug session."
                             }
                         }
                     }

--- a/src/util.ts
+++ b/src/util.ts
@@ -171,6 +171,32 @@ class Util {
     public isExtensionHostRunning() {
         return process.argv.includes('--type=extensionHost');
     }
+
+    /**
+     * Wraps a function and calls a callback before calling the original function
+     */
+    public wrap<T, K extends keyof T>(subject: T, name: K, callback) {
+        const fn = subject[name] as any;
+        (subject as any)[name] = (...args) => {
+            callback(...args);
+            fn.call(subject, ...args);
+        };
+    }
+
+    /**
+     * Creates an output channel but wraps the `append` and `appendLine`
+     * functions so a function can be called with their values
+     */
+    public createOutputChannel(name: string, interceptor: (value: string) => void) {
+        const channel = vscode.window.createOutputChannel(name);
+        this.wrap(channel, 'append', interceptor);
+        this.wrap(channel, 'appendLine', (line: string) => {
+            if (line) {
+                interceptor(line + '\n');
+            }
+        });
+        return channel;
+    }
 }
 
 const util = new Util();


### PR DESCRIPTION
Adds better logging support for tracking issues within the extension and its dependencies (i.e. roku-debug, roku-deploy, etc...). 

Changes:
- add `brightscript.extensionLogfilePath` setting to specify an output file for debug logs
- add `logLevel` debug parameter info for launch.json
- rename `SceneGraph Debug Commands Log` output panel to `SceneGraph Debug Commands`
- rename `BrightScript Debug Server` output panel to `BrightScript Extension` for wider usage.
