### PR TITLE
Add .bs and .brs file icon support

### DIFF
--- a/images/icons/brighterscript.svg
+++ b/images/icons/brighterscript.svg
@@ -1,0 +1,48 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   viewBox="0 0 32 32"
+   version="1.1"
+   id="svg4"
+   sodipodi:docname="brighterscript.svg"
+   inkscape:version="1.1.2 (b8e25be833, 2022-02-05)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     id="namedview6"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="26.09375"
+     inkscape:cx="16"
+     inkscape:cy="16"
+     inkscape:window-width="1920"
+     inkscape:window-height="1018"
+     inkscape:window-x="1913"
+     inkscape:window-y="-6"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg4">
+    <inkscape:grid
+       type="xygrid"
+       id="grid1039" />
+  </sodipodi:namedview>
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:20.5788px;line-height:1.25;font-family:Roboto;-inkscape-font-specification:'Roboto, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#5499b8;fill-opacity:1;stroke:none;stroke-width:1.02894"
+     x="6.2766333"
+     y="23.518963"
+     id="text4146-1"
+     transform="scale(1.0095029,0.99058655)"><tspan
+       sodipodi:role="line"
+       id="tspan4144-2"
+       x="6.2766333"
+       y="23.518963"
+       style="fill:#5499b8;fill-opacity:1;stroke-width:1.02894">BS</tspan></text>
+</svg>

--- a/images/icons/brightscript.svg
+++ b/images/icons/brightscript.svg
@@ -22,7 +22,7 @@
      showgrid="false"
      inkscape:zoom="26.09375"
      inkscape:cx="16"
-     inkscape:cy="16.11497"
+     inkscape:cy="16"
      inkscape:window-width="1920"
      inkscape:window-height="1018"
      inkscape:window-x="1913"
@@ -35,26 +35,14 @@
   </sodipodi:namedview>
   <text
      xml:space="preserve"
-     style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:20.5788px;line-height:1.25;font-family:Roboto;-inkscape-font-specification:'Roboto, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#9f75c0;fill-opacity:1;stroke:none;stroke-width:1.02894"
-     x="-0.93626046"
-     y="23.402901"
-     id="text4146-1"
-     transform="scale(1.0095029,0.99058655)"><tspan
-       sodipodi:role="line"
-       id="tspan4144-2"
-       x="-0.93626046"
-       y="23.402901"
-       style="fill:#9f75c0;fill-opacity:1;stroke-width:1.02894">BrS</tspan></text>
-  <text
-     xml:space="preserve"
-     style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:8px;line-height:1.25;font-family:Roboto;-inkscape-font-specification:'Roboto, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#9f75c0;fill-opacity:1;stroke:none;stroke-width:1.02894"
-     x="18.140873"
-     y="21.281321"
+     style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:19.0314px;line-height:1.25;font-family:Roboto;-inkscape-font-specification:'Roboto, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#5499b8;fill-opacity:1;stroke:none;stroke-width:0.951571"
+     x="7.1882892"
+     y="20.861814"
      id="text4146-1-5"
-     transform="scale(1.0095029,0.99058655)"><tspan
+     transform="scale(0.93359572,1.0711274)"><tspan
        sodipodi:role="line"
-       id="tspan4144-2-0"
-       x="18.140873"
-       y="21.281321"
-       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:8px;font-family:Roboto;-inkscape-font-specification:'Roboto, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#9f75c0;fill-opacity:1;stroke-width:1.02894" /></text>
+       id="tspan4144-2-2"
+       x="7.1882892"
+       y="20.861814"
+       style="fill:#9f75c0;fill-opacity:1;stroke-width:0.951571">brs</tspan></text>
 </svg>

--- a/images/icons/brightscript.svg
+++ b/images/icons/brightscript.svg
@@ -1,0 +1,60 @@
+<?xml version="1.0" encoding="UTF-8" standalone="no"?>
+<svg
+   viewBox="0 0 32 32"
+   version="1.1"
+   id="svg4"
+   sodipodi:docname="brightscript.svg"
+   inkscape:version="1.1.2 (b8e25be833, 2022-02-05)"
+   xmlns:inkscape="http://www.inkscape.org/namespaces/inkscape"
+   xmlns:sodipodi="http://sodipodi.sourceforge.net/DTD/sodipodi-0.dtd"
+   xmlns="http://www.w3.org/2000/svg"
+   xmlns:svg="http://www.w3.org/2000/svg">
+  <defs
+     id="defs8" />
+  <sodipodi:namedview
+     id="namedview6"
+     pagecolor="#ffffff"
+     bordercolor="#666666"
+     borderopacity="1.0"
+     inkscape:pageshadow="2"
+     inkscape:pageopacity="0.0"
+     inkscape:pagecheckerboard="0"
+     showgrid="false"
+     inkscape:zoom="26.09375"
+     inkscape:cx="16"
+     inkscape:cy="16.11497"
+     inkscape:window-width="1920"
+     inkscape:window-height="1018"
+     inkscape:window-x="1913"
+     inkscape:window-y="-6"
+     inkscape:window-maximized="1"
+     inkscape:current-layer="svg4">
+    <inkscape:grid
+       type="xygrid"
+       id="grid1039" />
+  </sodipodi:namedview>
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:20.5788px;line-height:1.25;font-family:Roboto;-inkscape-font-specification:'Roboto, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#9f75c0;fill-opacity:1;stroke:none;stroke-width:1.02894"
+     x="-0.93626046"
+     y="23.402901"
+     id="text4146-1"
+     transform="scale(1.0095029,0.99058655)"><tspan
+       sodipodi:role="line"
+       id="tspan4144-2"
+       x="-0.93626046"
+       y="23.402901"
+       style="fill:#9f75c0;fill-opacity:1;stroke-width:1.02894">BrS</tspan></text>
+  <text
+     xml:space="preserve"
+     style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:8px;line-height:1.25;font-family:Roboto;-inkscape-font-specification:'Roboto, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#9f75c0;fill-opacity:1;stroke:none;stroke-width:1.02894"
+     x="18.140873"
+     y="21.281321"
+     id="text4146-1-5"
+     transform="scale(1.0095029,0.99058655)"><tspan
+       sodipodi:role="line"
+       id="tspan4144-2-0"
+       x="18.140873"
+       y="21.281321"
+       style="font-style:normal;font-variant:normal;font-weight:bold;font-stretch:normal;font-size:8px;font-family:Roboto;-inkscape-font-specification:'Roboto, Bold';font-variant-ligatures:normal;font-variant-caps:normal;font-variant-numeric:normal;font-variant-east-asian:normal;fill:#9f75c0;fill-opacity:1;stroke-width:1.02894" /></text>
+</svg>

