### PR TITLE
Don't show error message when 0 Roku devices found

### DIFF
--- a/src/ActiveDeviceManager.ts
+++ b/src/ActiveDeviceManager.ts
@@ -126,12 +126,10 @@ export class ActiveDeviceManager extends EventEmitter {
             });
 
             finder.on('timeout', () => {
-                if (devices.length > 0) {
-                    // debug('found Roku devices at %o after %dms', addresses, elapsedTime());
-                    resolve(devices);
-                } else {
-                    reject(new Error(`Could not find any Roku devices after ${timeout / 1000} seconds`));
+                if (devices.length === 0) {
+                    console.info(`Could not find any Roku devices after ${timeout / 1000} seconds`);
                 }
+                resolve(devices);
             });
 
             finder.start(timeout);


### PR DESCRIPTION
Don't throw an error when 0 Roku devices are found. Instead, just log it and move on. 