### PR TITLE
Ignore default user settings not set by user

### DIFF
--- a/src/DebugConfigurationProvider.spec.ts
+++ b/src/DebugConfigurationProvider.spec.ts
@@ -81,7 +81,7 @@ describe('BrightScriptConfigurationProvider', () => {
                 expect(s`${filePath}`).to.equal(s`/some/project/.env`);
                 return Promise.resolve(Buffer.from('ROKU_PASSWORD=pass1234'));
             });
-            sinon.stub(configProvider, 'getBrsConfig').returns({});
+            sinon.stub(configProvider, 'getBsConfig').returns({});
             let config = await configProvider.resolveDebugConfiguration(folder, <any>{
                 host: '127.0.0.1',
                 type: 'brightscript',
@@ -100,7 +100,7 @@ describe('BrightScriptConfigurationProvider', () => {
                 expect(filePath).to.equal('/some/project/.env');
                 return Promise.resolve(Buffer.from('USERNAME=bob'));
             });
-            sinon.stub(configProvider, 'getBrsConfig').returns({});
+            sinon.stub(configProvider, 'getBsConfig').returns({});
             let config = await configProvider.resolveDebugConfiguration(<any>{ uri: { fsPath: '/some/project' } }, <any>{
                 host: '127.0.0.1',
                 type: 'brightscript',
@@ -114,7 +114,7 @@ describe('BrightScriptConfigurationProvider', () => {
         it('throws on missing .env file', async () => {
             sinon.restore();
             sinon.stub(configProvider.util, 'fileExists').returns(Promise.resolve(false));
-            sinon.stub(configProvider, 'getBrsConfig').returns({});
+            sinon.stub(configProvider, 'getBsConfig').returns({});
 
             try {
                 let config = await configProvider.resolveDebugConfiguration(folder, <any>{
@@ -130,7 +130,7 @@ describe('BrightScriptConfigurationProvider', () => {
         });
 
         it('handles non ${workspaceFolder} replacements', async () => {
-            sinon.stub(configProvider, 'getBrsConfig').returns({});
+            sinon.stub(configProvider, 'getBsConfig').returns({});
             let stub = sinon.stub(configProvider.fsExtra, 'readFile').callsFake((filePath: string) => {
                 //should load env file from proper place
                 expect(filePath).to.equal('/some/project/.env');

--- a/src/LanguageServerManager.spec.ts
+++ b/src/LanguageServerManager.spec.ts
@@ -242,7 +242,8 @@ describe('extension', () => {
                     value = null;
                 }
                 return {
-                    get: x => value
+                    get: x => value,
+                    inspect: () => ({}) as any
                 };
             });
             vscode.workspace.workspaceFolders.push({

--- a/src/mockVscode.spec.ts
+++ b/src/mockVscode.spec.ts
@@ -1,4 +1,4 @@
-import type { Command, Range, TreeDataProvider, TreeItemCollapsibleState, Uri, WorkspaceFolder, ConfigurationScope, ExtensionContext } from 'vscode';
+import type { Command, Range, TreeDataProvider, TreeItemCollapsibleState, Uri, WorkspaceFolder, ConfigurationScope, ExtensionContext, WorkspaceConfiguration } from 'vscode';
 
 afterEach(() => {
     delete vscode.workspace.workspaceFile;
@@ -76,10 +76,10 @@ export let vscode = {
         globalStoragePath: '',
         globalState: {
             _data: {},
-            update: function (key: string, value: any) {
+            update: function(key: string, value: any) {
                 this._data[key] = value;
             },
-            get: function (key: string) {
+            get: function(key: string) {
                 return this._data[key];
             }
         } as any,
@@ -111,6 +111,12 @@ export let vscode = {
             return {
                 get: (name: string) => {
                     return this._configuration?.[`${configurationName}.${name}`];
+                },
+                inspect: (name: string) => {
+                    return {
+                        key: name,
+                        globalValue: this._configuration?.[`${configurationName}.${name}`]
+                    } as ReturnType<WorkspaceConfiguration['inspect']>;
                 }
             };
         },


### PR DESCRIPTION
When #438 was released, it started flooding the debug session configs with all of the default launch.json values, even if the user hadn't set any of them. This PR fixes that by only merging in the `brightscript.debug` settings that were explicitly defined by the user. 

This PR also suppresses the "Could not load bsconfig file at..." error whenever the default file could not be loaded. Now it will only be shown if the user specifically defined a `configFile` value in their settings. 