### PR TITLE
Make vsix smaller by excluding unneeded files

### DIFF
--- a/.vscodeignore
+++ b/.vscodeignore
@@ -5,6 +5,9 @@
 coverage/**/*
 scripts/**
 src/**
+webviews/**
+docs/**
+.tmp/**
 **/*.map
 **/*.spec.js
 developer-guidelines.md


### PR DESCRIPTION
#450 introduced a significant vsix size increase. This PR fixes that by excluding the webviews source folder since it's not needed in the production build. 