### PR TITLE
Add enum syntax highlighting

### DIFF
--- a/src/commands/LanguageServerInfoCommand.ts
+++ b/src/commands/LanguageServerInfoCommand.ts
@@ -11,13 +11,21 @@ export class LanguageServerInfoCommand {
 
         context.subscriptions.push(vscode.commands.registerCommand(LanguageServerInfoCommand.commandName, async () => {
             const commands = [{
-                label: `Select BrighterScript Version`,
+                label: `Change Selected BrighterScript Version`,
                 description: `(current v${languageServerManager.selectedBscInfo.version})`,
                 command: this.selectBrighterScriptVersion.bind(this)
+            }, {
+                label: `Restart BrighterScript Language Server`,
+                description: ``,
+                command: this.restartLanguageServer.bind(this)
             }];
             let selection = await vscode.window.showQuickPick(commands, { placeHolder: `BrighterScript Project Info` });
             await selection?.command();
         }));
+    }
+
+    private restartLanguageServer() {
+        vscode.commands.executeCommand('extension.brightscript.languageServer.restart');
     }
 
     /**

--- a/syntaxes/brightscript.tmLanguage.json
+++ b/syntaxes/brightscript.tmLanguage.json
@@ -34,6 +34,9 @@
                     "include": "#namespace_declaration"
                 },
                 {
+                    "include": "#enum_declaration"
+                },
+                {
                     "include": "#end_namespace"
                 },
                 {

--- a/syntaxes/brightscript.tmLanguage.json
+++ b/syntaxes/brightscript.tmLanguage.json
@@ -487,6 +487,49 @@
                 }
             }
         },
+        "enum_declaration": {
+            "name": "meta.enum.declaration.brs",
+            "begin": "(?i)\\b(enum)[ \\t]+([a-zA-Z0-9_]+)\\b",
+            "beginCaptures": {
+                "1": {
+                    "name": "storage.type.enum.brs"
+                },
+                "2": {
+                    "name": "entity.name.type.enum.brs"
+                }
+            },
+            "patterns": [
+                {
+                    "include": "#comment"
+                },
+                {
+                    "include": "#annotation"
+                },
+                {
+                    "begin": "(?i)\\s*\\b([a-z0-9_]+)(?:[ \\t]*(=))?",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "variable.object.enummember.brs"
+                        },
+                        "2": {
+                            "name": "keyword.operator.assignment.brs"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "include": "#primitive_literal_expression"
+                        }
+                    ],
+                    "end": "\r?\n"
+                }
+            ],
+            "end": "(?i)[ \\t]+(end[ \\t]*enum)",
+            "endCaptures": {
+                "1": {
+                    "name": "storage.type.enum.brs"
+                }
+            }
+        },
         "type_expression": {
             "patterns": [
                 {


### PR DESCRIPTION
Adds enum syntax highlighting. Depends on #358 

Example:
![image](https://user-images.githubusercontent.com/2544493/152528347-5d085f58-ef0d-44be-8a41-5e28d5b42b29.png)
