### PR TITLE
Wrap the dnsLookup for host in a try/catch

### DIFF
--- a/src/BrightScriptCommands.ts
+++ b/src/BrightScriptCommands.ts
@@ -347,7 +347,12 @@ export class BrightScriptCommands {
             await this.context.workspaceState.update('remoteHost', this.host);
         }
         if (this.host) {
-            this.host = await rokuDebugUtil.dnsLookup(this.host);
+            //try resolving the hostname. (sometimes it fails for no reason, so just ignore the crash if it does)
+            try {
+                this.host = await rokuDebugUtil.dnsLookup(this.host);
+            } catch (e) {
+                console.error('Error doing dns lookup for host ', this.host, e);
+            }
         }
     }
 


### PR DESCRIPTION
Wrap the dnsLookup in the BrightScriptCommands file in a try/catch, so even if the dns lookup fails, it will still at least _try_ to use what we have.