### PR TITLE
Allow Ctrl/Cmd + Escape for home press

### DIFF
--- a/docs/Debugging/remote-control-mode.md
+++ b/docs/Debugging/remote-control-mode.md
@@ -33,6 +33,7 @@ Here are many of the registered key bindings. You can see the full list in the [
 | `Delete`             | `Delete`             | Back            |                                                                                                 |
 | `Home`               | `Home`               | Home            |                                                                                                 |
 | `Shift+Escape`       | `Shift+Escape`       | Home            |                                                                                                 |
+| `Ctrl+Escape`        | `Cmt+Escape`         | Home            |                                                                                                 |
 | `Backspace`          | `Backspace`          | Instant Replay  | Can also be used to delete the character to the left of the cursor in an input box              |
 | `Ctrl+Backspace`     | `Cmd+Backspace`      | Backspace       | Delete the character to the left of the cursor in an input box                                  |
 | `Ctrl+Enter`         | `Cmd+Enter`          | Play/Pause      |                                                                                                 |

--- a/package.json
+++ b/package.json
@@ -1945,6 +1945,12 @@
                 "when": "!searchInputBoxFocus && !findInputFocussed && !inCommandsPicker && !inQuickOpen && brightscript.isRemoteControlMode"
             },
             {
+                "command": "extension.brightscript.pressHomeButton",
+                "key": "Ctrl+Escape",
+                "mac": "Cmd+Escape",
+                "when": "!searchInputBoxFocus && !findInputFocussed && !inCommandsPicker && !inQuickOpen && brightscript.isRemoteControlMode"
+            },
+            {
                 "command": "extension.brightscript.pressInstantReplayButton",
                 "key": "Backspace",
                 "when": "!searchInputBoxFocus && !findInputFocussed && !inCommandsPicker && !inQuickOpen && brightscript.isRemoteControlMode"


### PR DESCRIPTION
Add another way to press the home button when in Remote Control Mode.
 - maps Ctrl+Escape (windows) or Cmd+Escape to the "Home" button.

Ctrl+Escape might be bound to a windows system key, but since you still have Shift+Home, it's no harm.