### PR TITLE
Fix crash during launch due to missing rale option

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -73,7 +73,7 @@
                 "rimraf": "^3.0.0",
                 "sinon": "^7.2.3",
                 "source-map-support": "^0.5.21",
-                "statigen": "^0.4.4",
+                "statigen": "^0.5.0",
                 "terminal-overwrite": "^2.0.1",
                 "ts-node": "^10.7.0",
                 "tslib": "^2.3.1",
@@ -981,6 +981,41 @@
                 "url": "https://opencollective.com/parcel"
             }
         },
+        "node_modules/@pnpm/config.env-replace": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@pnpm/config.env-replace/-/config.env-replace-1.0.0.tgz",
+            "integrity": "sha512-ZVPVDi1E8oeXlYqkGRtX0CkzLTwE2zt62bjWaWKaAvI8NZqHzlMvGeSNDpW+JB3+aKanYb4UETJOF1/CxGPemA==",
+            "dev": true,
+            "engines": {
+                "node": ">=12.22.0"
+            }
+        },
+        "node_modules/@pnpm/network.ca-file": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@pnpm/network.ca-file/-/network.ca-file-1.0.2.tgz",
+            "integrity": "sha512-YcPQ8a0jwYU9bTdJDpXjMi7Brhkr1mXsXrUJvjqM2mQDgkRiz8jFaQGOdaLxgjtUfQgZhKy/O3cG/YwmgKaxLA==",
+            "dev": true,
+            "dependencies": {
+                "graceful-fs": "4.2.10"
+            },
+            "engines": {
+                "node": ">=12.22.0"
+            }
+        },
+        "node_modules/@pnpm/npm-conf": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@pnpm/npm-conf/-/npm-conf-2.1.0.tgz",
+            "integrity": "sha512-Oe6ntvgsMTE3hDIqy6sajqHF+MnzJrOF06qC2QSiUEybLL7cp6tjoKUa32gpd9+KPVl4QyMs3E3nsXrx/Vdnlw==",
+            "dev": true,
+            "dependencies": {
+                "@pnpm/config.env-replace": "^1.0.0",
+                "@pnpm/network.ca-file": "^1.0.1",
+                "config-chain": "^1.1.11"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
         "node_modules/@rokucommunity/bslib": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/@rokucommunity/bslib/-/bslib-0.1.1.tgz",
@@ -1210,6 +1245,12 @@
                 "@types/minimatch": "*",
                 "@types/node": "*"
             }
+        },
+        "node_modules/@types/http-cache-semantics": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz",
+            "integrity": "sha512-SZs7ekbP8CN0txVG2xVRH6EgKmEm31BOxA07vkFaETzZz1xh+cbt8BcI0slpymvwhx5dlFnQG2rTlPVQn+iRPQ==",
+            "dev": true
         },
         "node_modules/@types/http-proxy": {
             "version": "1.17.10",
@@ -2491,6 +2532,15 @@
                 "node": ">= 0.8"
             }
         },
+        "node_modules/cacheable-lookup": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-7.0.0.tgz",
+            "integrity": "sha512-+qJyx4xiKra8mZrcwhjMRMUhD5NR1R8esPkzIYxX96JiecFoxAXFuz/GpR3+ev4PE1WamHip78wV0vcmPQtp8w==",
+            "dev": true,
+            "engines": {
+                "node": ">=14.16"
+            }
+        },
         "node_modules/cacheable-request": {
             "version": "6.1.0",
             "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-6.1.0.tgz",
@@ -2887,6 +2937,16 @@
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+        },
+        "node_modules/config-chain": {
+            "version": "1.1.13",
+            "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
+            "integrity": "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==",
+            "dev": true,
+            "dependencies": {
+                "ini": "^1.3.4",
+                "proto-list": "~1.2.1"
+            }
         },
         "node_modules/connect": {
             "version": "3.7.0",
@@ -3437,9 +3497,9 @@
             "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
         },
         "node_modules/ejs": {
-            "version": "3.1.8",
-            "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.8.tgz",
-            "integrity": "sha512-/sXZeMlhS0ArkfX2Aw780gJzXSMPnKjtspYZv+f3NiKLlubezAHDU5+9xz6gd3/NhG3txQCo6xlglmTS+oTGEQ==",
+            "version": "3.1.9",
+            "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.9.tgz",
+            "integrity": "sha512-rC+QVNMJWv+MtPgkt0y+0rVEIdbtxVADApW9JXrUVlzHetgcyczP/E7DJmWJ4fJCZF2cPcBk0laWO9ZHMG3DmQ==",
             "dev": true,
             "dependencies": {
                 "jake": "^10.8.5"
@@ -4496,9 +4556,9 @@
             }
         },
         "node_modules/filelist/node_modules/minimatch": {
-            "version": "5.1.1",
-            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.1.tgz",
-            "integrity": "sha512-362NP+zlprccbEt/SkxKfRMHnNY85V74mVnpUpNyr3F35covl09Kec7/sEFLt3RA4oXmewtoaanoIf67SE5Y5g==",
+            "version": "5.1.6",
+            "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+            "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
             "dev": true,
             "dependencies": {
                 "brace-expansion": "^2.0.1"
@@ -4683,6 +4743,15 @@
             },
             "engines": {
                 "node": ">= 0.12"
+            }
+        },
+        "node_modules/form-data-encoder": {
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-2.1.4.tgz",
+            "integrity": "sha512-yDYSgNMraqvnxiEXO4hi88+YZxaHC6QKzb5N84iRCTDeRO7ZALpir/lVmf/uXUhnwUr2O4HU8s/n6x+yNjQkHw==",
+            "dev": true,
+            "engines": {
+                "node": ">= 14.17"
             }
         },
         "node_modules/forwarded": {
@@ -5392,9 +5461,9 @@
             }
         },
         "node_modules/http-cache-semantics": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-            "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
