### PR TITLE
Run find node calculations in webview and other improvements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -30,7 +30,7 @@
                 "pretty-bytes": "^5.6.0",
                 "roku-debug": "^0.18.4",
                 "roku-deploy": "^3.10.0",
-                "roku-test-automation": "^2.0.0-beta.14",
+                "roku-test-automation": "^2.0.0-beta.17",
                 "semver": "^7.1.3",
                 "source-map": "^0.7.3",
                 "thenby": "^1.3.4",
@@ -8856,9 +8856,9 @@
             }
         },
         "node_modules/roku-test-automation": {
-            "version": "2.0.0-beta.14",
-            "resolved": "https://registry.npmjs.org/roku-test-automation/-/roku-test-automation-2.0.0-beta.14.tgz",
-            "integrity": "sha512-q/1nSyArDopEyp3phq3s500n6hNFVvBhPFrAAcMWfCvvIx2pqYM1rcBZ4piNcqZfUX4RENgVHDgi9pPzCrlWjg==",
+            "version": "2.0.0-beta.17",
+            "resolved": "https://registry.npmjs.org/roku-test-automation/-/roku-test-automation-2.0.0-beta.17.tgz",
+            "integrity": "sha512-dvBo1KWN90e6yYroAjCaIIW1vMG9H4UfdmXvlL5TLVxebpmTRilF/SPVbaim+olF349xUldbC6fdOtxliPXXTg==",
             "dependencies": {
                 "@suitest/types": "^4.6.0",
                 "ajv": "^6.12.6",
@@ -18058,9 +18058,9 @@
             }
         },
         "roku-test-automation": {
-            "version": "2.0.0-beta.14",
-            "resolved": "https://registry.npmjs.org/roku-test-automation/-/roku-test-automation-2.0.0-beta.14.tgz",
-            "integrity": "sha512-q/1nSyArDopEyp3phq3s500n6hNFVvBhPFrAAcMWfCvvIx2pqYM1rcBZ4piNcqZfUX4RENgVHDgi9pPzCrlWjg==",
+            "version": "2.0.0-beta.17",
+            "resolved": "https://registry.npmjs.org/roku-test-automation/-/roku-test-automation-2.0.0-beta.17.tgz",
+            "integrity": "sha512-dvBo1KWN90e6yYroAjCaIIW1vMG9H4UfdmXvlL5TLVxebpmTRilF/SPVbaim+olF349xUldbC6fdOtxliPXXTg==",
             "requires": {
                 "@suitest/types": "^4.6.0",
                 "ajv": "^6.12.6",

--- a/package.json
+++ b/package.json
@@ -71,7 +71,7 @@
         "pretty-bytes": "^5.6.0",
         "roku-debug": "^0.18.4",
         "roku-deploy": "^3.10.0",
-        "roku-test-automation": "^2.0.0-beta.14",
+        "roku-test-automation": "^2.0.0-beta.17",
         "semver": "^7.1.3",
         "source-map": "^0.7.3",
         "thenby": "^1.3.4",

--- a/webviews/src/views/SceneGraphInspectorView/Branch.svelte
+++ b/webviews/src/views/SceneGraphInspectorView/Branch.svelte
@@ -12,7 +12,7 @@
     export let depth = 0;
     let self: HTMLDivElement;
 
-    const expandedStorageKey = `expanded:${treeNode.ref}`;
+    const expandedStorageKey = `expanded:${treeNode.keyPath}`;
     export let expanded = utils.getStorageBooleanValue(expandedStorageKey);
     $: {
         if (expanded) {

--- a/webviews/src/views/SceneGraphInspectorView/NodeDetailPage.svelte
+++ b/webviews/src/views/SceneGraphInspectorView/NodeDetailPage.svelte
@@ -13,7 +13,10 @@
 
     let inspectChildNodeSubtype: string;
     let inspectChildNodeBaseKeyPath: BaseKeyPath | null;
-    let showKeyPathInfo = false;
+    let showKeyPathInfo = utils.getStorageBooleanValue('showKeyPathInfo');
+    $: {
+        utils.setStorageValue('showKeyPathInfo', showKeyPathInfo);
+    }
 
 
     function close() {

--- a/webviews/src/views/SceneGraphInspectorView/NodeDetailPage.svelte
+++ b/webviews/src/views/SceneGraphInspectorView/NodeDetailPage.svelte
@@ -5,7 +5,7 @@
     import { utils } from '../../utils';
     import ColorField from './ColorField.svelte';
     import Chevron from '../../shared/Chevron.svelte';
-    import { Refresh, Discard, ChromeClose, Move, Key } from 'svelte-codicons';
+    import { Refresh, Discard, ArrowLeft, Move, Key } from 'svelte-codicons';
 
     export let inspectNodeSubtype: string;
     export let inspectNodeBaseKeyPath: BaseKeyPath | null;
@@ -337,10 +337,6 @@
         width: auto;
     }
 
-    #closeButton {
-        float: right;
-    }
-
     .collectionItems {
         padding: 3px 0 3px 15px;
         display: block;
@@ -371,6 +367,12 @@
 <div id="background" />
 <div id="container" class:hide={inspectChildNodeBaseKeyPath}>
     <div id="header">
+        <span
+            class="icon-button"
+            title="Back"
+            on:click={close}>
+            <ArrowLeft />
+        </span>
         <span id="nodeSubtype">{inspectNodeSubtype}</span>
         <input
             class="inline"
@@ -393,13 +395,6 @@
             <Key />
         </span>
     {/if}
-        <span
-            id="closeButton"
-            class="icon-button"
-            title="Close"
-            on:click={close}>
-            <ChromeClose />
-        </span>
     </div>
 {#if showKeyPathInfo && inspectNodeTreeNode}
     <div id="baseKeyPathContainer">


### PR DESCRIPTION
• Switch from ChromeClose icon to ArrowLeft icon to avoid confusion when closing detail page 
• Remember last showKeyPathInfo to make accessing key path info easier]
• Switch to running findNodesAtLocation in webview directly
• switch to using keyPaths for key for expanded nodes