### PR TITLE
Delay language server when running in dev mode

### DIFF
--- a/src/LanguageServerManager.ts
+++ b/src/LanguageServerManager.ts
@@ -114,7 +114,8 @@ export class LanguageServerManager {
 
             //give the runner the specific version of bsc to run
             const args = [
-                this.selectedBscInfo.path
+                this.selectedBscInfo.path,
+                (this.context.extensionMode === vscode.ExtensionMode.Development).toString()
             ];
             // If the extension is launched in debug mode then the debug server options are used
             // Otherwise the run options are used

--- a/src/LanguageServerRunner.ts
+++ b/src/LanguageServerRunner.ts
@@ -1,5 +1,16 @@
 //this runs in a separate process without the vscode module support
 const pathToBrighterScript = process.argv[2];
+const isDevMode = process.argv[3] === 'true';
+
+//when running in dev mode, the language server sometimes runs faster than the debugger can pick up. So run a loop for a bit to let us catch up
+if (isDevMode) {
+    const delay = 1500;
+    const start = Date.now();
+    while (Date.now() < start + delay) {
+        //do nothing
+    }
+}
+
 // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
 const LanguageServer = require(pathToBrighterScript).LanguageServer;
 const server = new LanguageServer();


### PR DESCRIPTION
Sometimes when debugging the language server, our early breakpoints don't get hit. This seems to be related to vscode just running it before we can attach. To improve this, detect when we're in "Extension Host" mode, and add a 1.5s delay so it has time to attach properly. This has no effect when running in production mode (i.e. end-users won't get the delay applied).