+            "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==",
             "dev": true
         },
         "node_modules/http-errors": {
@@ -5519,6 +5588,19 @@
             "engines": {
                 "node": ">=0.8",
                 "npm": ">=1.3.7"
+            }
+        },
+        "node_modules/http2-wrapper": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-2.2.0.tgz",
+            "integrity": "sha512-kZB0wxMo0sh1PehyjJUWRFEd99KC5TLjZ2cULC4f9iqJBAmKQQXEICjxl5iPJRwP40dpeHFqqhm7tYCvODpqpQ==",
+            "dev": true,
+            "dependencies": {
+                "quick-lru": "^5.1.1",
+                "resolve-alpn": "^1.2.0"
+            },
+            "engines": {
+                "node": ">=10.19.0"
             }
         },
         "node_modules/iconv-lite": {
@@ -6613,9 +6695,9 @@
             }
         },
         "node_modules/marked": {
-            "version": "4.2.4",
-            "resolved": "https://registry.npmjs.org/marked/-/marked-4.2.4.tgz",
-            "integrity": "sha512-Wcc9ikX7Q5E4BYDPvh1C6QNSxrjC9tBgz+A/vAhp59KXUgachw++uMvMKiSW8oA85nopmPZcEvBoex/YLMsiyA==",
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+            "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
             "dev": true,
             "bin": {
                 "marked": "bin/marked.js"
@@ -8074,6 +8156,12 @@
             "integrity": "sha512-spZRyzKL5l5BZQrr/6m/SqFdBN0q3OCI0f9rjfBzCMBIP4p75P620rR3gTmaksNOhmzgdxcaxdNfMy6anrbM0g==",
             "dev": true
         },
+        "node_modules/proto-list": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+            "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
+            "dev": true
+        },
         "node_modules/proxy-addr": {
             "version": "2.0.7",
             "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -8153,6 +8241,18 @@
                     "url": "https://feross.org/support"
                 }
             ]
+        },
+        "node_modules/quick-lru": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+            "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+            "dev": true,
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
         },
         "node_modules/randombytes": {
             "version": "2.1.0",
@@ -8506,6 +8606,12 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
+        },
+        "node_modules/resolve-alpn": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
+            "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
+            "dev": true
         },
         "node_modules/resolve-from": {
             "version": "4.0.0",
@@ -9310,9 +9416,9 @@
             }
         },
         "node_modules/statigen": {
-            "version": "0.4.5",
-            "resolved": "https://registry.npmjs.org/statigen/-/statigen-0.4.5.tgz",
-            "integrity": "sha512-tkYDujveAgky0nYoAWellhYy5jcVf+tN+LCPQu+/+/GmnWTB5mIA7Mgd/0Roglh0+2w+NJqRi07OfihQJ+wQyw==",
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/statigen/-/statigen-0.5.0.tgz",
+            "integrity": "sha512-W9qp6ZDtHZzlQ3OhbQ+UWMNEh5s7p5RQ7YKl+MPUj7gjHRzrTjlc6/Qp+f1YiWusgGdW/Dt02Q0lDHfNMCG22g==",
             "dev": true,
             "dependencies": {
                 "@compodoc/live-server": "^1.2.3",
@@ -9326,13 +9432,55 @@
                 "fast-glob": "^3.2.11",
                 "front-matter": "^4.0.2",
                 "fs-extra": "^10.0.1",
-                "latest-version": "^5.1.0",
+                "latest-version": "^7.0.0",
                 "marked": "^4.0.12",
                 "moment": "^2.29.2",
                 "yargs": "^17.4.0"
             },
             "bin": {
                 "statigen": "dist/cli.js"
+            }
+        },
+        "node_modules/statigen/node_modules/@sindresorhus/is": {
+            "version": "5.3.0",
+            "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-5.3.0.tgz",
+            "integrity": "sha512-CX6t4SYQ37lzxicAqsBtxA3OseeoVrh9cSJ5PFYam0GksYlupRfy1A+Q4aYD3zvcfECLc0zO2u+ZnR2UYKvCrw==",
+            "dev": true,
+            "engines": {
+                "node": ">=14.16"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/is?sponsor=1"
+            }
+        },
+        "node_modules/statigen/node_modules/@szmarczak/http-timer": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-5.0.1.tgz",
+            "integrity": "sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw==",
+            "dev": true,
+            "dependencies": {
+                "defer-to-connect": "^2.0.1"
+            },
+            "engines": {
+                "node": ">=14.16"
+            }
+        },
+        "node_modules/statigen/node_modules/cacheable-request": {
+            "version": "10.2.9",
+            "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-10.2.9.tgz",
+            "integrity": "sha512-CaAMr53AS1Tb9evO1BIWFnZjSr8A4pbXofpsNVWPMDZZj3ZQKHwsQG9BrTqQ4x5ZYJXz1T2b8LLtTZODxSpzbg==",
+            "dev": true,
+            "dependencies": {
+                "@types/http-cache-semantics": "^4.0.1",
+                "get-stream": "^6.0.1",
+                "http-cache-semantics": "^4.1.1",
+                "keyv": "^4.5.2",
+                "mimic-response": "^4.0.0",
+                "normalize-url": "^8.0.0",
+                "responselike": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=14.16"
             }
         },
         "node_modules/statigen/node_modules/cliui": {
@@ -9347,6 +9495,42 @@
             },
             "engines": {
                 "node": ">=12"
+            }
+        },
+        "node_modules/statigen/node_modules/decompress-response": {
+            "version": "6.0.0",
+            "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+            "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+            "dev": true,
+            "dependencies": {
+                "mimic-response": "^3.1.0"
+            },
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/statigen/node_modules/decompress-response/node_modules/mimic-response": {
+            "version": "3.1.0",
+            "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+            "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/statigen/node_modules/defer-to-connect": {
+            "version": "2.0.1",
+            "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
+            "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
+            "dev": true,
+            "engines": {
+                "node": ">=10"
             }
         },
         "node_modules/statigen/node_modules/emoji-regex": {
@@ -9369,6 +9553,43 @@
                 "node": ">=12"
             }
         },
