### PR TITLE
Better import statement syntax highlighting.

### DIFF
--- a/src/grammar/brightscript.tmLanguage.spec.ts
+++ b/src/grammar/brightscript.tmLanguage.spec.ts
@@ -7,7 +7,7 @@ import { standardizePath as s } from 'brighterscript';
 const brightscriptTmlanguagePath = s`${__dirname}/../../syntaxes/brightscript.tmLanguage.json`;
 
 describe('brightscript.tmlanguage.json', () => {
-    it.only('allows 0+ space after import keyword', async () => {
+    it('allows 0+ space after import keyword', async () => {
         await testGrammar(`
              import"something.brs"
             '      ^^^^^^^^^^^^^^^ string.quoted.double.brs

--- a/src/grammar/brightscript.tmLanguage.spec.ts
+++ b/src/grammar/brightscript.tmLanguage.spec.ts
@@ -7,6 +7,20 @@ import { standardizePath as s } from 'brighterscript';
 const brightscriptTmlanguagePath = s`${__dirname}/../../syntaxes/brightscript.tmLanguage.json`;
 
 describe('brightscript.tmlanguage.json', () => {
+    it.only('allows 0+ space after import keyword', async () => {
+        await testGrammar(`
+             import"something.brs"
+            '      ^^^^^^^^^^^^^^^ string.quoted.double.brs
+            '^^^^^^ keyword.control.import.brs
+             import "something.brs"
+            '       ^^^^^^^^^^^^^^^ string.quoted.double.brs
+            '^^^^^^ keyword.control.import.brs
+             import    "something.brs"
+            '          ^^^^^^^^^^^^^^^ string.quoted.double.brs
+            '^^^^^^ keyword.control.import.brs
+        `);
+    });
+
     it('colors the const keyword', async () => {
         await testGrammar(`
              const API_KEY = true

--- a/syntaxes/brightscript.tmLanguage.json
+++ b/syntaxes/brightscript.tmLanguage.json
@@ -168,7 +168,7 @@
             }
         },
         "import_statement": {
-            "match": "(?i:(import)\\s(\".*\"))",
+            "match": "(?i:(import)\\s*(\".*\"))",
             "captures": {
                 "1": {
                     "name": "keyword.control.import.brs"


### PR DESCRIPTION
Fixes an issue with import keyword not coloring with 0 or 2+ spaces
![image](https://user-images.githubusercontent.com/2544493/178576456-3586b9cc-1025-4957-bd8f-d9e9ef5a6fd5.png)
