### PR TITLE
Add option to obscure the device-info

### DIFF
--- a/docs/extension-settings.md
+++ b/docs/extension-settings.md
@@ -36,8 +36,8 @@ specifies the display format for log output `pkg` link
 If set to true, an info toast will be shown when a Roku device has been found on the network.
 ### `brightscript.deviceDiscovery.enabled`
 If set to true, the extension will automatically watch and scan the network for online Roku devices. This can be pared with the `${promptForHost}` option in the launch config to display a list of online Rokus, removing the need to constantly change the host IP in your config files.
-### `brightscript.deviceDiscovery.scrambleDeviceInfo`
-If set to true, the extension will randomize the following fields (useful for hiding your sensitive device fields when creating public screenshots or demos).
+### `brightscript.deviceDiscovery.concealDeviceInfo`
+If set to true, the extension will randomize the numbers and letters in the following fields (useful for hiding your sensitive device fields when creating public screenshots or demos).
  - `udn`
  - `device-id`
  - `advertising-id`

--- a/docs/extension-settings.md
+++ b/docs/extension-settings.md
@@ -36,6 +36,16 @@ specifies the display format for log output `pkg` link
 If set to true, an info toast will be shown when a Roku device has been found on the network.
 ### `brightscript.deviceDiscovery.enabled`
 If set to true, the extension will automatically watch and scan the network for online Roku devices. This can be pared with the `${promptForHost}` option in the launch config to display a list of online Rokus, removing the need to constantly change the host IP in your config files.
+### `brightscript.deviceDiscovery.scrambleDeviceInfo`
+If set to true, the extension will randomize the following fields (useful for hiding your sensitive device fields when creating public screenshots or demos).
+ - `udn`
+ - `device-id`
+ - `advertising-id`
+ - `wifi-mac`
+ - `ethernet-mac`
+ - `serial-number`
+ - `keyed-developer-id`
+
 ### `brightscript.debug.autoRunSgDebugCommands`
 Give the ability to run a list of commands on port 8080 of the device at the start of a debug session. Currently there are three supported short hands for the most commonly desired commands. These are:
  - `chanperf` - runs chanperf with a one seconds repeating interval

--- a/package.json
+++ b/package.json
@@ -1534,10 +1534,10 @@
                         "description": "If set to true, the extension will also include devices that do not have their developer mode enabled that are found on the network.",
                         "scope": "resource"
                     },
-                    "brightscript.deviceDiscovery.scrambleDeviceInfo": {
+                    "brightscript.deviceDiscovery.concealDeviceInfo": {
                         "type": "boolean",
                         "default": false,
-                        "description": "If set to true, the extension will randomize the following fields (useful for hiding your sensitive device fields when creating public screenshots or demos). ['udn', 'device-id', 'advertising-id', 'wifi-mac', 'ethernet-mac', 'serial-number', 'keyed-developer-id']",
+                        "description": "If set to true, the extension will randomize the numbers and letters in the following fields (useful for hiding your sensitive device fields when creating public screenshots or demos). ['udn', 'device-id', 'advertising-id', 'wifi-mac', 'ethernet-mac', 'serial-number', 'keyed-developer-id']",
                         "scope": "resource"
                     }
                 }

--- a/package.json
+++ b/package.json
@@ -1533,6 +1533,12 @@
                         "default": false,
                         "description": "If set to true, the extension will also include devices that do not have their developer mode enabled that are found on the network.",
                         "scope": "resource"
+                    },
+                    "brightscript.deviceDiscovery.scrambleDeviceInfo": {
+                        "type": "boolean",
+                        "default": false,
+                        "description": "If set to true, the extension will randomize the following fields (useful for hiding your sensitive device fields when creating public screenshots or demos). ['udn', 'device-id', 'advertising-id', 'wifi-mac', 'ethernet-mac', 'serial-number', 'keyed-developer-id']",
+                        "scope": "resource"
                     }
                 }
             },