+        "node_modules/statigen/node_modules/get-stream": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+            "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+            "dev": true,
+            "engines": {
+                "node": ">=10"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/statigen/node_modules/got": {
+            "version": "12.6.0",
+            "resolved": "https://registry.npmjs.org/got/-/got-12.6.0.tgz",
+            "integrity": "sha512-WTcaQ963xV97MN3x0/CbAriXFZcXCfgxVp91I+Ze6pawQOa7SgzwSx2zIJJsX+kTajMnVs0xcFD1TxZKFqhdnQ==",
+            "dev": true,
+            "dependencies": {
+                "@sindresorhus/is": "^5.2.0",
+                "@szmarczak/http-timer": "^5.0.1",
+                "cacheable-lookup": "^7.0.0",
+                "cacheable-request": "^10.2.8",
+                "decompress-response": "^6.0.0",
+                "form-data-encoder": "^2.1.2",
+                "get-stream": "^6.0.1",
+                "http2-wrapper": "^2.1.10",
+                "lowercase-keys": "^3.0.0",
+                "p-cancelable": "^3.0.0",
+                "responselike": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=14.16"
+            },
+            "funding": {
+                "url": "https://github.com/sindresorhus/got?sponsor=1"
+            }
+        },
         "node_modules/statigen/node_modules/is-fullwidth-code-point": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
@@ -9377,6 +9598,12 @@
             "engines": {
                 "node": ">=8"
             }
