### PR TITLE
Syntax highlighting support for the new `const` keyword

### DIFF
--- a/src/grammar/brightscript.tmLanguage.spec.ts
+++ b/src/grammar/brightscript.tmLanguage.spec.ts
@@ -7,6 +7,23 @@ import { standardizePath as s } from 'brighterscript';
 const brightscriptTmlanguagePath = s`${__dirname}/../../syntaxes/brightscript.tmLanguage.json`;
 
 describe('brightscript.tmlanguage.json', () => {
+    it('colors the const keyword', async () => {
+        await testGrammar(`
+             const API_KEY = true
+            '                ^^^^ constant.language.boolean.true.brs
+            '              ^ keyword.operator.brs
+            '      ^^^^^^^ entity.name.variable.local.brs
+            '^^^^^ storage.type.brs
+            namespace Name.Space
+                 const API_URL = "u/r/l"
+                '                ^^^^^^^ string.quoted.double.brs
+                '              ^ keyword.operator.brs
+                '      ^^^^^^^ entity.name.variable.local.brs
+                '^^^^^ storage.type.brs
+            end namespace
+        `);
+    });
+
     it('bool assignment', async () => {
         await testGrammar(`
              thing = true

--- a/syntaxes/brightscript.tmLanguage.json
+++ b/syntaxes/brightscript.tmLanguage.json
@@ -430,7 +430,7 @@
         },
         "storage_types": {
             "comment": "Included 'dim' because it didn't warrant its own matcher",
-            "match": "(?i:\\b(boolean|integer|longinteger|float|double|string|object|function|sub|interface|dynamic|brsub|dim)\\b)",
+            "match": "(?i:\\b(boolean|integer|longinteger|float|double|string|object|function|sub|interface|dynamic|brsub|dim|const)\\b)",
             "captures": {
                 "1": {
                     "name": "storage.type.brs"


### PR DESCRIPTION
Adds syntax highlighting support for the new `const` keyword. 

See https://github.com/rokucommunity/brighterscript/pull/632