### PR TITLE
Fix colorization with interfaces inside namespaces

### DIFF
--- a/syntaxes/brightscript.tmLanguage.json
+++ b/syntaxes/brightscript.tmLanguage.json
@@ -446,7 +446,7 @@
         },
         "interface_declaration": {
             "name": "meta.interface.brs",
-            "begin": "(?i)\\b(interface)[\\s\\t]+([a-zA-Z0-9_]+)\\b",
+            "begin": "(?i)\\b[\\s\\t]*(interface)[\\s\\t]+([a-zA-Z0-9_]+)\\b",
             "beginCaptures": {
                 "1": {
                     "name": "storage.type.interface.brs"
@@ -480,7 +480,7 @@
                     "end": "\r?\n"
                 }
             ],
-            "end": "(?i)(end[\\s\\t]*interface)",
+            "end": "(?i)[\\s\\t]*(end[\\s\\t]*interface)",
             "endCaptures": {
                 "1": {
                     "name": "storage.type.interface.brs"


### PR DESCRIPTION
Fixes bug where interfaces weren't colored properly when indented.

Before:
![image](https://user-images.githubusercontent.com/2544493/152521520-c607ccad-1a67-4ead-adff-f892c034f737.png)

After:
![image](https://user-images.githubusercontent.com/2544493/152521575-e679e9bc-24f6-49b9-b00c-dc6f3a585fdf.png)
