### PR TITLE
Fix crash by using postman-request instead of request

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -27,6 +27,7 @@
                 "net": "^1.0.2",
                 "node-cache": "^4.2.0",
                 "node-ssdp": "^4.0.0",
+                "postman-request": "^2.88.1-postman.32",
                 "pretty-bytes": "^5.6.0",
                 "roku-debug": "^0.18.10",
                 "roku-deploy": "^3.10.2",

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
         "net": "^1.0.2",
         "node-cache": "^4.2.0",
         "node-ssdp": "^4.0.0",
+        "postman-request": "^2.88.1-postman.32",
         "pretty-bytes": "^5.6.0",
         "roku-debug": "^0.18.10",
         "roku-deploy": "^3.10.2",

--- a/src/BrightScriptCommands.ts
+++ b/src/BrightScriptCommands.ts
@@ -1,4 +1,4 @@
-import * as request from 'request';
+import * as request from 'postman-request';
 import * as vscode from 'vscode';
 import BrightScriptFileUtils from './BrightScriptFileUtils';
 import { GlobalStateManager } from './GlobalStateManager';


### PR DESCRIPTION
Fix runtime crash when inside vscode extension because request module was removed. Fixed by declaring postman-request as direct dependency and using that.