--- a/src/ActiveDeviceManager.ts
+++ b/src/ActiveDeviceManager.ts
@@ -21,10 +21,17 @@ export class ActiveDeviceManager extends EventEmitter {
         let config: any = vscode.workspace.getConfiguration('brightscript') || {};
         this.enabled = config.deviceDiscovery?.enabled;
         this.showInfoMessages = config.deviceDiscovery?.showInfoMessages;
-        vscode.workspace.onDidChangeConfiguration((e) => {
+        vscode.workspace.onDidChangeConfiguration((event) => {
             let config: any = vscode.workspace.getConfiguration('brightscript') || {};
             this.enabled = config.deviceDiscovery?.enabled;
             this.showInfoMessages = config.deviceDiscovery?.showInfoMessages;
+
+            //if the `scrambleDeviceInfo` setting was changed, refresh the list
+            if (event.affectsConfiguration('brightscript.deviceDiscovery.scrambleDeviceInfo')) {
+                //stop (which clears the list), and then the `processEnabledState` below will re-start it if enabled
+                this.stop();
+            }
+
             this.processEnabledState();
         });
 

--- a/src/ActiveDeviceManager.ts
+++ b/src/ActiveDeviceManager.ts
@@ -26,8 +26,8 @@ export class ActiveDeviceManager extends EventEmitter {
             this.enabled = config.deviceDiscovery?.enabled;
             this.showInfoMessages = config.deviceDiscovery?.showInfoMessages;
 
-            //if the `scrambleDeviceInfo` setting was changed, refresh the list
-            if (event.affectsConfiguration('brightscript.deviceDiscovery.scrambleDeviceInfo')) {
+            //if the `concealDeviceInfo` setting was changed, refresh the list
+            if (event.affectsConfiguration('brightscript.deviceDiscovery.concealDeviceInfo')) {
                 //stop (which clears the list), and then the `processEnabledState` below will re-start it if enabled
                 this.stop();
             }

--- a/src/util.spec.ts
+++ b/src/util.spec.ts
@@ -277,10 +277,10 @@ describe('Util', () => {
         });
     });
 
-    describe('scrambleObject', () => {
-        it('does not scramble anything when no secret keys are provided', () => {
+    describe('concealObject', () => {
+        it('does not conceal anything when no secret keys are provided', () => {
             expect(
-                [...util.scrambleObject({ alpha: 'a', beta: 'b' }, [])]
+                [...util.concealObject({ alpha: 'a', beta: 'b' }, [])]
             ).to.eql([
                 ['alpha', { value: 'a', originalValue: 'a' }],
                 ['beta', { value: 'b', originalValue: 'b' }]
@@ -289,7 +289,7 @@ describe('Util', () => {
 
         it('does not crash for unrecognized secret keys', () => {
             expect(
-                [...util.scrambleObject({ alpha: 'a', beta: 'b' }, [undefined, '', false as unknown as string])]
+                [...util.concealObject({ alpha: 'a', beta: 'b' }, [undefined, '', false as unknown as string])]
             ).to.eql([
                 ['alpha', { value: 'a', originalValue: 'a' }],
                 ['beta', { value: 'b', originalValue: 'b' }]
@@ -298,7 +298,7 @@ describe('Util', () => {
 
         it('does not crash for undefined secret values', () => {
             expect(
-                [...util.scrambleObject({ alpha: 'a', beta: undefined }, ['beta'])]
+                [...util.concealObject({ alpha: 'a', beta: undefined }, ['beta'])]
             ).to.eql([
                 ['alpha', { value: 'a', originalValue: 'a' }],
                 ['beta', { value: undefined, originalValue: undefined }]
@@ -307,19 +307,19 @@ describe('Util', () => {
 
         it('ignores blank and empty strings', () => {
             expect(
-                [...util.scrambleObject({ alpha: 'alpha', beta: '' }, ['beta'])]
+                [...util.concealObject({ alpha: 'alpha', beta: '' }, ['beta'])]
             ).to.eql([
                 ['alpha', { value: 'alpha', originalValue: 'alpha' }],
                 ['beta', { value: '', originalValue: '' }]
             ]);
         });
 
-        it('scrambles various value types', () => {
+        it('conceals various value types', () => {
             //prefill the cache so we always know what it'll contain for this key
-            util['scrambleCache'].set('123', 'abc');
-            util['scrambleCache'].set('456', 'def');
+            util['concealCache'].set('123', 'abc');
+            util['concealCache'].set('456', 'def');
             expect(
-                [...util.scrambleObject({ alpha: '123', beta: 'beta 123 456', charlie: '456', delta: 123 }, ['alpha', 'charlie'])]
+                [...util.concealObject({ alpha: '123', beta: 'beta 123 456', charlie: '456', delta: 123 }, ['alpha', 'charlie'])]
             ).to.eql([
                 ['alpha', { value: 'abc', originalValue: '123' }],
                 ['beta', { value: 'beta abc def', originalValue: 'beta 123 456' }],

--- a/src/util.spec.ts
+++ b/src/util.spec.ts
@@ -276,4 +276,56 @@ describe('Util', () => {
             });
         });
     });
+
+    describe('scrambleObject', () => {
+        it('does not scramble anything when no secret keys are provided', () => {
+            expect(
+                [...util.scrambleObject({ alpha: 'a', beta: 'b' }, [])]
+            ).to.eql([
+                ['alpha', { value: 'a', originalValue: 'a' }],
+                ['beta', { value: 'b', originalValue: 'b' }]
+            ]);
+        });
+
+        it('does not crash for unrecognized secret keys', () => {
+            expect(
+                [...util.scrambleObject({ alpha: 'a', beta: 'b' }, [undefined, '', false as unknown as string])]
+            ).to.eql([
+                ['alpha', { value: 'a', originalValue: 'a' }],
+                ['beta', { value: 'b', originalValue: 'b' }]
+            ]);
+        });
+
+        it('does not crash for undefined secret values', () => {
+            expect(
+                [...util.scrambleObject({ alpha: 'a', beta: undefined }, ['beta'])]
+            ).to.eql([
+                ['alpha', { value: 'a', originalValue: 'a' }],
+                ['beta', { value: undefined, originalValue: undefined }]
+            ]);
+        });
+
+        it('ignores blank and empty strings', () => {
+            expect(
+                [...util.scrambleObject({ alpha: 'alpha', beta: '' }, ['beta'])]
+            ).to.eql([
+                ['alpha', { value: 'alpha', originalValue: 'alpha' }],
+                ['beta', { value: '', originalValue: '' }]
+            ]);
+        });
+
+        it('scrambles various value types', () => {
+            //prefill the cache so we always know what it'll contain for this key
+            util['scrambleCache'].set('123', 'abc');
+            util['scrambleCache'].set('456', 'def');
+            expect(
+                [...util.scrambleObject({ alpha: '123', beta: 'beta 123 456', charlie: '456', delta: 123 }, ['alpha', 'charlie'])]
+            ).to.eql([
+                ['alpha', { value: 'abc', originalValue: '123' }],
+                ['beta', { value: 'beta abc def', originalValue: 'beta 123 456' }],
+                ['charlie', { value: 'def', originalValue: '456' }],
+                ['delta', { value: 123, originalValue: 123 }]
+            ]);
+        });
+    });
 });

--- a/src/util.ts
+++ b/src/util.ts
@@ -4,6 +4,7 @@ import * as net from 'net';
 import * as url from 'url';
 import { debounce } from 'debounce';
 import * as vscode from 'vscode';
+import { Cache } from 'brighterscript/dist/Cache';
 
 class Util {
     public async readDir(dirPath: string) {
@@ -300,6 +301,89 @@ class Util {
             new vscode.Position(range.start.line, range.start.character),
             new vscode.Position(range.end.line, range.end.character)
         );
+    }
+
+    /**
+     * Is the value null or undefined
+     */
+    public isNullish(value?: any) {
+        return value === undefined || value === null;
+    }
+
+    /**
+      * Scrambles any of the specified keys across all string properties in the object
+      */
+    public scrambleObject(object: Record<string, any>, secretKeys: string[]) {
+        const result = new Map<string, { value: string; originalValue: string }>();
+        const secretValues = Object.entries(object)
+            //only keep the non-blank string keys
+            .filter(([key, value]) => secretKeys.includes(key) && typeof value === 'string' && value?.toString() !== '')
+            .map(([, value]) => value) as string[];
+
+        //build the initial result
+        for (const [key, value] of Object.entries(object)) {
+            result.set(key, {
+                value: value,
+                originalValue: value
+            });
+        }
+
+        //do value transforms
+        for (let [key, entry] of result) {
+            let { value } = entry;
+            for (const secretValue of secretValues) {
+                if (typeof value === 'string') {
+                    const regexp = new RegExp(
+                        //escape the regex, or use an unmatchable regex if unable to escape it
+                        util.escapeRegex(secretValue) ?? /(?!)/,
+                        'g'
+                    );
+                    entry.value = entry.value.replace(regexp, this.scrambleString(secretValue));
+                }
+            }
+        }
+
+        return result;
+    }
+
+    private scrambleCache = new Cache<string, string>();
+
+    /**
+     * Given a string, replace the alphanumeric characters with random values.
+     * This is useful for things like scrambling a uuid
+     */
+    public scrambleString(text: string) {
+        return this.scrambleCache.getOrAdd(text, () => {
+            if (this.isNullish(text)) {
+                return text;
+            } else {
+                return text.replace(/[a-z0-9]/ig, (match) => {
+                    // is a number
+                    if (parseInt(match)) {
+                        return this.getRandomChar('0123456789');
+
+                        //is an uppercase letter
+                    } else if (match.toUpperCase() === match) {
+                        return this.getRandomChar('ABCDEFGHIJKLMNOPQRSTUVWXYZ');
+
+                        //is a lower case number
+                    } else {
+                        return this.getRandomChar('abcdefghijklmnopqrstuvwxyz');
+                    }
+                });
+            }
+        });
+    }
+
+    private getRandomChar(dictionary: string) {
+        return dictionary.charAt(Math.floor(Math.random() * dictionary.length));
+    }
+
+    /**
+     * Escapes a string so that it can be used as a regex pattern
+     */
+    public escapeRegex(text: string) {
+        return text?.toString().replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
     }
 }
 

--- a/src/util.ts
+++ b/src/util.ts
@@ -311,9 +311,9 @@ class Util {
     }
 
     /**
-      * Scrambles any of the specified keys across all string properties in the object
+      * Conceals (scrambles/obfuscates) any of the specified keys across all string properties in the object
       */
-    public scrambleObject(object: Record<string, any>, secretKeys: string[]) {
+    public concealObject(object: Record<string, any>, secretKeys: string[]) {
         const result = new Map<string, { value: string; originalValue: string }>();
         const secretValues = Object.entries(object)
             //only keep the non-blank string keys
@@ -338,7 +338,7 @@ class Util {
                         util.escapeRegex(secretValue) ?? /(?!)/,
                         'g'
                     );
-                    entry.value = entry.value.replace(regexp, this.scrambleString(secretValue));
+                    entry.value = entry.value.replace(regexp, this.concealString(secretValue));
                 }
             }
         }
@@ -346,14 +346,14 @@ class Util {
         return result;
     }
 
-    private scrambleCache = new Cache<string, string>();
+    private concealCache = new Cache<string, string>();
 
     /**
      * Given a string, replace the alphanumeric characters with random values.
      * This is useful for things like scrambling a uuid
      */
-    public scrambleString(text: string) {
-        return this.scrambleCache.getOrAdd(text, () => {
+    public concealString(text: string) {
+        return this.concealCache.getOrAdd(text, () => {
             if (this.isNullish(text)) {
                 return text;
             } else {

--- a/src/viewProviders/OnlineDevicesViewProvider.ts
+++ b/src/viewProviders/OnlineDevicesViewProvider.ts
@@ -36,10 +36,10 @@ export class OnlineDevicesViewProvider implements vscode.TreeDataProvider<vscode
     }
 
     /**
-     * Should the unique info about a device be scrambled (i.e. randomly modified to protect the data)?
+     * Should the unique info about a device be obfuscated (i.e. randomly modified to protect the data)?
      */
-    private get enableDeviceInfoScrambling() {
-        return vscode.workspace.getConfiguration('brightscript.deviceDiscovery').get('scrambleDeviceInfo') === true;
+    private get isConcealDeviceInfoEnabled() {
+        return vscode.workspace.getConfiguration('brightscript.deviceDiscovery').get('concealDeviceInfo') === true;
     }
 
     private devices: Array<RokuDeviceDetails>;
@@ -78,7 +78,7 @@ export class OnlineDevicesViewProvider implements vscode.TreeDataProvider<vscode
                 for (const device of devices) {
                     // Make a rook item for each device
                     let treeItem = new DeviceTreeItem(
-                        device.deviceInfo['user-device-name'] + ' - ' + this.scrambleString(device.deviceInfo['serial-number']),
+                        device.deviceInfo['user-device-name'] + ' - ' + this.concealString(device.deviceInfo['serial-number']),
                         vscode.TreeItemCollapsibleState.Collapsed,
                         device.id,
                         device.deviceInfo
@@ -105,8 +105,8 @@ export class OnlineDevicesViewProvider implements vscode.TreeDataProvider<vscode
             // Process the details of a device
             let result: Array<DeviceInfoTreeItem> = [];
 
-            //scramble all of these unique keys
-            const details = this.scrambleObject(element.details, ['udn', 'device-id', 'advertising-id', 'wifi-mac', 'ethernet-mac', 'serial-number', 'keyed-developer-id']);
+            //conceal all of these unique keys
+            const details = this.concealObject(element.details, ['udn', 'device-id', 'advertising-id', 'wifi-mac', 'ethernet-mac', 'serial-number', 'keyed-developer-id']);
 
             for (let [key, values] of details) {
 
@@ -116,7 +116,7 @@ export class OnlineDevicesViewProvider implements vscode.TreeDataProvider<vscode
                     element,
                     vscode.TreeItemCollapsibleState.None,
                     key,
-                    //if this is one of the properties that need scrambled
+                    //if this is one of the properties that need concealed
                     values.value?.toString()
                 );
 
@@ -212,10 +212,10 @@ export class OnlineDevicesViewProvider implements vscode.TreeDataProvider<vscode
         return this.devices.find(device => device.id === deviceId);
     }
 
-    private scrambleObject(object: Record<string, any>, secretKeys: string[]) {
-        return util.scrambleObject(
+    private concealObject(object: Record<string, any>, secretKeys: string[]) {
+        return util.concealObject(
             object,
-            this.enableDeviceInfoScrambling ? secretKeys : []
+            this.isConcealDeviceInfoEnabled ? secretKeys : []
         );
     }
 
@@ -224,9 +224,9 @@ export class OnlineDevicesViewProvider implements vscode.TreeDataProvider<vscode
      * Given a string, return a new string with random numbers and letters of the same size.
      * Returns the same value for every input for the lifetime of the current extension uptime
      */
-    private scrambleString(value: string) {
-        if (this.enableDeviceInfoScrambling) {
-            return util.scrambleString(value);
+    private concealString(value: string) {
+        if (this.isConcealDeviceInfoEnabled) {
+            return util.concealString(value);
         } else {
             return value;
         }

--- a/src/viewProviders/OnlineDevicesViewProvider.ts
+++ b/src/viewProviders/OnlineDevicesViewProvider.ts
@@ -3,6 +3,8 @@ import * as semver from 'semver';
 import type { ActiveDeviceManager, RokuDeviceDetails } from '../ActiveDeviceManager';
 import { icons } from '../icons';
 import { firstBy } from 'thenby';
+import { Cache } from 'brighterscript/dist/Cache';
+import { util } from '../util';
 
 export class OnlineDevicesViewProvider implements vscode.TreeDataProvider<vscode.TreeItem> {
 
@@ -33,6 +35,12 @@ export class OnlineDevicesViewProvider implements vscode.TreeDataProvider<vscode
         });
     }
 
+    /**
+     * Should the unique info about a device be scrambled (i.e. randomly modified to protect the data)?
+     */
+    private get enableDeviceInfoScrambling() {
+        return vscode.workspace.getConfiguration('brightscript.deviceDiscovery').get('scrambleDeviceInfo') === true;
+    }
 
     private devices: Array<RokuDeviceDetails>;
 
@@ -49,8 +57,8 @@ export class OnlineDevicesViewProvider implements vscode.TreeDataProvider<vscode
     getChildren(element?: DeviceTreeItem | DeviceInfoTreeItem): vscode.ProviderResult<DeviceTreeItem[] | DeviceInfoTreeItem[]> {
         if (!element) {
             if (this.devices) {
-                // Process the root level devices in order by id
 
+                // Process the root level devices in order by id
 
                 let devices = this.devices.sort(
                     firstBy((a: RokuDeviceDetails, b: RokuDeviceDetails) => {
@@ -70,7 +78,7 @@ export class OnlineDevicesViewProvider implements vscode.TreeDataProvider<vscode
                 for (const device of devices) {
                     // Make a rook item for each device
                     let treeItem = new DeviceTreeItem(
-                        device.deviceInfo['user-device-name'] + ' - ' + device.deviceInfo['serial-number'],
+                        device.deviceInfo['user-device-name'] + ' - ' + this.scrambleString(device.deviceInfo['serial-number']),
                         vscode.TreeItemCollapsibleState.Collapsed,
                         device.id,
                         device.deviceInfo
@@ -97,14 +105,19 @@ export class OnlineDevicesViewProvider implements vscode.TreeDataProvider<vscode
             // Process the details of a device
             let result: Array<DeviceInfoTreeItem> = [];
 
-            for (let property in element.details) {
+            //scramble all of these unique keys
+            const details = this.scrambleObject(element.details, ['udn', 'device-id', 'advertising-id', 'wifi-mac', 'ethernet-mac', 'serial-number', 'keyed-developer-id']);
+
+            for (let [key, values] of details) {
+
                 // Create a tree item for every detail property on the device
                 let treeItem = new DeviceInfoTreeItem(
-                    property,
+                    key,
                     element,
                     vscode.TreeItemCollapsibleState.None,
-                    property,
-                    element.details[property].toString()
+                    key,
+                    //if this is one of the properties that need scrambled
+                    values.value?.toString()
                 );
 
                 // Prepare the copy to clipboard command
@@ -112,7 +125,7 @@ export class OnlineDevicesViewProvider implements vscode.TreeDataProvider<vscode
                 treeItem.command = {
                     command: 'extension.brightscript.copyToClipboard',
                     title: 'Copy To Clipboard',
-                    arguments: [element.details[property].toString()]
+                    arguments: [values.originalValue]
                 };
                 result.push(treeItem);
             }
@@ -157,7 +170,7 @@ export class OnlineDevicesViewProvider implements vscode.TreeDataProvider<vscode
             result.unshift(openWebpageItem);
 
             if (semver.satisfies(element.details['software-version'], '>=11')) {
-                // TODO: add ECP system hooks here in the future
+                // TODO: add ECP system hooks here in the future (like registry call, etc...)
             }
 
             // Return the device details
@@ -197,6 +210,26 @@ export class OnlineDevicesViewProvider implements vscode.TreeDataProvider<vscode
 
     private findDeviceById(deviceId: string): RokuDeviceDetails {
         return this.devices.find(device => device.id === deviceId);
+    }
+
+    private scrambleObject(object: Record<string, any>, secretKeys: string[]) {
+        return util.scrambleObject(
+            object,
+            this.enableDeviceInfoScrambling ? secretKeys : []
+        );
+    }
+
+
+    /**
+     * Given a string, return a new string with random numbers and letters of the same size.
+     * Returns the same value for every input for the lifetime of the current extension uptime
+     */
+    private scrambleString(value: string) {
+        if (this.enableDeviceInfoScrambling) {
+            return util.scrambleString(value);
+        } else {
+            return value;
+        }
     }
 }
 


### PR DESCRIPTION
Adds an option to obfuscate (scramble/obscure) the device-info for items in the device panel. 

The option is named `brightscript.deviceDiscovery.concealDeviceInfo`.


Here are the fields that get redacted.

![image](https://user-images.githubusercontent.com/2544493/198591816-e3cbafa8-d287-4a7e-8560-15746c29922a.png)