+        },
+        "node_modules/statigen/node_modules/json-buffer": {
+            "version": "3.0.1",
+            "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+            "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
+            "dev": true
         },
         "node_modules/statigen/node_modules/jsonfile": {
             "version": "6.1.0",
@@ -9388,6 +9615,135 @@
             },
             "optionalDependencies": {
                 "graceful-fs": "^4.1.6"
+            }
+        },
+        "node_modules/statigen/node_modules/keyv": {
+            "version": "4.5.2",
+            "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.2.tgz",
+            "integrity": "sha512-5MHbFaKn8cNSmVW7BYnijeAVlE4cYA/SVkifVgrh7yotnfhKmjuXpDKjrABLnT0SfHWV21P8ow07OGfRrNDg8g==",
+            "dev": true,
+            "dependencies": {
+                "json-buffer": "3.0.1"
+            }
+        },
+        "node_modules/statigen/node_modules/latest-version": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-7.0.0.tgz",
+            "integrity": "sha512-KvNT4XqAMzdcL6ka6Tl3i2lYeFDgXNCuIX+xNx6ZMVR1dFq+idXd9FLKNMOIx0t9mJ9/HudyX4oZWXZQ0UJHeg==",
+            "dev": true,
+            "dependencies": {
+                "package-json": "^8.1.0"
+            },
+            "engines": {
+                "node": ">=14.16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/statigen/node_modules/lowercase-keys": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-3.0.0.tgz",
+            "integrity": "sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==",
+            "dev": true,
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/statigen/node_modules/mimic-response": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-4.0.0.tgz",
+            "integrity": "sha512-e5ISH9xMYU0DzrT+jl8q2ze9D6eWBto+I8CNpe+VI+K2J/F/k3PdkdTdz4wvGVH4NTpo+NRYTVIuMQEMMcsLqg==",
+            "dev": true,
+            "engines": {
+                "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/statigen/node_modules/normalize-url": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-8.0.0.tgz",
+            "integrity": "sha512-uVFpKhj5MheNBJRTiMZ9pE/7hD1QTeEvugSJW/OmLzAp78PB5O6adfMNTvmfKhXBkvCzC+rqifWcVYpGFwTjnw==",
+            "dev": true,
+            "engines": {
+                "node": ">=14.16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/statigen/node_modules/p-cancelable": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-3.0.0.tgz",
+            "integrity": "sha512-mlVgR3PGuzlo0MmTdk4cXqXWlwQDLnONTAg6sm62XkMJEiRxN3GL3SffkYvqwonbkJBcrI7Uvv5Zh9yjvn2iUw==",
+            "dev": true,
+            "engines": {
+                "node": ">=12.20"
+            }
+        },
+        "node_modules/statigen/node_modules/package-json": {
+            "version": "8.1.0",
+            "resolved": "https://registry.npmjs.org/package-json/-/package-json-8.1.0.tgz",
+            "integrity": "sha512-hySwcV8RAWeAfPsXb9/HGSPn8lwDnv6fabH+obUZKX169QknRkRhPxd1yMubpKDskLFATkl3jHpNtVtDPFA0Wg==",
+            "dev": true,
+            "dependencies": {
+                "got": "^12.1.0",
+                "registry-auth-token": "^5.0.1",
+                "registry-url": "^6.0.0",
+                "semver": "^7.3.7"
+            },
+            "engines": {
+                "node": ">=14.16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/statigen/node_modules/registry-auth-token": {
+            "version": "5.0.2",
+            "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-5.0.2.tgz",
+            "integrity": "sha512-o/3ikDxtXaA59BmZuZrJZDJv8NMDGSj+6j6XaeBmHw8eY1i1qd9+6H+LjVvQXx3HN6aRCGa1cUdJ9RaJZUugnQ==",
+            "dev": true,
+            "dependencies": {
+                "@pnpm/npm-conf": "^2.1.0"
+            },
+            "engines": {
+                "node": ">=14"
+            }
+        },
+        "node_modules/statigen/node_modules/registry-url": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-6.0.1.tgz",
+            "integrity": "sha512-+crtS5QjFRqFCoQmvGduwYWEBng99ZvmFvF+cUJkGYF1L1BfU8C6Zp9T7f5vPAwyLkUExpvK+ANVZmGU49qi4Q==",
+            "dev": true,
+            "dependencies": {
+                "rc": "1.2.8"
+            },
+            "engines": {
+                "node": ">=12"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
+            }
+        },
+        "node_modules/statigen/node_modules/responselike": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/responselike/-/responselike-3.0.0.tgz",
+            "integrity": "sha512-40yHxbNcl2+rzXvZuVkrYohathsSJlMTXKryG5y8uciHv1+xDLHQpgjG64JUO9nrEq2jGLH6IZ8BcZyw3wrweg==",
+            "dev": true,
+            "dependencies": {
+                "lowercase-keys": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=14.16"
+            },
+            "funding": {
+                "url": "https://github.com/sponsors/sindresorhus"
             }
         },
         "node_modules/statigen/node_modules/string-width": {
@@ -9414,9 +9770,9 @@
             }
         },
         "node_modules/statigen/node_modules/yargs": {
-            "version": "17.6.2",
-            "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.2.tgz",
-            "integrity": "sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==",
+            "version": "17.7.1",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.1.tgz",
+            "integrity": "sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==",
             "dev": true,
             "dependencies": {
                 "cliui": "^8.0.1",
@@ -11675,6 +12031,32 @@
                 "node-gyp-build": "^4.3.0"
             }
         },
+        "@pnpm/config.env-replace": {
+            "version": "1.0.0",
+            "resolved": "https://registry.npmjs.org/@pnpm/config.env-replace/-/config.env-replace-1.0.0.tgz",
+            "integrity": "sha512-ZVPVDi1E8oeXlYqkGRtX0CkzLTwE2zt62bjWaWKaAvI8NZqHzlMvGeSNDpW+JB3+aKanYb4UETJOF1/CxGPemA==",
+            "dev": true
+        },
+        "@pnpm/network.ca-file": {
+            "version": "1.0.2",
+            "resolved": "https://registry.npmjs.org/@pnpm/network.ca-file/-/network.ca-file-1.0.2.tgz",
+            "integrity": "sha512-YcPQ8a0jwYU9bTdJDpXjMi7Brhkr1mXsXrUJvjqM2mQDgkRiz8jFaQGOdaLxgjtUfQgZhKy/O3cG/YwmgKaxLA==",
+            "dev": true,
+            "requires": {
+                "graceful-fs": "4.2.10"
+            }
+        },
+        "@pnpm/npm-conf": {
+            "version": "2.1.0",
+            "resolved": "https://registry.npmjs.org/@pnpm/npm-conf/-/npm-conf-2.1.0.tgz",
+            "integrity": "sha512-Oe6ntvgsMTE3hDIqy6sajqHF+MnzJrOF06qC2QSiUEybLL7cp6tjoKUa32gpd9+KPVl4QyMs3E3nsXrx/Vdnlw==",
+            "dev": true,
+            "requires": {
+                "@pnpm/config.env-replace": "^1.0.0",
+                "@pnpm/network.ca-file": "^1.0.1",
+                "config-chain": "^1.1.11"
+            }
+        },
         "@rokucommunity/bslib": {
             "version": "0.1.1",
             "resolved": "https://registry.npmjs.org/@rokucommunity/bslib/-/bslib-0.1.1.tgz",
@@ -11885,6 +12267,12 @@
                 "@types/minimatch": "*",
                 "@types/node": "*"
             }
+        },
+        "@types/http-cache-semantics": {
+            "version": "4.0.1",
+            "resolved": "https://registry.npmjs.org/@types/http-cache-semantics/-/http-cache-semantics-4.0.1.tgz",
+            "integrity": "sha512-SZs7ekbP8CN0txVG2xVRH6EgKmEm31BOxA07vkFaETzZz1xh+cbt8BcI0slpymvwhx5dlFnQG2rTlPVQn+iRPQ==",
+            "dev": true
         },
         "@types/http-proxy": {
             "version": "1.17.10",
@@ -12859,6 +13247,12 @@
             "resolved": "https://registry.npmjs.org/bytes/-/bytes-3.1.2.tgz",
             "integrity": "sha512-/Nf7TyzTx6S3yRJObOAV7956r8cr2+Oj8AC5dt8wSP3BQAoeX58NoHyCU8P8zGkNXStjTSi6fzO6F0pBdcYbEg=="
         },