--- a/package-lock.json
+++ b/package-lock.json
@@ -6664,6 +6664,19 @@
                 "node": ">=0.6"
             }
         },
+        "node_modules/loose-envify": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+            "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+            "dev": true,
+            "peer": true,
+            "dependencies": {
+                "js-tokens": "^3.0.0 || ^4.0.0"
+            },
+            "bin": {
+                "loose-envify": "cli.js"
+            }
+        },
         "node_modules/loupe": {
             "version": "2.3.4",
             "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.4.tgz",
@@ -8425,6 +8438,19 @@
             "resolved": "https://registry.npmjs.org/strip-json-comments/-/strip-json-comments-2.0.1.tgz",
             "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
             "dev": true,
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/react": {
+            "version": "18.2.0",
+            "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
+            "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+            "dev": true,
+            "peer": true,
+            "dependencies": {
+                "loose-envify": "^1.1.0"
+            },
             "engines": {
                 "node": ">=0.10.0"
             }
@@ -16447,6 +16473,16 @@
             "resolved": "https://registry.npmjs.org/long/-/long-3.2.0.tgz",
             "integrity": "sha512-ZYvPPOMqUwPoDsbJaR10iQJYnMuZhRTvHYl62ErLIEX7RgFlziSBUUvrt3OVfc47QlHHpzPZYP17g3Fv7oeJkg=="
         },
+        "loose-envify": {
+            "version": "1.4.0",
+            "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
+            "integrity": "sha512-lyuxPGr/Wfhrlem2CL/UcnUc1zcqKAImBDzukY7Y5F/yQiNdko6+fRLevlw1HgMySw7f611UIY408EtxRSoK3Q==",
+            "dev": true,
+            "peer": true,
+            "requires": {
+                "js-tokens": "^3.0.0 || ^4.0.0"
+            }
+        },
         "loupe": {
             "version": "2.3.4",
             "resolved": "https://registry.npmjs.org/loupe/-/loupe-2.3.4.tgz",
@@ -17786,6 +17822,16 @@
                     "integrity": "sha512-4gB8na07fecVVkOI6Rs4e7T6NOTki5EmL7TUduTs6bu3EdnSycntVJ4re8kgZA+wx9IueI2Y11bfbgwtzuE0KQ==",
                     "dev": true
                 }
+            }
+        },
+        "react": {
+            "version": "18.2.0",
+            "resolved": "https://registry.npmjs.org/react/-/react-18.2.0.tgz",
+            "integrity": "sha512-/3IjMdb2L9QbBdWiW5e3P2/npwMBaU9mHCSCUzNln0ZCYbcfTsGbTJrU/kGemdH2IWmB2ioZ+zkxtmq6g09fGQ==",
+            "dev": true,
+            "peer": true,
+            "requires": {
+                "loose-envify": "^1.1.0"
             }
         },
         "read": {

--- a/package.json
+++ b/package.json
@@ -667,7 +667,11 @@
                 "aliases": [
                     "BrightScript"
                 ],
-                "configuration": "./language-configuration.json"
+                "configuration": "./language-configuration.json",
+                "icon": {
+                    "light": "./images/icons/brightscript.svg",
+                    "dark": "./images/icons/brightscript.svg"
+                }
             },
             {
                 "id": "brighterscript",
@@ -677,7 +681,11 @@
                 "aliases": [
                     "BrighterScript"
                 ],
-                "configuration": "./language-configuration.json"
+                "configuration": "./language-configuration.json",
+                "icon": {
+                    "light": "./images/icons/brighterscript.svg",
+                    "dark": "./images/icons/brighterscript.svg"
+                }
             },
             {
                 "id": "Log",


### PR DESCRIPTION
Adds custom file icons for .bs and .brs files. 

Note that the brightscript icon is slightly wider than most other icons. I thought it was important to show the lowercase `r` to better visualize that this was a non-brighterscript file. 

![image](https://user-images.githubusercontent.com/2544493/184369722-40f22d2c-3a95-4fd4-957f-d4d79731281d.png)
