### PR TITLE
Remove mocha param

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -56,7 +56,6 @@
                 "changelog-parser": "^2.8.0",
                 "coveralls": "^3.0.11",
                 "mocha": "^9.1.3",
-                "mocha-param": "^2.0.0",
                 "nyc": "^15.0.0",
                 "ovsx": "^0.3.0",
                 "rimraf": "^3.0.0",
@@ -4225,12 +4224,6 @@
                 "type": "opencollective",
                 "url": "https://opencollective.com/mochajs"
             }
-        },
-        "node_modules/mocha-param": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/mocha-param/-/mocha-param-2.0.1.tgz",
-            "integrity": "sha512-TDrDAChx9XtkGmRKWGOzMoQefwHsfYUxyjNWgkfAze+EFRIRT28yJVcpcNhw9iWg2NvfeMQZnSwWCNMYwPxZew==",
-            "dev": true
         },
         "node_modules/mocha/node_modules/argparse": {
             "version": "2.0.1",
@@ -10680,12 +10673,6 @@
                     }
                 }
             }
-        },
-        "mocha-param": {
-            "version": "2.0.1",
-            "resolved": "https://registry.npmjs.org/mocha-param/-/mocha-param-2.0.1.tgz",
-            "integrity": "sha512-TDrDAChx9XtkGmRKWGOzMoQefwHsfYUxyjNWgkfAze+EFRIRT28yJVcpcNhw9iWg2NvfeMQZnSwWCNMYwPxZew==",
-            "dev": true
         },
         "moment": {
             "version": "2.29.1",

--- a/package.json
+++ b/package.json
@@ -94,7 +94,6 @@
         "changelog-parser": "^2.8.0",
         "coveralls": "^3.0.11",
         "mocha": "^9.1.3",
-        "mocha-param": "^2.0.0",
         "nyc": "^15.0.0",
         "ovsx": "^0.3.0",
         "rimraf": "^3.0.0",

--- a/src/LogOutputManager.spec.ts
+++ b/src/LogOutputManager.spec.ts
@@ -2,7 +2,7 @@
 /* tslint:disable:no-var-requires */
 /* tslint:disable:no-string-literal */
 import { assert, expect } from 'chai';
-import { createSandbox } from 'sinon';
+import Sinon, { createSandbox } from 'sinon';
 const sinon = createSandbox();
 let Module = require('module');
 
@@ -22,18 +22,15 @@ Module.prototype.require = function hijacked(file) {
 import { DeclarationProvider } from './DeclarationProvider';
 import { LogDocumentLinkProvider } from './LogDocumentLinkProvider';
 import { LogLine, LogOutputManager } from './LogOutputManager';
-import { SymbolInformationRepository } from './SymbolInformationRepository';
-const itParam = require('mocha-param');
 
 describe('LogOutputManager ', () => {
-    let logOutputManagerMock;
+    let logOutputManagerMock: Sinon.SinonMock;
     let logOutputManager: LogOutputManager;
-    let languagesMock;
-    let outputChannelMock;
-    let logDocumentLinkProviderMock;
-    let collectionMock;
-    let declarationProvider;
-    let declarationProviderMock;
+    let languagesMock: Sinon.SinonMock;
+    let outputChannelMock: Sinon.SinonMock;
+    let logDocumentLinkProviderMock: Sinon.SinonMock;
+    let collectionMock: Sinon.SinonMock;
+    let declarationProviderMock: Sinon.SinonMock;
 
     beforeEach(() => {
         sinon.restore();
@@ -267,81 +264,87 @@ describe('LogOutputManager ', () => {
             assert.equal(logText, ' ');
         });
 
-        describe('tests Filename', () => {
-            let params = [
-                { configSetting: 'Filename', text: 'pkg:/file.brs(20)' },
-                { configSetting: 'Filename', text: 'pkg:/path/file.brs(20)' },
-                { configSetting: 'Filename', text: 'pkg:/path/path2/file.brs(20)' },
-            ];
-            itParam('lf ${value.configSetting} if ${value.text} ', params, (param) => {
+        it('Filename', () => {
+            test({ configSetting: 'Filename', text: 'pkg:/file.brs(20)' });
+            test({ configSetting: 'Filename', text: 'pkg:/path/file.brs(20)' });
+            test({ configSetting: 'Filename', text: 'pkg:/path/path2/file.brs(20)' });
+
+            function test(param) {
                 logOutputManager.hyperlinkFormat = param.configSetting;
                 declarationProviderMock.expects('getFunctionBeforeLine').returns({ name: 'methodName' });
                 logDocumentLinkProviderMock.expects('convertPkgPathToFsPath').returns({ name: 'filesystem/file.brs' });
-                let logText = logOutputManager.getCustomLogText(param.text, 'file',
-                    '.brs', 20, 2, false);
-                assert.equal(logText, 'file.brs(20)');
-            });
+                assert.equal(
+                    logOutputManager.getCustomLogText(param.text, 'file', '.brs', 20, 2, false),
+                    'file.brs(20)'
+                );
+            }
         });
 
-        describe('tests Filename with addline to log', () => {
-            let params = [
-                { configSetting: 'Filename', text: 'pkg:/file.brs(20)' },
-                { configSetting: 'Filename', text: 'pkg:/path/file.brs(20)' },
-                { configSetting: 'Filename', text: 'pkg:/path/path2/file.brs(20)' },
-            ];
-            itParam('lf ${value.configSetting} if {$value.text} ', params, (param) => {
+        it('tests Filename with addline to log', () => {
+            test({ configSetting: 'Filename', text: 'pkg:/file.brs(20)' });
+            test({ configSetting: 'Filename', text: 'pkg:/path/file.brs(20)' });
+            test({ configSetting: 'Filename', text: 'pkg:/path/path2/file.brs(20)' });
+
+            function test(param) {
                 logOutputManager.hyperlinkFormat = param.configSetting;
                 declarationProviderMock.expects('getFunctionBeforeLine').returns({ name: 'methodName' });
                 logDocumentLinkProviderMock.expects('convertPkgPathToFsPath').returns({ name: 'filesystem/file.brs' });
                 logDocumentLinkProviderMock.expects('addCustomPkgLink');
                 const logLine = new LogLine(param.text + ' sometext', true);
+
+                const stub = sinon.stub(logOutputManager['outputChannel'], 'appendLine');
+
                 logOutputManager.addLogLineToOutput(logLine);
-                // assert.equal(logText, 'file.methodName(20)');
-            });
-        });
-        describe('tests FilenameAndFunction', () => {
-            let params = [
-                { configSetting: null, text: 'pkg:/file.brs(20)' },
-                { configSetting: null, text: 'pkg:/path/file.brs(20)' },
-                { configSetting: null, text: 'pkg:/path/path2/file.brs(20)' },
-                { configSetting: '', text: 'pkg:/file.brs(20)' },
-                { configSetting: '', text: 'pkg:/path/file.brs(20)' },
-                { configSetting: '', text: 'pkg:/path/path2/file.brs(20)' },
-                { configSetting: 'FilenameAndFunction', text: 'pkg:/file.brs(20)' },
-                { configSetting: 'FilenameAndFunction', text: 'pkg:/path/file.brs(20)' },
-                { configSetting: 'FilenameAndFunction', text: 'pkg:/path/path2/file.brs(20)' },
-            ];
-            itParam('lf ${value.configSetting} if {$value.text} ', params, (param) => {
-                logOutputManager.hyperlinkFormat = param.configSetting;
-                declarationProviderMock.expects('getFunctionBeforeLine').returns({ name: 'methodName' });
-                logDocumentLinkProviderMock.expects('convertPkgPathToFsPath').returns({ name: 'filesystem/file.brs' });
-                let logText = logOutputManager.getCustomLogText(param.text, 'file',
-                    '.brs', 20, 2, false);
-                assert.equal(logText, 'file.methodName(20)');
-            });
+
+                expect(stub.getCall(0).args[0]).to.eql('file.brs(20) sometext');
+                stub.restore();
+            }
         });
 
-        describe('tests FilenameAndFunction with addline to log', () => {
-            let params = [
-                { configSetting: null, text: 'pkg:/file.brs(20)' },
-                { configSetting: null, text: 'pkg:/path/file.brs(20)' },
-                { configSetting: null, text: 'pkg:/path/path2/file.brs(20)' },
-                { configSetting: '', text: 'pkg:/file.brs(20)' },
-                { configSetting: '', text: 'pkg:/path/file.brs(20)' },
-                { configSetting: '', text: 'pkg:/path/path2/file.brs(20)' },
-                { configSetting: 'FilenameAndFunction', text: 'pkg:/file.brs(20)' },
-                { configSetting: 'FilenameAndFunction', text: 'pkg:/path/file.brs(20)' },
-                { configSetting: 'FilenameAndFunction', text: 'pkg:/path/path2/file.brs(20)' },
-            ];
-            itParam('lf ${value.configSetting} if {$value.text} ', params, (param) => {
-                logOutputManager.hyperlinkFormat = param.configSetting;
+        it('FilenameAndFunction', () => {
+            test(null, 'pkg:/file.brs(20)');
+            test(null, 'pkg:/path/file.brs(20)');
+            test(null, 'pkg:/path/path2/file.brs(20)');
+            test('', 'pkg:/file.brs(20)');
+            test('', 'pkg:/path/file.brs(20)');
+            test('', 'pkg:/path/path2/file.brs(20)');
+            test('FilenameAndFunction', 'pkg:/file.brs(20)');
+            test('FilenameAndFunction', 'pkg:/path/file.brs(20)');
+            test('FilenameAndFunction', 'pkg:/path/path2/file.brs(20)');
+
+            function test(hyperlinkFormat: string, text) {
+                logOutputManager.hyperlinkFormat = hyperlinkFormat;
                 declarationProviderMock.expects('getFunctionBeforeLine').returns({ name: 'methodName' });
                 logDocumentLinkProviderMock.expects('convertPkgPathToFsPath').returns({ name: 'filesystem/file.brs' });
+                expect(
+                    logOutputManager.getCustomLogText(text, 'file', '.brs', 20, 2, false)
+                ).to.eql('file.methodName(20)');
+            }
+        });
+
+        it('tests FilenameAndFunction with addline to log', () => {
+            test(null, 'pkg:/file.brs(20)', 'file.methodName(20)');
+            test(null, 'pkg:/path/file.brs(20)', 'file.methodName(20)');
+            test(null, 'pkg:/path/path2/file.brs(20)', 'file.methodName(20)');
+            test('', 'pkg:/file.brs(20)', 'file.methodName(20)');
+            test('', 'pkg:/path/file.brs(20)', 'file.methodName(20)');
+            test('', 'pkg:/path/path2/file.brs(20)', 'file.methodName(20)');
+            test('FilenameAndFunction', 'pkg:/file.brs(20)', 'file.methodName(20)');
+            test('FilenameAndFunction', 'pkg:/path/file.brs(20)', 'file.methodName(20)');
+            test('FilenameAndFunction', 'pkg:/path/path2/file.brs(20)', 'file.methodName(20)');
+            function test(hyperlinkFormat: string, text: string, expected: string) {
+                logOutputManager.hyperlinkFormat = hyperlinkFormat;
+                declarationProviderMock.expects('getFunctionBeforeLine').returns({ name: 'methodName' });
+                declarationProviderMock.expects('getFunctionBeforeLine').returns({ name: 'methodName' });
+                logDocumentLinkProviderMock.expects('convertPkgPathToFsPath').returns({ name: 'filesystem/file.brs' });
+                logDocumentLinkProviderMock.expects('convertPkgPathToFsPath').returns({ name: 'filesystem/file.brs' });
                 logDocumentLinkProviderMock.expects('addCustomPkgLink');
-                const logLine = new LogLine(param.text + ' sometext', true);
+                const logLine = new LogLine(text + ' sometext', true);
                 logOutputManager.addLogLineToOutput(logLine);
-                // assert.equal(logText, 'file.methodName(20)');
-            });
+                expect(
+                    logOutputManager.getCustomLogText(text, 'file', '.brs', 20, 2, false)
+                ).to.eql(expected);
+            }
         });
     });
 
@@ -367,155 +370,152 @@ describe('LogOutputManager ', () => {
             assert.equal(logText, ' ');
         });
 
-        describe('tests Filename', () => {
-            let params = [
-                { configSetting: 'Filename', text: 'file:///file.brs(20)' },
-                { configSetting: 'Filename', text: 'file:///path/file.brs(20)' },
-                { configSetting: 'Filename', text: 'file:///path/path2/file.brs(20)' },
-            ];
-            itParam('lf ${value.configSetting} if {$value.text} ', params, (param) => {
-                logOutputManager.hyperlinkFormat = param.configSetting;
+        it('tests Filename', () => {
+            function test(hyperlinkFormat: string, text: string) {
+                logOutputManager.hyperlinkFormat = hyperlinkFormat;
                 declarationProviderMock.expects('getFunctionBeforeLine').returns({ name: 'methodName' });
                 logDocumentLinkProviderMock.expects('convertPkgPathToFsPath').returns({ name: 'filesystem/file.brs' });
-                let logText = logOutputManager.getCustomLogText(param.text, 'file',
-                    '.brs', 20, 2, true);
-                assert.equal(logText, 'file.brs(20)');
-            });
+                expect(
+                    logOutputManager.getCustomLogText(text, 'file', '.brs', 20, 2, true)
+                ).to.eql('file.brs(20)');
+            }
+
+            test('Filename', 'file:///file.brs(20)');
+            test('Filename', 'file:///path/file.brs(20)');
+            test('Filename', 'file:///path/path2/file.brs(20)');
         });
 
-        describe('tests Filename with addline to log', () => {
-            let params = [
-                { configSetting: 'Filename', text: 'file:///file.brs(20)' },
-                { configSetting: 'Filename', text: 'file:///path/file.brs(20)' },
-                { configSetting: 'Filename', text: 'file:///path/path2/file.brs(20)' },
-            ];
-            itParam('lf ${value.configSetting} if {$value.text} ', params, (param) => {
+        it('tests Filename with addline to log', () => {
+            test({ configSetting: 'Filename', text: 'file:///file.brs(20)' });
+            test({ configSetting: 'Filename', text: 'file:///path/file.brs(20)' });
+            test({ configSetting: 'Filename', text: 'file:///path/path2/file.brs(20)' });
+            function test(param) {
                 logOutputManager.hyperlinkFormat = param.configSetting;
                 declarationProviderMock.expects('getFunctionBeforeLine').returns({ name: 'methodName' });
                 logDocumentLinkProviderMock.expects('convertPkgPathToFsPath').returns({ name: 'filesystem/file.brs' });
                 logDocumentLinkProviderMock.expects('addCustomFileLink');
                 const logLine = new LogLine(param.text + ' sometext', true);
+                const stub = sinon.stub(logOutputManager['outputChannel'], 'appendLine');
+
                 logOutputManager.addLogLineToOutput(logLine);
-                // assert.equal(logText, 'file.methodName(20)');
-            });
+
+                expect(stub.getCall(0).args[0]).to.eql('file.brs(20) sometext');
+                stub.restore();
+            }
         });
-        describe('tests FilenameAndFunction', () => {
-            let params = [
-                { configSetting: null, text: 'file:///file.brs(20)' },
-                { configSetting: null, text: 'file:///path/file.brs(20)' },
-                { configSetting: null, text: 'file:///path/path2/file.brs(20)' },
-                { configSetting: '', text: 'file:///file.brs(20)' },
-                { configSetting: '', text: 'file:///path/file.brs(20)' },
-                { configSetting: '', text: 'file:///path/path2/file.brs(20)' },
-                { configSetting: 'FilenameAndFunction', text: 'file:///file.brs(20)' },
-                { configSetting: 'FilenameAndFunction', text: 'file:///path/file.brs(20)' },
-                { configSetting: 'FilenameAndFunction', text: 'file:///path/path2/file.brs(20)' },
-            ];
-            itParam('lf ${value.configSetting} if {$value.text} ', params, (param) => {
+        it('FilenameAndFunction', () => {
+            test({ configSetting: null, text: 'file:///file.brs(20)' });
+            test({ configSetting: null, text: 'file:///path/file.brs(20)' });
+            test({ configSetting: null, text: 'file:///path/path2/file.brs(20)' });
+            test({ configSetting: '', text: 'file:///file.brs(20)' });
+            test({ configSetting: '', text: 'file:///path/file.brs(20)' });
+            test({ configSetting: '', text: 'file:///path/path2/file.brs(20)' });
+            test({ configSetting: 'FilenameAndFunction', text: 'file:///file.brs(20)' });
+            test({ configSetting: 'FilenameAndFunction', text: 'file:///path/file.brs(20)' });
+            test({ configSetting: 'FilenameAndFunction', text: 'file:///path/path2/file.brs(20)' });
+
+            function test(param) {
                 logOutputManager.hyperlinkFormat = param.configSetting;
                 declarationProviderMock.expects('getFunctionBeforeLine').returns({ name: 'methodName' });
                 logDocumentLinkProviderMock.expects('convertPkgPathToFsPath').returns({ name: 'filesystem/file.brs' });
-                let logText = logOutputManager.getCustomLogText(param.text, 'file',
-                    '.brs', 20, 2, true);
-                assert.equal(logText, 'file.methodName(20)');
-            });
+                expect(
+                    logOutputManager.getCustomLogText(param.text, 'file', '.brs', 20, 2, true)
+                ).to.eql('file.methodName(20)');
+            }
         });
 
-        describe('tests FilenameAndFunction with addline to log', () => {
-            let params = [
-                { configSetting: null, text: 'pkg:/file.brs(20)' },
-                { configSetting: null, text: 'pkg:/path/file.brs(20)' },
-                { configSetting: null, text: 'pkg:/path/path2/file.brs(20)' },
-                { configSetting: '', text: 'pkg:/file.brs(20)' },
-                { configSetting: '', text: 'pkg:/path/file.brs(20)' },
-                { configSetting: '', text: 'pkg:/path/path2/file.brs(20)' },
-                { configSetting: 'FilenameAndFunction', text: 'pkg:/file.brs(20)' },
-                { configSetting: 'FilenameAndFunction', text: 'pkg:/path/file.brs(20)' },
-                { configSetting: 'FilenameAndFunction', text: 'pkg:/path/path2/file.brs(20)' },
-            ];
-            itParam('lf ${value.configSetting} if {$value.text} ', params, (param) => {
+        it('FilenameAndFunction with addline to log', () => {
+            test({ configSetting: null, text: 'pkg:/file.brs(20)' });
+            test({ configSetting: null, text: 'pkg:/path/file.brs(20)' });
+            test({ configSetting: null, text: 'pkg:/path/path2/file.brs(20)' });
+            test({ configSetting: '', text: 'pkg:/file.brs(20)' });
+            test({ configSetting: '', text: 'pkg:/path/file.brs(20)' });
+            test({ configSetting: '', text: 'pkg:/path/path2/file.brs(20)' });
+            test({ configSetting: 'FilenameAndFunction', text: 'pkg:/file.brs(20)' });
+            test({ configSetting: 'FilenameAndFunction', text: 'pkg:/path/file.brs(20)' });
+            test({ configSetting: 'FilenameAndFunction', text: 'pkg:/path/path2/file.brs(20)' });
+            function test(param) {
                 logOutputManager.hyperlinkFormat = param.configSetting;
                 declarationProviderMock.expects('getFunctionBeforeLine').returns({ name: 'methodName' });
+                declarationProviderMock.expects('getFunctionBeforeLine').returns({ name: 'methodName' });
+                logDocumentLinkProviderMock.expects('convertPkgPathToFsPath').returns({ name: 'filesystem/file.brs' });
                 logDocumentLinkProviderMock.expects('convertPkgPathToFsPath').returns({ name: 'filesystem/file.brs' });
                 logDocumentLinkProviderMock.expects('addCustomPkgLink');
                 const logLine = new LogLine(param.text + ' sometext', true);
                 logOutputManager.addLogLineToOutput(logLine);
-                // assert.equal(logText, 'file.methodName(20)');
-            });
+                expect(
+                    logOutputManager.getCustomLogText(param.text, 'file', '.brs', 20, 2, true)
+                ).to.eql('file.methodName(20)');
+            }
         });
     });
 
-    describe('tests matchesFilter', () => {
-        describe('mustInclude items', () => {
-            let mustIncludeParams = [
-                { text: 'test1', levelFilter: null, includeFilter: null, excludeFilter: null, expected: true },
-                { text: 'test1', levelFilter: 'INFO', includeFilter: null, excludeFilter: null, expected: true },
-                { text: 'test1', levelFilter: null, includeFilter: 'INCLUDE', excludeFilter: null, expected: true },
-                { text: 'test1', levelFilter: null, includeFilter: null, excludeFilter: 'EXCLUDE', expected: true },
-                { text: 'test1', levelFilter: 'INFO', includeFilter: 'INCLUDE', excludeFilter: null, expected: true },
-                { text: 'test1', levelFilter: 'INFO', includeFilter: null, excludeFilter: 'EXCLUDE', expected: true },
-                { text: 'test1', levelFilter: null, includeFilter: 'INCLUDE', excludeFilter: 'EXCLUDE', expected: true },
-                { text: 'test1', levelFilter: 'INFO', includeFilter: 'INCLUDE', excludeFilter: 'EXCLUDE', expected: true },
-            ];
-            itParam('lf ${value.levelFilter} if {$value.levelFilter} ' +
-                'ef ${value.excludeFilter}', mustIncludeParams, (params) => {
-                    const logLine = new LogLine(params.text, true);
-                    logOutputManager.setIncludeFilter(params.includeFilter);
-                    logOutputManager.setExcludeFilter(params.excludeFilter);
-                    logOutputManager.setLevelFilter(params.levelFilter);
-                    assert.equal(logOutputManager['shouldLineBeShown'](logLine), params.expected);
-                });
+    describe('matchesFilter', () => {
+        it('mustInclude items', () => {
+            test({ text: 'test1', levelFilter: null, includeFilter: null, excludeFilter: null, expected: true });
+            test({ text: 'test1', levelFilter: 'INFO', includeFilter: null, excludeFilter: null, expected: true });
+            test({ text: 'test1', levelFilter: null, includeFilter: 'INCLUDE', excludeFilter: null, expected: true });
+            test({ text: 'test1', levelFilter: null, includeFilter: null, excludeFilter: 'EXCLUDE', expected: true });
+            test({ text: 'test1', levelFilter: 'INFO', includeFilter: 'INCLUDE', excludeFilter: null, expected: true });
+            test({ text: 'test1', levelFilter: 'INFO', includeFilter: null, excludeFilter: 'EXCLUDE', expected: true });
+            test({ text: 'test1', levelFilter: null, includeFilter: 'INCLUDE', excludeFilter: 'EXCLUDE', expected: true });
+            test({ text: 'test1', levelFilter: 'INFO', includeFilter: 'INCLUDE', excludeFilter: 'EXCLUDE', expected: true });
+
+            function test(params) {
+                const logLine = new LogLine(params.text, true);
+                logOutputManager.setIncludeFilter(params.includeFilter);
+                logOutputManager.setExcludeFilter(params.excludeFilter);
+                logOutputManager.setLevelFilter(params.levelFilter);
+                assert.equal(logOutputManager['shouldLineBeShown'](logLine), params.expected);
+            }
         });
-        describe('non-mustinclude items true scenarios', () => {
-            let mustIncludeParams = [
-                { text: 'INFO test1 INCLUDE', levelFilter: null, includeFilter: null, excludeFilter: null, expected: true },
-                { text: 'INFO test1 INCLUDE', levelFilter: 'INFO', includeFilter: null, excludeFilter: null, expected: true },
-                { text: 'INFO test1 INCLUDE', levelFilter: null, includeFilter: 'INCLUDE', excludeFilter: null, expected: true },
-                { text: 'INFO test1 INCLUDE', levelFilter: null, includeFilter: null, excludeFilter: 'EXCLUDE', expected: true },
-                { text: 'INFO test1 INCLUDE', levelFilter: 'INFO', includeFilter: 'INCLUDE', excludeFilter: null, expected: true },
-                { text: 'INFO test1 INCLUDE', levelFilter: 'INFO', includeFilter: null, excludeFilter: 'EXCLUDE', expected: true },
-                { text: 'INFO test1 INCLUDE', levelFilter: null, includeFilter: 'INCLUDE', excludeFilter: 'EXCLUDE', expected: true },
-                { text: 'INFO test1 INCLUDE', levelFilter: 'INFO', includeFilter: 'INCLUDE', excludeFilter: 'EXCLUDE', expected: true },
-            ];
-            itParam('lf ${value.levelFilter} if {$value.levelFilter} ' +
-                'ef ${value.excludeFilter}', mustIncludeParams, (params) => {
-                    const logLine = new LogLine(params.text, false);
-                    logOutputManager.setIncludeFilter(params.includeFilter);
-                    logOutputManager.setExcludeFilter(params.excludeFilter);
-                    logOutputManager.setLevelFilter(params.levelFilter);
-                    assert.equal(logOutputManager['shouldLineBeShown'](logLine), params.expected);
-                });
+
+        it('non-mustInclude items true scenarios', () => {
+            test({ text: 'INFO test1 INCLUDE', levelFilter: null, includeFilter: null, excludeFilter: null, expected: true });
+            test({ text: 'INFO test1 INCLUDE', levelFilter: 'INFO', includeFilter: null, excludeFilter: null, expected: true });
+            test({ text: 'INFO test1 INCLUDE', levelFilter: null, includeFilter: 'INCLUDE', excludeFilter: null, expected: true });
+            test({ text: 'INFO test1 INCLUDE', levelFilter: null, includeFilter: null, excludeFilter: 'EXCLUDE', expected: true });
+            test({ text: 'INFO test1 INCLUDE', levelFilter: 'INFO', includeFilter: 'INCLUDE', excludeFilter: null, expected: true });
+            test({ text: 'INFO test1 INCLUDE', levelFilter: 'INFO', includeFilter: null, excludeFilter: 'EXCLUDE', expected: true });
+            test({ text: 'INFO test1 INCLUDE', levelFilter: null, includeFilter: 'INCLUDE', excludeFilter: 'EXCLUDE', expected: true });
+            test({ text: 'INFO test1 INCLUDE', levelFilter: 'INFO', includeFilter: 'INCLUDE', excludeFilter: 'EXCLUDE', expected: true });
+
+            function test(params) {
+                const logLine = new LogLine(params.text, false);
+                logOutputManager.setIncludeFilter(params.includeFilter);
+                logOutputManager.setExcludeFilter(params.excludeFilter);
+                logOutputManager.setLevelFilter(params.levelFilter);
+                assert.equal(logOutputManager['shouldLineBeShown'](logLine), params.expected);
+            }
         });
-        describe('non-must include items false scenarios', () => {
-            let mustIncludeParams = [
-                { text: 'INFO test1 INCLUDE', levelFilter: 'DEBUG', includeFilter: null, excludeFilter: null, expected: false },
-                { text: 'INFO test1 NOTTHERE', levelFilter: null, includeFilter: 'INCLUDE', excludeFilter: null, expected: false },
-                { text: 'INFO test1 INCLUDE EXCLUDE', levelFilter: null, includeFilter: null, excludeFilter: 'EXCLUDE', expected: false },
-                { text: 'INFO test1 NOTTHERE', levelFilter: 'INFO', includeFilter: 'INCLUDE', excludeFilter: null, expected: false },
-                { text: 'INFO test1 INCLUDE', levelFilter: 'DEBUG', includeFilter: 'INCLUDE', excludeFilter: null, expected: false },
-                { text: 'INFO test1 NOTTHERE', levelFilter: 'DEBUG', includeFilter: 'INCLUDE', excludeFilter: null, expected: false },
-                { text: 'INFO test1 INCLUDE EXCLUDE', levelFilter: 'INFO', includeFilter: null, excludeFilter: 'EXCLUDE', expected: false },
-                { text: 'INFO test1 INCLUDE', levelFilter: 'DEBUG', includeFilter: null, excludeFilter: 'EXCLUDE', expected: false },
-                { text: 'INFO test1 INCLUDE EXCLUDE', levelFilter: null, includeFilter: 'INCLUDE', excludeFilter: 'EXCLUDE', expected: false },
-                { text: 'INFO test1 NOTHERE', levelFilter: null, includeFilter: 'INCLUDE', excludeFilter: 'EXCLUDE', expected: false },
-                { text: 'INFO test1 NOTHERE EXCLUDE', levelFilter: null, includeFilter: 'INCLUDE', excludeFilter: 'EXCLUDE', expected: false },
-                { text: 'INFO test1 NOTTHERE', levelFilter: 'INFO', includeFilter: 'INCLUDE', excludeFilter: 'EXCLUDE', expected: false },
-                { text: 'INFO test1 NOTTHERE', levelFilter: 'INFO', includeFilter: 'INCLUDE', excludeFilter: 'EXCLUDE', expected: false },
-                { text: 'INFO test1 NOTHERE', levelFilter: 'INFO', includeFilter: 'INCLUDE', excludeFilter: 'EXCLUDE', expected: false },
-                { text: 'INFO test1 NOTHERE EXCLUDE', levelFilter: 'DEBUG', includeFilter: 'INCLUDE', excludeFilter: 'EXCLUDE', expected: false },
-                { text: 'INFO test1 INCLUDE', levelFilter: 'DEBUG', includeFilter: 'INCLUDE', excludeFilter: 'EXCLUDE', expected: false },
-                { text: 'INFO test1 NOTHERE', levelFilter: 'DEBUG', includeFilter: 'INCLUDE', excludeFilter: 'EXCLUDE', expected: false },
-                { text: 'INFO test1 NOTHERE EXCLUDE', levelFilter: 'DEBUG', includeFilter: 'INCLUDE', excludeFilter: 'EXCLUDE', expected: false },
-            ];
-            itParam('lf ${value.levelFilter} if {$value.levelFilter} ' +
-                'ef ${value.excludeFilter}', mustIncludeParams, (params) => {
-                    const logLine = new LogLine(params.text, false);
-                    logOutputManager.setIncludeFilter(params.includeFilter);
-                    logOutputManager.setExcludeFilter(params.excludeFilter);
-                    logOutputManager.setLevelFilter(params.levelFilter);
-                    assert.equal(logOutputManager['shouldLineBeShown'](logLine), params.expected);
-                });
+
+        it('non-must include items false scenarios', () => {
+            test({ text: 'INFO test1 INCLUDE', levelFilter: 'DEBUG', includeFilter: null, excludeFilter: null, expected: false });
+            test({ text: 'INFO test1 NOTTHERE', levelFilter: null, includeFilter: 'INCLUDE', excludeFilter: null, expected: false });
+            test({ text: 'INFO test1 INCLUDE EXCLUDE', levelFilter: null, includeFilter: null, excludeFilter: 'EXCLUDE', expected: false });
+            test({ text: 'INFO test1 NOTTHERE', levelFilter: 'INFO', includeFilter: 'INCLUDE', excludeFilter: null, expected: false });
+            test({ text: 'INFO test1 INCLUDE', levelFilter: 'DEBUG', includeFilter: 'INCLUDE', excludeFilter: null, expected: false });
+            test({ text: 'INFO test1 NOTTHERE', levelFilter: 'DEBUG', includeFilter: 'INCLUDE', excludeFilter: null, expected: false });
+            test({ text: 'INFO test1 INCLUDE EXCLUDE', levelFilter: 'INFO', includeFilter: null, excludeFilter: 'EXCLUDE', expected: false });
+            test({ text: 'INFO test1 INCLUDE', levelFilter: 'DEBUG', includeFilter: null, excludeFilter: 'EXCLUDE', expected: false });
+            test({ text: 'INFO test1 INCLUDE EXCLUDE', levelFilter: null, includeFilter: 'INCLUDE', excludeFilter: 'EXCLUDE', expected: false });
+            test({ text: 'INFO test1 NOTHERE', levelFilter: null, includeFilter: 'INCLUDE', excludeFilter: 'EXCLUDE', expected: false });
+            test({ text: 'INFO test1 NOTHERE EXCLUDE', levelFilter: null, includeFilter: 'INCLUDE', excludeFilter: 'EXCLUDE', expected: false });
+            test({ text: 'INFO test1 NOTTHERE', levelFilter: 'INFO', includeFilter: 'INCLUDE', excludeFilter: 'EXCLUDE', expected: false });
+            test({ text: 'INFO test1 NOTTHERE', levelFilter: 'INFO', includeFilter: 'INCLUDE', excludeFilter: 'EXCLUDE', expected: false });
+            test({ text: 'INFO test1 NOTHERE', levelFilter: 'INFO', includeFilter: 'INCLUDE', excludeFilter: 'EXCLUDE', expected: false });
+            test({ text: 'INFO test1 NOTHERE EXCLUDE', levelFilter: 'DEBUG', includeFilter: 'INCLUDE', excludeFilter: 'EXCLUDE', expected: false });
+            test({ text: 'INFO test1 INCLUDE', levelFilter: 'DEBUG', includeFilter: 'INCLUDE', excludeFilter: 'EXCLUDE', expected: false });
+            test({ text: 'INFO test1 NOTHERE', levelFilter: 'DEBUG', includeFilter: 'INCLUDE', excludeFilter: 'EXCLUDE', expected: false });
+            test({ text: 'INFO test1 NOTHERE EXCLUDE', levelFilter: 'DEBUG', includeFilter: 'INCLUDE', excludeFilter: 'EXCLUDE', expected: false });
+
+            function test(params) {
+                const logLine = new LogLine(params.text, false);
+                logOutputManager.setIncludeFilter(params.includeFilter);
+                logOutputManager.setExcludeFilter(params.excludeFilter);
+                logOutputManager.setLevelFilter(params.levelFilter);
+                assert.equal(logOutputManager['shouldLineBeShown'](logLine), params.expected);
+            }
         });
     });
-
 });

--- a/src/LogOutputManager.spec.ts
+++ b/src/LogOutputManager.spec.ts
@@ -1,8 +1,9 @@
 /* tslint:disable:no-unused-expression */
 /* tslint:disable:no-var-requires */
 /* tslint:disable:no-string-literal */
-import { assert } from 'chai';
-import * as sinon from 'sinon';
+import { assert, expect } from 'chai';
+import { createSandbox } from 'sinon';
+const sinon = createSandbox();
 let Module = require('module');
 
 import { vscode } from './mockVscode.spec';
@@ -35,6 +36,7 @@ describe('LogOutputManager ', () => {
     let declarationProviderMock;
 
     beforeEach(() => {
+        sinon.restore();
         const outputChannel = new vscode.OutputChannel();
         const debugCollection = new vscode.DebugCollection();
         const logDocumentLinkProvider = new LogDocumentLinkProvider();
@@ -51,10 +53,7 @@ describe('LogOutputManager ', () => {
     });
 
     afterEach(() => {
-        outputChannelMock.restore();
-        languagesMock.restore();
-        collectionMock.restore();
-        logOutputManagerMock.restore();
+        sinon.restore();
     });
 
     it('tests onDidStartDebugSession clear flag', () => {
@@ -231,23 +230,18 @@ describe('LogOutputManager ', () => {
         });
     });
 
-    describe('tests getFilename', () => {
-        describe('mustInclude items', () => {
-            let params = [
-                { text: 'pkg:/file.xml', expected: 'file' },
-                { text: 'pkg:/path/file.xml', expected: 'file' },
-                { text: 'pkg:/path/path2/file.xml', expected: 'file' },
-                { text: 'pkg:/file.brs', expected: 'file' },
-                { text: 'pkg:/path/file.brs', expected: 'file' },
-                { text: 'pkg:/path/path2/file.brs', expected: 'file' },
-                { text: 'path/file.brs', expected: 'file' },
-                { text: 'path/path2/file.brs', expected: 'file' },
-                { text: 'file.brs', expected: 'file' },
-                { text: 'pkg:/file.other', expected: 'file.other' },
-            ];
-            itParam('lf ${value.text} if {$value.expected}', params, (param) => {
-                assert.equal(logOutputManager.getFilename(param.text), param.expected);
-            });
+    describe('getFilename', () => {
+        it('works', () => {
+            expect(logOutputManager.getFilename('pkg:/file.xml')).to.eql('file');
+            expect(logOutputManager.getFilename('pkg:/path/file.xml')).to.eql('file');
+            expect(logOutputManager.getFilename('pkg:/path/path2/file.xml')).to.eql('file');
+            expect(logOutputManager.getFilename('pkg:/file.brs')).to.eql('file');
+            expect(logOutputManager.getFilename('pkg:/path/file.brs')).to.eql('file');
+            expect(logOutputManager.getFilename('pkg:/path/path2/file.brs')).to.eql('file');
+            expect(logOutputManager.getFilename('path/file.brs')).to.eql('file');
+            expect(logOutputManager.getFilename('path/path2/file.brs')).to.eql('file');
+            expect(logOutputManager.getFilename('file.brs')).to.eql('file');
+            expect(logOutputManager.getFilename('pkg:/file.other')).to.eql('file.other');
         });
     });
 
@@ -279,7 +273,7 @@ describe('LogOutputManager ', () => {
                 { configSetting: 'Filename', text: 'pkg:/path/file.brs(20)' },
                 { configSetting: 'Filename', text: 'pkg:/path/path2/file.brs(20)' },
             ];
-            itParam('lf ${value.configSetting} if {$value.text} ', params, (param) => {
+            itParam('lf ${value.configSetting} if ${value.text} ', params, (param) => {
                 logOutputManager.hyperlinkFormat = param.configSetting;
                 declarationProviderMock.expects('getFunctionBeforeLine').returns({ name: 'methodName' });
                 logDocumentLinkProviderMock.expects('convertPkgPathToFsPath').returns({ name: 'filesystem/file.brs' });

--- a/src/LogOutputManager.ts
+++ b/src/LogOutputManager.ts
@@ -268,7 +268,14 @@ export class LogOutputManager {
                 const path = isFilePath ? match[3] : 'pkg:/' + match[3];
                 let lineNumber = match[1] ? Number(match[1]) : undefined;
                 if (!lineNumber) {
-                    lineNumber = isFilePath ? Number(match[7]) : Number(match[5]);
+                    if (isFilePath) {
+                        lineNumber = Number(match[7]);
+                        if (isNaN(lineNumber)) {
+                            lineNumber = Number(match[5]);
+                        }
+                    } else {
+                        lineNumber = Number(match[5]);
+                    }
                 }
 
                 const filename = this.getFilename(path);

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,5 +15,8 @@
         "noUnusedParameters": false,
         "allowSyntheticDefaultImports": true
     },
-    "include": ["src/**/*"]
+    "include": ["src/**/*"],
+    "ts-node": {
+        "transpileOnly": true
+    }
 }


### PR DESCRIPTION
the mocha-param library makes unit tests a little harder to debug. Removed it in favor of a helper test function with explicit calls.

Fixed a small bug with log line numbers not being properly detected.