### PR TITLE
Unfocus Remote Control Mode statusbar item on click

### DIFF
--- a/src/managers/RemoteControlManager.ts
+++ b/src/managers/RemoteControlManager.ts
@@ -52,6 +52,21 @@ export class RemoteControlManager {
     public async toggleRemoteControlMode(initiator: RemoteControlModeInitiator) {
         const currentMode = vscodeContextManager.get<boolean>('brightscript.isRemoteControlMode', false);
         await this.setRemoteControlMode(!currentMode, initiator);
+
+        //remove focus from statusbar item after clicking
+        if (initiator === 'statusbar') {
+            //focus the active text editor (if there is one)
+            if (vscode.window.activeTextEditor?.document) {
+                await vscode.window.showTextDocument(vscode.window.activeTextEditor.document);
+
+                //there's no active text editor. Move focus away from the statusbar item (somehow)
+            } else {
+                //focus the next editor group, then the previous editor group.
+                //This is safe to call when there are no editor groups, so it's a good way to remove focus from the statusbar item
+                await vscode.commands.executeCommand('workbench.action.focusNextGroup');
+                await vscode.commands.executeCommand('workbench.action.focusPreviousGroup');
+            }
+        }
     }
 
     public async setRemoteControlMode(isEnabled: boolean, initiator: RemoteControlModeInitiator) {


### PR DESCRIPTION
Fixes a quirk that, whenever the Remote Control Mode statusbar item is clicked, it would retain focus. Then, when a user would press the `enter` key, it would act like a "click" on the statusbar item and disable **remote control mode**. 

To fix this, after the item is clicked, we focus the active editor. If there is no active editor, then we execute a few workspace commands to toggle through active editor groups. Since there are no active editor groups when there's no active editor, it removes focus to the statusbar item without any negative side effects.

One downside to this is that I can't really know what else to focus on. For example, if you have the terminal focused, this will technically lose focus on the terminal. However, since you clicked a statusbar item, you already moved the focus. Not a big deal in my opinion, but something to consider for the future if we wanted to query more focusable items to figure out which one to re-focus. 