+        "cacheable-lookup": {
+            "version": "7.0.0",
+            "resolved": "https://registry.npmjs.org/cacheable-lookup/-/cacheable-lookup-7.0.0.tgz",
+            "integrity": "sha512-+qJyx4xiKra8mZrcwhjMRMUhD5NR1R8esPkzIYxX96JiecFoxAXFuz/GpR3+ev4PE1WamHip78wV0vcmPQtp8w==",
+            "dev": true
+        },
         "cacheable-request": {
             "version": "6.1.0",
             "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-6.1.0.tgz",
@@ -13153,6 +13547,16 @@
             "version": "0.0.1",
             "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
             "integrity": "sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg=="
+        },
+        "config-chain": {
+            "version": "1.1.13",
+            "resolved": "https://registry.npmjs.org/config-chain/-/config-chain-1.1.13.tgz",
+            "integrity": "sha512-qj+f8APARXHrM0hraqXYb2/bOVSV4PvJQlNZ/DVj0QrmNM2q2euizkeuVckQ57J+W0mRH6Hvi+k50M4Jul2VRQ==",
+            "dev": true,
+            "requires": {
+                "ini": "^1.3.4",
+                "proto-list": "~1.2.1"
+            }
         },
         "connect": {
             "version": "3.7.0",
@@ -13576,9 +13980,9 @@
             "integrity": "sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow=="
         },
         "ejs": {
-            "version": "3.1.8",
-            "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.8.tgz",
-            "integrity": "sha512-/sXZeMlhS0ArkfX2Aw780gJzXSMPnKjtspYZv+f3NiKLlubezAHDU5+9xz6gd3/NhG3txQCo6xlglmTS+oTGEQ==",
+            "version": "3.1.9",
+            "resolved": "https://registry.npmjs.org/ejs/-/ejs-3.1.9.tgz",
+            "integrity": "sha512-rC+QVNMJWv+MtPgkt0y+0rVEIdbtxVADApW9JXrUVlzHetgcyczP/E7DJmWJ4fJCZF2cPcBk0laWO9ZHMG3DmQ==",
             "dev": true,
             "requires": {
                 "jake": "^10.8.5"
@@ -14409,9 +14813,9 @@
                     }
                 },
                 "minimatch": {
-                    "version": "5.1.1",
-                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.1.tgz",
-                    "integrity": "sha512-362NP+zlprccbEt/SkxKfRMHnNY85V74mVnpUpNyr3F35covl09Kec7/sEFLt3RA4oXmewtoaanoIf67SE5Y5g==",
+                    "version": "5.1.6",
+                    "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-5.1.6.tgz",
+                    "integrity": "sha512-lKwV/1brpG6mBUFHtb7NUmtABCb2WZZmm2wNiOA5hAb8VdCS4B3dtMWyvcoViccwAW/COERjXLt0zP1zXUN26g==",
                     "dev": true,
                     "requires": {
                         "brace-expansion": "^2.0.1"
@@ -14551,6 +14955,12 @@
                 "combined-stream": "^1.0.6",
                 "mime-types": "^2.1.12"
             }
+        },
+        "form-data-encoder": {
+            "version": "2.1.4",
+            "resolved": "https://registry.npmjs.org/form-data-encoder/-/form-data-encoder-2.1.4.tgz",
+            "integrity": "sha512-yDYSgNMraqvnxiEXO4hi88+YZxaHC6QKzb5N84iRCTDeRO7ZALpir/lVmf/uXUhnwUr2O4HU8s/n6x+yNjQkHw==",
+            "dev": true
         },
         "forwarded": {
             "version": "0.2.0",
@@ -15060,9 +15470,9 @@
             "dev": true
         },
         "http-cache-semantics": {
-            "version": "4.1.0",
-            "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.0.tgz",
-            "integrity": "sha512-carPklcUh7ROWRK7Cv27RPtdhYhUsela/ue5/jKzjegVvXDqM2ILE9Q2BGn9JZJh1g87cp56su/FgQSzcWS8cQ==",
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/http-cache-semantics/-/http-cache-semantics-4.1.1.tgz",
+            "integrity": "sha512-er295DKPVsV82j5kw1Gjt+ADA/XYHsajl82cGNQG2eyoPkvgUhX+nDIyelzhIWbbsXP39EHcI6l5tYs2FYqYXQ==",
             "dev": true
         },
         "http-errors": {
@@ -15161,6 +15571,16 @@
                 "assert-plus": "^1.0.0",
                 "jsprim": "^1.2.2",
                 "sshpk": "^1.7.0"
+            }
+        },
+        "http2-wrapper": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/http2-wrapper/-/http2-wrapper-2.2.0.tgz",
+            "integrity": "sha512-kZB0wxMo0sh1PehyjJUWRFEd99KC5TLjZ2cULC4f9iqJBAmKQQXEICjxl5iPJRwP40dpeHFqqhm7tYCvODpqpQ==",
+            "dev": true,
+            "requires": {
+                "quick-lru": "^5.1.1",
+                "resolve-alpn": "^1.2.0"
             }
         },
         "iconv-lite": {
@@ -15985,9 +16405,9 @@
             }
         },
         "marked": {
-            "version": "4.2.4",
-            "resolved": "https://registry.npmjs.org/marked/-/marked-4.2.4.tgz",
-            "integrity": "sha512-Wcc9ikX7Q5E4BYDPvh1C6QNSxrjC9tBgz+A/vAhp59KXUgachw++uMvMKiSW8oA85nopmPZcEvBoex/YLMsiyA==",
+            "version": "4.3.0",
+            "resolved": "https://registry.npmjs.org/marked/-/marked-4.3.0.tgz",
+            "integrity": "sha512-PRsaiG84bK+AMvxziE/lCFss8juXjNaWzVbN5tXAm4XjeaS9NAHhop+PjQxz2A9h8Q4M/xGmzP8vqNwy6JeK0A==",
             "dev": true
         },
         "mdurl": {
@@ -17099,6 +17519,12 @@
                 }
             }
         },
