### PR TITLE
Added validation for raleTrackerTaskFileLocation setting existence.

### DIFF
--- a/src/DebugConfigurationProvider.ts
+++ b/src/DebugConfigurationProvider.ts
@@ -241,6 +241,9 @@ export class BrightScriptDebugConfigurationProvider implements DebugConfiguratio
 
         // Check for the existence of the tracker task file in auto injection is enabled
         if (config.injectRaleTrackerTask) {
+            if (!config.raleTrackerTaskFileLocation) {
+                await vscode.window.showErrorMessage(`injectRaleTrackerTask was set to true but config raleTrackerTaskFileLocation not set`);
+            }
             if (config.raleTrackerTaskFileLocation.includes('${workspaceFolder}')) {
                 config.raleTrackerTaskFileLocation = path.normalize(config.raleTrackerTaskFileLocation.replace('${workspaceFolder}', folderUri.fsPath));
             }

--- a/src/DebugConfigurationProvider.ts
+++ b/src/DebugConfigurationProvider.ts
@@ -242,7 +242,7 @@ export class BrightScriptDebugConfigurationProvider implements DebugConfiguratio
         // Check for the existence of the tracker task file in auto injection is enabled
         if (config.injectRaleTrackerTask) {
             if (!config.raleTrackerTaskFileLocation) {
-                await vscode.window.showErrorMessage(`injectRaleTrackerTask was set to true but config raleTrackerTaskFileLocation not set`);
+                await vscode.window.showErrorMessage(`"raleTrackerTaskFileLocation" must be defined when "injectRaleTrackerTask" is enabled`);
             }
             if (config.raleTrackerTaskFileLocation.includes('${workspaceFolder}')) {
                 config.raleTrackerTaskFileLocation = path.normalize(config.raleTrackerTaskFileLocation.replace('${workspaceFolder}', folderUri.fsPath));


### PR DESCRIPTION
Ran into this issue on a new install of an existing project.
injectRale was set, setting was non-existent and error VS Code gave was...less than helpful.