### PR TITLE
Improve multi-network-interface device discovery

### DIFF
--- a/src/ActiveDeviceManager.ts
+++ b/src/ActiveDeviceManager.ts
@@ -142,7 +142,10 @@ class RokuFinder extends EventEmitter {
     constructor() {
         super();
 
-        this.client = new Client();
+        this.client = new Client({
+            //Bind sockets to each discovered interface explicitly instead of relying on the system. Might help with issues with multiple NICs.
+            explicitSocketBind: true
+        });
 
         this.client.on('response', (headers: SsdpHeaders) => {
             if (!this.running) {


### PR DESCRIPTION
Fixes issue with the "Devices" panel that was not always finding devices whenever the developer machine has multiple active network interfaces. 