+        "proto-list": {
+            "version": "1.2.4",
+            "resolved": "https://registry.npmjs.org/proto-list/-/proto-list-1.2.4.tgz",
+            "integrity": "sha512-vtK/94akxsTMhe0/cbfpR+syPuszcuwhqVjJq26CuNDgFGj682oRBXOP5MJpv2r7JtE8MsiepGIqvvOTBwn2vA==",
+            "dev": true
+        },
         "proxy-addr": {
             "version": "2.0.7",
             "resolved": "https://registry.npmjs.org/proxy-addr/-/proxy-addr-2.0.7.tgz",
@@ -17148,6 +17574,12 @@
             "version": "1.2.3",
             "resolved": "https://registry.npmjs.org/queue-microtask/-/queue-microtask-1.2.3.tgz",
             "integrity": "sha512-NuaNSa6flKT5JaSYQzJok04JzTL1CA6aGhv5rfLW3PgqA+M2ChpZQnAC8h8i4ZFkBS8X5RqkDBHA7r4hej3K9A=="
+        },
+        "quick-lru": {
+            "version": "5.1.1",
+            "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+            "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+            "dev": true
         },
         "randombytes": {
             "version": "2.1.0",
@@ -17429,6 +17861,12 @@
                 "path-parse": "^1.0.7",
                 "supports-preserve-symlinks-flag": "^1.0.0"
             }
+        },
+        "resolve-alpn": {
+            "version": "1.2.1",
+            "resolved": "https://registry.npmjs.org/resolve-alpn/-/resolve-alpn-1.2.1.tgz",
+            "integrity": "sha512-0a1F4l73/ZFZOakJnQ3FvkJ2+gSTQWz/r2KE5OdDY0TxPm5h4GkqkWWfM47T7HsbnOtcJVEF4epCVy6u7Q3K+g==",
+            "dev": true
         },
         "resolve-from": {
             "version": "4.0.0",
@@ -18036,9 +18474,9 @@
             "dev": true
         },
         "statigen": {
-            "version": "0.4.5",
-            "resolved": "https://registry.npmjs.org/statigen/-/statigen-0.4.5.tgz",
-            "integrity": "sha512-tkYDujveAgky0nYoAWellhYy5jcVf+tN+LCPQu+/+/GmnWTB5mIA7Mgd/0Roglh0+2w+NJqRi07OfihQJ+wQyw==",
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/statigen/-/statigen-0.5.0.tgz",
+            "integrity": "sha512-W9qp6ZDtHZzlQ3OhbQ+UWMNEh5s7p5RQ7YKl+MPUj7gjHRzrTjlc6/Qp+f1YiWusgGdW/Dt02Q0lDHfNMCG22g==",
             "dev": true,
             "requires": {
                 "@compodoc/live-server": "^1.2.3",
@@ -18052,12 +18490,42 @@
                 "fast-glob": "^3.2.11",
                 "front-matter": "^4.0.2",
                 "fs-extra": "^10.0.1",
-                "latest-version": "^5.1.0",
+                "latest-version": "^7.0.0",
                 "marked": "^4.0.12",
                 "moment": "^2.29.2",
                 "yargs": "^17.4.0"
             },
             "dependencies": {
+                "@sindresorhus/is": {
+                    "version": "5.3.0",
+                    "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-5.3.0.tgz",
+                    "integrity": "sha512-CX6t4SYQ37lzxicAqsBtxA3OseeoVrh9cSJ5PFYam0GksYlupRfy1A+Q4aYD3zvcfECLc0zO2u+ZnR2UYKvCrw==",
+                    "dev": true
+                },
+                "@szmarczak/http-timer": {
+                    "version": "5.0.1",
+                    "resolved": "https://registry.npmjs.org/@szmarczak/http-timer/-/http-timer-5.0.1.tgz",
+                    "integrity": "sha512-+PmQX0PiAYPMeVYe237LJAYvOMYW1j2rH5YROyS3b4CTVJum34HfRvKvAzozHAQG0TnHNdUfY9nCeUyRAs//cw==",
+                    "dev": true,
+                    "requires": {
+                        "defer-to-connect": "^2.0.1"
+                    }
+                },
+                "cacheable-request": {
+                    "version": "10.2.9",
+                    "resolved": "https://registry.npmjs.org/cacheable-request/-/cacheable-request-10.2.9.tgz",
+                    "integrity": "sha512-CaAMr53AS1Tb9evO1BIWFnZjSr8A4pbXofpsNVWPMDZZj3ZQKHwsQG9BrTqQ4x5ZYJXz1T2b8LLtTZODxSpzbg==",
+                    "dev": true,
+                    "requires": {
+                        "@types/http-cache-semantics": "^4.0.1",
+                        "get-stream": "^6.0.1",
+                        "http-cache-semantics": "^4.1.1",
+                        "keyv": "^4.5.2",
+                        "mimic-response": "^4.0.0",
+                        "normalize-url": "^8.0.0",
+                        "responselike": "^3.0.0"
+                    }
+                },
                 "cliui": {
                     "version": "8.0.1",
                     "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
@@ -18068,6 +18536,29 @@
                         "strip-ansi": "^6.0.1",
                         "wrap-ansi": "^7.0.0"
                     }
+                },
+                "decompress-response": {
+                    "version": "6.0.0",
+                    "resolved": "https://registry.npmjs.org/decompress-response/-/decompress-response-6.0.0.tgz",
+                    "integrity": "sha512-aW35yZM6Bb/4oJlZncMH2LCoZtJXTRxES17vE3hoRiowU2kWHaJKFkSBDnDR+cm9J+9QhXmREyIfv0pji9ejCQ==",
+                    "dev": true,
+                    "requires": {
+                        "mimic-response": "^3.1.0"
+                    },
+                    "dependencies": {
+                        "mimic-response": {
+                            "version": "3.1.0",
+                            "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-3.1.0.tgz",
+                            "integrity": "sha512-z0yWI+4FDrrweS8Zmt4Ej5HdJmky15+L2e6Wgn3+iK5fWzb6T3fhNFq2+MeTRb064c6Wr4N/wv0DzQTjNzHNGQ==",
+                            "dev": true
+                        }
+                    }
+                },
+                "defer-to-connect": {
+                    "version": "2.0.1",
+                    "resolved": "https://registry.npmjs.org/defer-to-connect/-/defer-to-connect-2.0.1.tgz",
+                    "integrity": "sha512-4tvttepXG1VaYGrRibk5EwJd1t4udunSOVMdLSAL6mId1ix438oPwPZMALY41FCijukO1L0twNcGsdzS7dHgDg==",
+                    "dev": true
                 },
                 "emoji-regex": {
                     "version": "8.0.0",
@@ -18086,10 +18577,41 @@
                         "universalify": "^2.0.0"
                     }
                 },
