### PR TITLE
Show a spinner in the statusbar when lsp is busy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -13,7 +13,7 @@
                 "@vscode/extension-telemetry": "^0.4.7",
                 "array-sort": "^1.0.0",
                 "backoff": "^2.5.0",
-                "brighterscript": "^0.65.1",
+                "brighterscript": "^0.65.4",
                 "brighterscript-formatter": "^1.6.30",
                 "debounce": "^1.2.0",
                 "dotenv": "^6.2.0",
@@ -2461,9 +2461,9 @@
             }
         },
         "node_modules/brighterscript": {
-            "version": "0.65.1",
-            "resolved": "https://registry.npmjs.org/brighterscript/-/brighterscript-0.65.1.tgz",
-            "integrity": "sha512-OmNQd5Sckrx2K63y6cLbK8EIPqVi4yoc6bmz4k2J47NdnGib//JcMngJWG9JxJnCQCOuz1EheyPHW3jXryI7yg==",
+            "version": "0.65.4",
+            "resolved": "https://registry.npmjs.org/brighterscript/-/brighterscript-0.65.4.tgz",
+            "integrity": "sha512-bp2aVhLOM1xRuZiyKx1WQp4JS8Fm6wfD7kAI4rE3YYMYeMhZ/SxTCvBtmTsaW/Z40oB8bBJXuKSuXgz2uF+ywQ==",
             "dependencies": {
                 "@rokucommunity/bslib": "^0.1.1",
                 "@xml-tools/parser": "^1.0.7",
@@ -2488,7 +2488,7 @@
                 "parse-ms": "^2.1.0",
                 "readline": "^1.3.0",
                 "require-relative": "^0.8.7",
-                "roku-deploy": "^3.10.2",
+                "roku-deploy": "^3.10.3",
                 "serialize-error": "^7.0.1",
                 "source-map": "^0.7.4",
                 "vscode-languageserver": "7.0.0",
@@ -9089,9 +9089,9 @@
             }
         },
         "node_modules/roku-deploy": {
-            "version": "3.10.2",
-            "resolved": "https://registry.npmjs.org/roku-deploy/-/roku-deploy-3.10.2.tgz",
-            "integrity": "sha512-oKMw8+CpbvFrNjf3g7PmhSRInTXitaFmtFhxb0ANiE+sC2p+/8wn/1/KqnYsTWPdEKUOLh0xIz2FHK9Nd5o9UA==",
+            "version": "3.10.3",
+            "resolved": "https://registry.npmjs.org/roku-deploy/-/roku-deploy-3.10.3.tgz",
+            "integrity": "sha512-COJSQ638QklcM+8AN1nujFuzT04rTZLFuLSww35edm8w/y0l60oF/Iu7TQ46m75DwoGFzGFfomLEmA1ltQk9mA==",
             "dependencies": {
                 "chalk": "^2.4.2",
                 "dateformat": "^3.0.3",
@@ -13506,9 +13506,9 @@
             }
         },
         "brighterscript": {
-            "version": "0.65.1",
-            "resolved": "https://registry.npmjs.org/brighterscript/-/brighterscript-0.65.1.tgz",
-            "integrity": "sha512-OmNQd5Sckrx2K63y6cLbK8EIPqVi4yoc6bmz4k2J47NdnGib//JcMngJWG9JxJnCQCOuz1EheyPHW3jXryI7yg==",
+            "version": "0.65.4",
+            "resolved": "https://registry.npmjs.org/brighterscript/-/brighterscript-0.65.4.tgz",
+            "integrity": "sha512-bp2aVhLOM1xRuZiyKx1WQp4JS8Fm6wfD7kAI4rE3YYMYeMhZ/SxTCvBtmTsaW/Z40oB8bBJXuKSuXgz2uF+ywQ==",
             "requires": {
                 "@rokucommunity/bslib": "^0.1.1",
                 "@xml-tools/parser": "^1.0.7",
@@ -13533,7 +13533,7 @@
                 "parse-ms": "^2.1.0",
                 "readline": "^1.3.0",
                 "require-relative": "^0.8.7",
-                "roku-deploy": "^3.10.2",
+                "roku-deploy": "^3.10.3",
                 "serialize-error": "^7.0.1",
                 "source-map": "^0.7.4",
                 "vscode-languageserver": "7.0.0",
@@ -18547,9 +18547,9 @@
             }
         },
         "roku-deploy": {
-            "version": "3.10.2",
-            "resolved": "https://registry.npmjs.org/roku-deploy/-/roku-deploy-3.10.2.tgz",
-            "integrity": "sha512-oKMw8+CpbvFrNjf3g7PmhSRInTXitaFmtFhxb0ANiE+sC2p+/8wn/1/KqnYsTWPdEKUOLh0xIz2FHK9Nd5o9UA==",
+            "version": "3.10.3",
+            "resolved": "https://registry.npmjs.org/roku-deploy/-/roku-deploy-3.10.3.tgz",
+            "integrity": "sha512-COJSQ638QklcM+8AN1nujFuzT04rTZLFuLSww35edm8w/y0l60oF/Iu7TQ46m75DwoGFzGFfomLEmA1ltQk9mA==",
             "requires": {
                 "chalk": "^2.4.2",
                 "dateformat": "^3.0.3",

--- a/package.json
+++ b/package.json
@@ -55,7 +55,7 @@
         "@vscode/extension-telemetry": "^0.4.7",
         "array-sort": "^1.0.0",
         "backoff": "^2.5.0",
-        "brighterscript": "^0.65.1",
+        "brighterscript": "^0.65.4",
         "brighterscript-formatter": "^1.6.30",
         "debounce": "^1.2.0",
         "dotenv": "^6.2.0",

--- a/src/LanguageServerManager.ts
+++ b/src/LanguageServerManager.ts
@@ -106,7 +106,7 @@ export class LanguageServerManager {
             this.languageServerStatusBar.command = LanguageServerInfoCommand.commandName;
 
             //enable the statusbar loading anmation. the language server will disable once it finishes loading
-            this.updateStatusbar(true);
+            this.updateStatusbar(false);
 
             this.languageServerStatusBar.show();
 
@@ -216,7 +216,6 @@ export class LanguageServerManager {
      * Enable/disable the loading spinner on the statusbar item
      */
     private updateStatusbar(isLoading: boolean) {
-        console.log('update statusbar:', isLoading);
         const icon = isLoading ? '$(sync~spin)' : '$(flame)';
         this.languageServerStatusBar.text = `${icon} bsc-${this.selectedBscInfo.version}`;
         this.languageServerStatusBar.tooltip = `BrightScript Language Server: running`;

--- a/src/commands/LanguageServerInfoCommand.ts
+++ b/src/commands/LanguageServerInfoCommand.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { languageServerManager } from '../LanguageServerManager';
+import { LANGUAGE_SERVER_NAME, languageServerManager } from '../LanguageServerManager';
 import * as path from 'path';
 
 export class LanguageServerInfoCommand {
@@ -18,10 +18,23 @@ export class LanguageServerInfoCommand {
                 label: `Restart BrighterScript Language Server`,
                 description: ``,
                 command: this.restartLanguageServer.bind(this)
+            }, {
+                label: `View language server logs`,
+                description: ``,
+                command: this.focusLanguageServerOutputChannel.bind(this)
             }];
+
             let selection = await vscode.window.showQuickPick(commands, { placeHolder: `BrighterScript Project Info` });
             await selection?.command();
         }));
+    }
+
+    private async focusLanguageServerOutputChannel() {
+        const commands = await vscode.commands.getCommands();
+        const command = commands.find(x => x.endsWith(LANGUAGE_SERVER_NAME));
+        if (command) {
+            void vscode.commands.executeCommand(command);
+        }
     }
 
     private async restartLanguageServer() {


### PR DESCRIPTION
Shows a busy spinner in the statusbar anytime the language server is busy.

Depends on https://github.com/rokucommunity/brighterscript/pull/852 being released.

![bsc-busy-spinner](https://github.com/rokucommunity/vscode-brightscript-language/assets/2544493/57736670-0c50-4629-83fa-401315d30b1e)
