### PR TITLE
fix: continue keyword colorization

### DIFF
--- a/src/grammar/brightscript.tmLanguage.spec.ts
+++ b/src/grammar/brightscript.tmLanguage.spec.ts
@@ -6,6 +6,26 @@ import { standardizePath as s } from 'brighterscript';
 const brightscriptTmlanguagePath = s`${__dirname}/../../syntaxes/brightscript.tmLanguage.json`;
 
 describe('brightscript.tmlanguage.json', () => {
+    it('colors `continue for`', async () => {
+        await testGrammar(`
+            for i = 0 to 10
+                continue for
+                        '^^^ keyword.control.loop.brs
+               '^^^^^^^^ keyword.control.loop.brs
+            end for
+        `);
+    });
+
+    it('colors `continue while`', async () => {
+        await testGrammar(`
+            while true
+                continue while
+                        '^^^^^ keyword.control.loop.brs
+               '^^^^^^^^ keyword.control.loop.brs
+            end for
+        `);
+    });
+
     it('colors strings correctly', async () => {
         await testGrammar(`
             print "hello world", true

--- a/syntaxes/brightscript.tmLanguage.json
+++ b/syntaxes/brightscript.tmLanguage.json
@@ -110,6 +110,9 @@
                     "include": "#storage_types"
                 },
                 {
+                    "include": "#loop_keywords"
+                },
+                {
                     "include": "#program_statements"
                 },
                 {
@@ -133,213 +136,213 @@
             ]
         },
         "regex": {
-			"patterns": [
-				{
-					"name": "string.regexp.brs",
-					"begin": "(?<!\\+\\+|--|})(?<=[=(:,\\[?+!]|^return|[^\\._$[:alnum:]]return|^case|[^\\._$[:alnum:]]case|=>|&&|\\|\\||\\*\\/)\\s*(\\/)(?![\\/*])(?=(?:[^\\/\\\\\\[\\()]|\\\\.|\\[([^\\]\\\\]|\\\\.)+\\]|\\(([^\\)\\\\]|\\\\.)+\\))+\\/([gmixsuXUAJ]+|(?![\\/\\*])|(?=\\/\\*))(?!\\s*[a-zA-Z0-9_$]))",
-					"beginCaptures": {
-						"1": {
-							"name": "punctuation.definition.string.begin.brs"
-						}
-					},
-					"end": "(/)([gmixsuXUAJ]*)",
-					"endCaptures": {
-						"1": {
-							"name": "punctuation.definition.string.end.brs"
-						},
-						"2": {
-							"name": "keyword.other.brs"
-						}
-					},
-					"patterns": [
-						{
-							"include": "#regexp"
-						}
-					]
-				},
-				{
-					"name": "string.regexp.brs",
-					"begin": "((?<![_$[:alnum:])\\]]|\\+\\+|--|}|\\*\\/)|((?<=^return|[^\\._$[:alnum:]]return|^case|[^\\._$[:alnum:]]case))\\s*)\\/(?![\\/*])(?=(?:[^\\/\\\\\\[]|\\\\.|\\[([^\\]\\\\]|\\\\.)*\\])+\\/([gmixsuXUAJ]+|(?![\\/\\*])|(?=\\/\\*))(?!\\s*[a-zA-Z0-9_$]))",
-					"beginCaptures": {
-						"0": {
-							"name": "punctuation.definition.string.begin.brs"
-						}
-					},
-					"end": "(/)([gmixsuXUAJ]*)",
-					"endCaptures": {
-						"1": {
-							"name": "punctuation.definition.string.end.brs"
-						},
-						"2": {
-							"name": "keyword.other.brs"
-						}
-					},
-					"patterns": [
-						{
-							"include": "#regexp"
-						}
-					]
-				}
-			]
-		},
-		"regexp": {
-			"patterns": [
-				{
-					"name": "keyword.control.anchor.regexp",
-					"match": "\\\\[bB]|\\^|\\$"
-				},
-				{
-					"match": "\\\\[1-9]\\d*|\\\\k<([a-zA-Z_$][\\w$]*)>",
-					"captures": {
-						"0": {
-							"name": "keyword.other.back-reference.regexp"
-						},
-						"1": {
-							"name": "variable.other.regexp"
-						}
-					}
-				},
-				{
-					"name": "keyword.operator.quantifier.regexp",
-					"match": "[?+*]|\\{(\\d+,\\d+|\\d+,|,\\d+|\\d+)\\}\\??"
-				},
-				{
-					"name": "keyword.operator.or.regexp",
-					"match": "\\|"
-				},
-				{
-					"name": "meta.group.assertion.regexp",
-					"begin": "(\\()((\\?=)|(\\?!)|(\\?\\|)|(\\?<=)|(\\?<!))",
-					"beginCaptures": {
-						"1": {
-							"name": "punctuation.definition.group.regexp"
-						},
-						"2": {
-							"name": "punctuation.definition.group.assertion.regexp"
-						},
-						"3": {
-							"name": "meta.assertion.look-ahead.regexp"
-						},
-						"4": {
-							"name": "meta.assertion.negative-look-ahead.regexp"
-						},
-						"5": {
-							"name": "meta.assertion.look-behind.regexp"
-						},
-						"6": {
-							"name": "meta.assertion.negative-look-behind.regexp"
-						}
-					},
-					"end": "(\\))",
-					"endCaptures": {
-						"1": {
-							"name": "punctuation.definition.group.regexp"
-						}
-					},
-					"patterns": [
-						{
-							"include": "#regexp"
-						}
-					]
-				},
-				{
-					"name": "meta.group.regexp",
-					"begin": "\\((?:(\\?[:>])|(?:\\?<([a-zA-Z_$][\\w$]*)>))?",
-					"beginCaptures": {
-						"0": {
-							"name": "punctuation.definition.group.regexp"
-						},
-						"1": {
-							"name": "punctuation.definition.group.no-capture.regexp"
-						},
-						"2": {
-							"name": "variable.other.regexp"
-						}
-					},
-					"end": "\\)",
-					"endCaptures": {
-						"0": {
-							"name": "punctuation.definition.group.regexp"
-						}
-					},
-					"patterns": [
-						{
-							"include": "#regexp"
-						}
-					]
-				},
-				{
-					"name": "constant.other.character-class.set.regexp",
-					"begin": "(\\[)(\\^)?",
-					"beginCaptures": {
-						"1": {
-							"name": "punctuation.definition.character-class.regexp"
-						},
-						"2": {
-							"name": "keyword.operator.negation.regexp"
-						}
-					},
-					"end": "(\\])",
-					"endCaptures": {
-						"1": {
-							"name": "punctuation.definition.character-class.regexp"
-						}
-					},
-					"patterns": [
-						{
-							"name": "constant.other.character-class.range.regexp",
-							"match": "(?:.|(\\\\(?:[0-7]{3}|x[0-9A-Fa-f]{2}|u[0-9A-Fa-f]{4}))|(\\\\c[A-Z])|(\\\\.))\\-(?:[^\\]\\\\]|(\\\\(?:[0-7]{3}|x[0-9A-Fa-f]{2}|u[0-9A-Fa-f]{4}))|(\\\\c[A-Z])|(\\\\.))",
-							"captures": {
-								"1": {
-									"name": "constant.character.numeric.regexp"
-								},
-								"2": {
-									"name": "constant.character.control.regexp"
-								},
-								"3": {
-									"name": "constant.character.escape.backslash.regexp"
-								},
-								"4": {
-									"name": "constant.character.numeric.regexp"
-								},
-								"5": {
-									"name": "constant.character.control.regexp"
-								},
-								"6": {
-									"name": "constant.character.escape.backslash.regexp"
-								}
-							}
-						},
-						{
-							"include": "#regex-character-class"
-						}
-					]
-				},
-				{
-					"include": "#regex-character-class"
-				}
-			]
-		},
-		"regex-character-class": {
-			"patterns": [
-				{
-					"name": "constant.other.character-class.regexp",
-					"match": "\\\\[wWsSdDtrnvf]|\\."
-				},
-				{
-					"name": "constant.character.numeric.regexp",
-					"match": "\\\\([0-7]{3}|x[0-9A-Fa-f]{2}|u[0-9A-Fa-f]{4})"
-				},
-				{
-					"name": "constant.character.control.regexp",
-					"match": "\\\\c[A-Z]"
-				},
-				{
-					"name": "constant.character.escape.backslash.regexp",
-					"match": "\\\\."
-				}
-			]
-		},
+            "patterns": [
+                {
+                    "name": "string.regexp.brs",
+                    "begin": "(?<!\\+\\+|--|})(?<=[=(:,\\[?+!]|^return|[^\\._$[:alnum:]]return|^case|[^\\._$[:alnum:]]case|=>|&&|\\|\\||\\*\\/)\\s*(\\/)(?![\\/*])(?=(?:[^\\/\\\\\\[\\()]|\\\\.|\\[([^\\]\\\\]|\\\\.)+\\]|\\(([^\\)\\\\]|\\\\.)+\\))+\\/([gmixsuXUAJ]+|(?![\\/\\*])|(?=\\/\\*))(?!\\s*[a-zA-Z0-9_$]))",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "punctuation.definition.string.begin.brs"
+                        }
+                    },
+                    "end": "(/)([gmixsuXUAJ]*)",
+                    "endCaptures": {
+                        "1": {
+                            "name": "punctuation.definition.string.end.brs"
+                        },
+                        "2": {
+                            "name": "keyword.other.brs"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "include": "#regexp"
+                        }
+                    ]
+                },
+                {
+                    "name": "string.regexp.brs",
+                    "begin": "((?<![_$[:alnum:])\\]]|\\+\\+|--|}|\\*\\/)|((?<=^return|[^\\._$[:alnum:]]return|^case|[^\\._$[:alnum:]]case))\\s*)\\/(?![\\/*])(?=(?:[^\\/\\\\\\[]|\\\\.|\\[([^\\]\\\\]|\\\\.)*\\])+\\/([gmixsuXUAJ]+|(?![\\/\\*])|(?=\\/\\*))(?!\\s*[a-zA-Z0-9_$]))",
+                    "beginCaptures": {
+                        "0": {
+                            "name": "punctuation.definition.string.begin.brs"
+                        }
+                    },
+                    "end": "(/)([gmixsuXUAJ]*)",
+                    "endCaptures": {
+                        "1": {
+                            "name": "punctuation.definition.string.end.brs"
+                        },
+                        "2": {
+                            "name": "keyword.other.brs"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "include": "#regexp"
+                        }
+                    ]
+                }
+            ]
+        },
+        "regexp": {
+            "patterns": [
+                {
+                    "name": "keyword.control.anchor.regexp",
+                    "match": "\\\\[bB]|\\^|\\$"
+                },
+                {
+                    "match": "\\\\[1-9]\\d*|\\\\k<([a-zA-Z_$][\\w$]*)>",
+                    "captures": {
+                        "0": {
+                            "name": "keyword.other.back-reference.regexp"
+                        },
+                        "1": {
+                            "name": "variable.other.regexp"
+                        }
+                    }
+                },
+                {
+                    "name": "keyword.operator.quantifier.regexp",
+                    "match": "[?+*]|\\{(\\d+,\\d+|\\d+,|,\\d+|\\d+)\\}\\??"
+                },
+                {
+                    "name": "keyword.operator.or.regexp",
+                    "match": "\\|"
+                },
+                {
+                    "name": "meta.group.assertion.regexp",
+                    "begin": "(\\()((\\?=)|(\\?!)|(\\?\\|)|(\\?<=)|(\\?<!))",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "punctuation.definition.group.regexp"
+                        },
+                        "2": {
+                            "name": "punctuation.definition.group.assertion.regexp"
+                        },
+                        "3": {
+                            "name": "meta.assertion.look-ahead.regexp"
+                        },
+                        "4": {
+                            "name": "meta.assertion.negative-look-ahead.regexp"
+                        },
+                        "5": {
+                            "name": "meta.assertion.look-behind.regexp"
+                        },
+                        "6": {
+                            "name": "meta.assertion.negative-look-behind.regexp"
+                        }
+                    },
+                    "end": "(\\))",
+                    "endCaptures": {
+                        "1": {
+                            "name": "punctuation.definition.group.regexp"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "include": "#regexp"
+                        }
+                    ]
+                },
+                {
+                    "name": "meta.group.regexp",
+                    "begin": "\\((?:(\\?[:>])|(?:\\?<([a-zA-Z_$][\\w$]*)>))?",
+                    "beginCaptures": {
+                        "0": {
+                            "name": "punctuation.definition.group.regexp"
+                        },
+                        "1": {
+                            "name": "punctuation.definition.group.no-capture.regexp"
+                        },
+                        "2": {
+                            "name": "variable.other.regexp"
+                        }
+                    },
+                    "end": "\\)",
+                    "endCaptures": {
+                        "0": {
+                            "name": "punctuation.definition.group.regexp"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "include": "#regexp"
+                        }
+                    ]
+                },
+                {
+                    "name": "constant.other.character-class.set.regexp",
+                    "begin": "(\\[)(\\^)?",
+                    "beginCaptures": {
+                        "1": {
+                            "name": "punctuation.definition.character-class.regexp"
+                        },
+                        "2": {
+                            "name": "keyword.operator.negation.regexp"
+                        }
+                    },
+                    "end": "(\\])",
+                    "endCaptures": {
+                        "1": {
+                            "name": "punctuation.definition.character-class.regexp"
+                        }
+                    },
+                    "patterns": [
+                        {
+                            "name": "constant.other.character-class.range.regexp",
+                            "match": "(?:.|(\\\\(?:[0-7]{3}|x[0-9A-Fa-f]{2}|u[0-9A-Fa-f]{4}))|(\\\\c[A-Z])|(\\\\.))\\-(?:[^\\]\\\\]|(\\\\(?:[0-7]{3}|x[0-9A-Fa-f]{2}|u[0-9A-Fa-f]{4}))|(\\\\c[A-Z])|(\\\\.))",
+                            "captures": {
+                                "1": {
+                                    "name": "constant.character.numeric.regexp"
+                                },
+                                "2": {
+                                    "name": "constant.character.control.regexp"
+                                },
+                                "3": {
+                                    "name": "constant.character.escape.backslash.regexp"
+                                },
+                                "4": {
+                                    "name": "constant.character.numeric.regexp"
+                                },
+                                "5": {
+                                    "name": "constant.character.control.regexp"
+                                },
+                                "6": {
+                                    "name": "constant.character.escape.backslash.regexp"
+                                }
+                            }
+                        },
+                        {
+                            "include": "#regex-character-class"
+                        }
+                    ]
+                },
+                {
+                    "include": "#regex-character-class"
+                }
+            ]
+        },
+        "regex-character-class": {
+            "patterns": [
+                {
+                    "name": "constant.other.character-class.regexp",
+                    "match": "\\\\[wWsSdDtrnvf]|\\."
+                },
+                {
+                    "name": "constant.character.numeric.regexp",
+                    "match": "\\\\([0-7]{3}|x[0-9A-Fa-f]{2}|u[0-9A-Fa-f]{4})"
+                },
+                {
+                    "name": "constant.character.control.regexp",
+                    "match": "\\\\c[A-Z]"
+                },
+                {
+                    "name": "constant.character.escape.backslash.regexp",
+                    "match": "\\\\."
+                }
+            ]
+        },
         "template_string": {
             "begin": "(`)",
             "beginCaptures": {
@@ -822,6 +825,10 @@
                 }
             },
             "match": "(?i:[^\\.\\w\\\"](then|stop|run|end|each|next|throw)(?!(\\s*:)|[\\d\\w_]))"
+        },
+        "loop_keywords": {
+            "match": "(?i:(?<!\\.)(continue\\s+(for|while)\\b))",
+            "name": "keyword.control.loop.brs"
         },
         "program_statements": {
             "match": "(?i:(?<!\\.)(if|else\\s*if|else|print|library|while|for\\s+each|for|end\\s*for|exit\\s+for|end\\s*while|exit\\s*while|end\\s*if|to|step|in|goto|rem|as)\\b)",


### PR DESCRIPTION
Fix syntax highlighting for `continue for` and `continue while`. 

**Before:**
![image](https://user-images.githubusercontent.com/2544493/213289463-b614a8cf-e84d-4cbe-b144-295bbbc63b93.png)

**After:**
![image](https://user-images.githubusercontent.com/2544493/213289592-a593fe99-51ab-4d32-82f4-df6770912a93.png)