+                "get-stream": {
+                    "version": "6.0.1",
+                    "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-6.0.1.tgz",
+                    "integrity": "sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==",
+                    "dev": true
+                },
+                "got": {
+                    "version": "12.6.0",
+                    "resolved": "https://registry.npmjs.org/got/-/got-12.6.0.tgz",
+                    "integrity": "sha512-WTcaQ963xV97MN3x0/CbAriXFZcXCfgxVp91I+Ze6pawQOa7SgzwSx2zIJJsX+kTajMnVs0xcFD1TxZKFqhdnQ==",
+                    "dev": true,
+                    "requires": {
+                        "@sindresorhus/is": "^5.2.0",
+                        "@szmarczak/http-timer": "^5.0.1",
+                        "cacheable-lookup": "^7.0.0",
+                        "cacheable-request": "^10.2.8",
+                        "decompress-response": "^6.0.0",
+                        "form-data-encoder": "^2.1.2",
+                        "get-stream": "^6.0.1",
+                        "http2-wrapper": "^2.1.10",
+                        "lowercase-keys": "^3.0.0",
+                        "p-cancelable": "^3.0.0",
+                        "responselike": "^3.0.0"
+                    }
+                },
                 "is-fullwidth-code-point": {
                     "version": "3.0.0",
                     "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
                     "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+                    "dev": true
+                },
+                "json-buffer": {
+                    "version": "3.0.1",
+                    "resolved": "https://registry.npmjs.org/json-buffer/-/json-buffer-3.0.1.tgz",
+                    "integrity": "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ==",
                     "dev": true
                 },
                 "jsonfile": {
@@ -18100,6 +18622,87 @@
                     "requires": {
                         "graceful-fs": "^4.1.6",
                         "universalify": "^2.0.0"
+                    }
+                },
+                "keyv": {
+                    "version": "4.5.2",
+                    "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.2.tgz",
+                    "integrity": "sha512-5MHbFaKn8cNSmVW7BYnijeAVlE4cYA/SVkifVgrh7yotnfhKmjuXpDKjrABLnT0SfHWV21P8ow07OGfRrNDg8g==",
+                    "dev": true,
+                    "requires": {
+                        "json-buffer": "3.0.1"
+                    }
+                },
+                "latest-version": {
+                    "version": "7.0.0",
+                    "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-7.0.0.tgz",
+                    "integrity": "sha512-KvNT4XqAMzdcL6ka6Tl3i2lYeFDgXNCuIX+xNx6ZMVR1dFq+idXd9FLKNMOIx0t9mJ9/HudyX4oZWXZQ0UJHeg==",
+                    "dev": true,
+                    "requires": {
+                        "package-json": "^8.1.0"
+                    }
+                },
+                "lowercase-keys": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/lowercase-keys/-/lowercase-keys-3.0.0.tgz",
+                    "integrity": "sha512-ozCC6gdQ+glXOQsveKD0YsDy8DSQFjDTz4zyzEHNV5+JP5D62LmfDZ6o1cycFx9ouG940M5dE8C8CTewdj2YWQ==",
+                    "dev": true
+                },
+                "mimic-response": {
+                    "version": "4.0.0",
+                    "resolved": "https://registry.npmjs.org/mimic-response/-/mimic-response-4.0.0.tgz",
+                    "integrity": "sha512-e5ISH9xMYU0DzrT+jl8q2ze9D6eWBto+I8CNpe+VI+K2J/F/k3PdkdTdz4wvGVH4NTpo+NRYTVIuMQEMMcsLqg==",
+                    "dev": true
+                },
+                "normalize-url": {
+                    "version": "8.0.0",
+                    "resolved": "https://registry.npmjs.org/normalize-url/-/normalize-url-8.0.0.tgz",
+                    "integrity": "sha512-uVFpKhj5MheNBJRTiMZ9pE/7hD1QTeEvugSJW/OmLzAp78PB5O6adfMNTvmfKhXBkvCzC+rqifWcVYpGFwTjnw==",
+                    "dev": true
+                },
+                "p-cancelable": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/p-cancelable/-/p-cancelable-3.0.0.tgz",
+                    "integrity": "sha512-mlVgR3PGuzlo0MmTdk4cXqXWlwQDLnONTAg6sm62XkMJEiRxN3GL3SffkYvqwonbkJBcrI7Uvv5Zh9yjvn2iUw==",
+                    "dev": true
+                },
+                "package-json": {
+                    "version": "8.1.0",
+                    "resolved": "https://registry.npmjs.org/package-json/-/package-json-8.1.0.tgz",
+                    "integrity": "sha512-hySwcV8RAWeAfPsXb9/HGSPn8lwDnv6fabH+obUZKX169QknRkRhPxd1yMubpKDskLFATkl3jHpNtVtDPFA0Wg==",
+                    "dev": true,
+                    "requires": {
+                        "got": "^12.1.0",
+                        "registry-auth-token": "^5.0.1",
+                        "registry-url": "^6.0.0",
+                        "semver": "^7.3.7"
+                    }
+                },
+                "registry-auth-token": {
+                    "version": "5.0.2",
+                    "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-5.0.2.tgz",
+                    "integrity": "sha512-o/3ikDxtXaA59BmZuZrJZDJv8NMDGSj+6j6XaeBmHw8eY1i1qd9+6H+LjVvQXx3HN6aRCGa1cUdJ9RaJZUugnQ==",
+                    "dev": true,
+                    "requires": {
+                        "@pnpm/npm-conf": "^2.1.0"
+                    }
+                },
+                "registry-url": {
+                    "version": "6.0.1",
+                    "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-6.0.1.tgz",
+                    "integrity": "sha512-+crtS5QjFRqFCoQmvGduwYWEBng99ZvmFvF+cUJkGYF1L1BfU8C6Zp9T7f5vPAwyLkUExpvK+ANVZmGU49qi4Q==",
+                    "dev": true,
+                    "requires": {
+                        "rc": "1.2.8"
+                    }
+                },
+                "responselike": {
+                    "version": "3.0.0",
+                    "resolved": "https://registry.npmjs.org/responselike/-/responselike-3.0.0.tgz",
+                    "integrity": "sha512-40yHxbNcl2+rzXvZuVkrYohathsSJlMTXKryG5y8uciHv1+xDLHQpgjG64JUO9nrEq2jGLH6IZ8BcZyw3wrweg==",
+                    "dev": true,
+                    "requires": {
+                        "lowercase-keys": "^3.0.0"
                     }
                 },
                 "string-width": {
@@ -18120,9 +18723,9 @@
                     "dev": true
                 },
                 "yargs": {
-                    "version": "17.6.2",
-                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.6.2.tgz",
-                    "integrity": "sha512-1/9UrdHjDZc0eOU0HxOHoS78C69UD3JRMvzlJ7S79S2nTaWRA/whGCTV8o9e/N/1Va9YIV7Q4sOxD8VV4pCWOw==",
+                    "version": "17.7.1",
+                    "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.1.tgz",
+                    "integrity": "sha512-cwiTb08Xuv5fqF4AovYacTFNxk62th7LKJ6BL9IGUpTJrWoU7/7WdQGTP2SjKf1dUNBGzDd28p/Yfs/GI6JrLw==",
                     "dev": true,
                     "requires": {
                         "cliui": "^8.0.1",

--- a/package.json
+++ b/package.json
@@ -114,7 +114,7 @@
         "rimraf": "^3.0.0",
         "sinon": "^7.2.3",
         "source-map-support": "^0.5.21",
-        "statigen": "^0.4.4",
+        "statigen": "^0.5.0",
         "terminal-overwrite": "^2.0.1",
         "ts-node": "^10.7.0",
         "tslib": "^2.3.1",

--- a/src/DebugConfigurationProvider.spec.ts
+++ b/src/DebugConfigurationProvider.spec.ts
@@ -51,7 +51,7 @@ describe('BrightScriptConfigurationProvider', () => {
         let activeDeviceManager = {
             getActiveDevices: () => []
         };
-        configProvider = new BrightScriptDebugConfigurationProvider(<any>context, activeDeviceManager, null);
+        configProvider = new BrightScriptDebugConfigurationProvider(<any>context, activeDeviceManager, null, vscode.window.createOutputChannel('Extension'));
     });
 
     afterEach(() => {

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -130,7 +130,7 @@ export class Extension {
         );
 
         //register the debug configuration provider
-        let configProvider = new BrightScriptDebugConfigurationProvider(context, activeDeviceManager, this.telemetryManager);
+        let configProvider = new BrightScriptDebugConfigurationProvider(context, activeDeviceManager, this.telemetryManager, this.extensionOutputChannel);
         context.subscriptions.push(
             vscode.debug.registerDebugConfigurationProvider('brightscript', configProvider)
         );

--- a/src/mockVscode.spec.ts
+++ b/src/mockVscode.spec.ts
@@ -1,4 +1,4 @@
-import type { Command, Range, TreeDataProvider, TreeItemCollapsibleState, Uri, WorkspaceFolder, ConfigurationScope, ExtensionContext, WorkspaceConfiguration } from 'vscode';
+import type { Command, Range, TreeDataProvider, TreeItemCollapsibleState, Uri, WorkspaceFolder, ConfigurationScope, ExtensionContext, WorkspaceConfiguration, OutputChannel } from 'vscode';
 
 afterEach(() => {
     delete vscode.workspace.workspaceFile;
@@ -143,12 +143,17 @@ export let vscode = {
                 show: () => { }
             };
         },
-        createOutputChannel: function() {
+        createOutputChannel: function(name?: string) {
             return {
+                name: name,
+                append: () => { },
+                dispose: () => { },
+                hide: () => { },
+                replace: () => { },
                 show: () => { },
                 clear: () => { },
                 appendLine: () => { }
-            };
+            } as OutputChannel;
         },
         registerTreeDataProvider: function(viewId: string, treeDataProvider: TreeDataProvider<any>) { },
         showErrorMessage: function(message: string) {


### PR DESCRIPTION
- Fixes an issue during launch that would crash if `injectRaleTrackerTask` was true, but no tracker task path was specified. 
- wraps the entire launch config sanitization in a try/catch so we can write any exception to the output channel

