### PR TITLE
add "bs" as "fileTypes" element

### DIFF
--- a/syntaxes/brightscript.tmLanguage.json
+++ b/syntaxes/brightscript.tmLanguage.json
@@ -2,6 +2,7 @@
     "name": "BrightScript",
     "scopeName": "source.brs",
     "fileTypes": [
+        "bs",
         "brs"
     ],
     "uuid": "3194ae45-03ed-40d0-97fa-55bf088ceabb",


### PR DESCRIPTION
ease the import of brightscript.tmLanguage.json in eclipse+tm4e