### PR TITLE
Improve wording for bsc picker. Add bsc restart command

### DIFF
--- a/src/commands/LanguageServerInfoCommand.ts
+++ b/src/commands/LanguageServerInfoCommand.ts
@@ -11,13 +11,21 @@ export class LanguageServerInfoCommand {
 
         context.subscriptions.push(vscode.commands.registerCommand(LanguageServerInfoCommand.commandName, async () => {
             const commands = [{
-                label: `Select BrighterScript Version`,
+                label: `Change Selected BrighterScript Version`,
                 description: `(current v${languageServerManager.selectedBscInfo.version})`,
                 command: this.selectBrighterScriptVersion.bind(this)
+            }, {
+                label: `Restart BrighterScript Language Server`,
+                description: ``,
+                command: this.restartLanguageServer.bind(this)
             }];
             let selection = await vscode.window.showQuickPick(commands, { placeHolder: `BrighterScript Project Info` });
             await selection?.command();
         }));
+    }
+
+    private restartLanguageServer() {
+        vscode.commands.executeCommand('extension.brightscript.languageServer.restart');
     }
 
     /**


### PR DESCRIPTION
 - Improves wording around the "Pick which version of brighterscript language server you want to use" menu option.
 - adds second entry in the menu (restart language server) to make it more clear that you need to pick the other option to change the language server version. 

Here's the new design: 
![image](https://user-images.githubusercontent.com/2544493/152198863-db0acab7-3e93-4de5-856c-996a98790101.png)

https://user-images.githubusercontent.com/2544493/152199358-211f8c75-4e59-4edc-8fea-951f197e8d97.mp4


