### PR TITLE
Fix property and call syntax highlighting

### DIFF
--- a/src/grammar/brightscript.tmLanguage.spec.ts
+++ b/src/grammar/brightscript.tmLanguage.spec.ts
@@ -21,6 +21,17 @@ describe('brightscript.tmlanguage.json', () => {
         `);
     });
 
+    it('matches functions and properties in a chain', async () => {
+        await testGrammar(`
+             m.a().beta().c.delta = true
+            '               ^^^^^ variable.other.object.property.brs
+            '             ^ variable.other.object.property.brs
+            '      ^^^^ entity.name.function.brs
+            '  ^ entity.name.function.brs
+            '^ keyword.other.this.brs
+        `);
+    });
+
     it('colors the const keyword', async () => {
         await testGrammar(`
              const API_KEY = true

--- a/syntaxes/brightscript.tmLanguage.json
+++ b/syntaxes/brightscript.tmLanguage.json
@@ -73,6 +73,9 @@
                     "include": "#keyword_logical_operator"
                 },
                 {
+                    "include": "#function_call"
+                },
+                {
                     "include": "#object_properties"
                 },
                 {
@@ -98,9 +101,6 @@
                 },
                 {
                     "include": "#end_function"
-                },
-                {
-                    "include": "#function_call"
                 },
                 {
                     "include": "#interface_declaration"
@@ -525,7 +525,7 @@
             ]
         },
         "object_properties": {
-            "match": "(?i:\\b\\.((?:[a-z0-9_])*)(?!\\s*\\()\\b)",
+            "match": "(?i:(?<=\\.)([a-z0-9_][a-z0-9_\\$%!#&]*))",
             "captures": {
                 "1": {
                     "name": "variable.other.object.property.brs"
@@ -534,7 +534,7 @@
         },
         "identifiers_with_type_designators": {
             "name": "entity.name.variable.local.brs",
-            "match": "(?i:\\b([a-z_][a-z0-9_]*)[\\$%!#])"
+            "match": "(?i:\\b([a-z_][a-z0-9_]*)[\\$%!#&])"
         },
         "primitive_literal_expression": {
             "patterns": [
@@ -673,7 +673,7 @@
                     "name": "entity.name.function.brs"
                 }
             },
-            "match": "(?i:\\b([a-z_][a-z0-9_]*)\\s*\\()"
+            "match": "(?i:\\b([a-z_][a-z0-9_]*)[ \\t]*(?=\\())"
         },
         "function_declaration": {
             "captures": {


### PR DESCRIPTION
Fix syntax highlighting bug in property use and function calls.

**Before:**:
Notice the `isLoggedIn` is colored weird, and the `andDogs` is totally white (meaning it wasn't tokenized at all).
![image](https://user-images.githubusercontent.com/2544493/179288010-5f881890-defb-480d-a53c-ab2621a2fc20.png)

**After:**
![image](https://user-images.githubusercontent.com/2544493/179288136-ea769955-5042-4604-b5dd-b9e0a4a35bab.png)

