### PR TITLE
Allow clearRendezvous cmd outside a debug session

### DIFF
--- a/package.json
+++ b/package.json
@@ -241,7 +241,7 @@
                 {
                     "command": "extension.brightscript.rendezvous.clearHistory",
                     "when": "debugType == 'brightscript' && view == rendezvousView",
-                    "group": "Rendezvous"
+                    "group": "navigation"
                 },
                 {
                     "command": "extension.brightscript.refreshDeviceList",
@@ -2290,7 +2290,7 @@
                 "command": "extension.brightscript.rendezvous.clearHistory",
                 "title": "Clear History",
                 "category": "Brightscript Rendezvous",
-                "enablement": "debugType == 'brightscript'"
+                "icon": "$(clear-all)"
             },
             {
                 "command": "brighterscript.showPreview",
@@ -2309,19 +2309,19 @@
             {
                 "command": "extension.brightscript.refreshDeviceList",
                 "title": "Refresh",
-                "category": "BrighterScript",
+                "category": "BrightScript",
                 "icon": "$(refresh)"
             },
             {
                 "command": "extension.brightscript.languageServer.restart",
                 "title": "Restart Language Server",
-                "category": "BrightScript",
+                "category": "BrighterScript",
                 "icon": "$(refresh)"
             },
             {
                 "command": "extension.brightscript.languageServer.info",
                 "title": "View BrighterScript LanguageServer Info",
-                "category": "BrightScript"
+                "category": "BrighterScript"
             }
         ],
         "keybindings": [

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -113,7 +113,12 @@ export class Extension {
         vscode.window.registerTreeDataProvider('onlineDevicesView', onlineDevicesViewProvider);
 
         context.subscriptions.push(vscode.commands.registerCommand('extension.brightscript.rendezvous.clearHistory', async () => {
-            await vscode.debug.activeDebugSession.customRequest('rendezvous.clearHistory');
+            try {
+                await vscode.debug.activeDebugSession.customRequest('rendezvous.clearHistory');
+            } catch { }
+
+            //also clear the local rendezvous list
+            rendezvousViewProvider.clear();
         }));
 
         context.subscriptions.push(vscode.commands.registerCommand('extension.brightscript.languageServer.restart', async () => {

--- a/src/viewProviders/RendezvousViewProvider.ts
+++ b/src/viewProviders/RendezvousViewProvider.ts
@@ -55,6 +55,15 @@ export class RendezvousViewProvider implements vscode.TreeDataProvider<vscode.Tr
     }
 
     /**
+     * Clears the local copy of the rendezvous data. The debug session sends all data, so this call won't clear that. if you need to clear that,
+     * call the `rendezvous.clearHistory` command
+     */
+    public clear() {
+        this.rendezvousHistory = undefined;
+        this._onDidChangeTreeData.fire(null);
+    }
+
+    /**
      * Handles the custom events
      */
     public onDidReceiveDebugSessionCustomEvent(e: any) {


### PR DESCRIPTION
Allow the rendezvous panel to be cleared even when there's no active debug session. 

Also moved the "clear" button out to an icon on the bar instead of hiding it inside the menu.

Current:
![image](https://user-images.githubusercontent.com/2544493/198620544-6c62e8d8-ddc7-4c0d-8c65-cc5e3fc2359f.png)

Proposed:

![image](https://user-images.githubusercontent.com/2544493/198617708-82d55889-ee9d-47c7-b9d9-ac9faa63ba6e.png)
