### PR TITLE
Fix automation view crash when no config found

### DIFF
--- a/src/viewProviders/RokuAutomationViewViewProvider.ts
+++ b/src/viewProviders/RokuAutomationViewViewProvider.ts
@@ -113,23 +113,25 @@ export class RokuAutomationViewViewProvider extends BaseRdbViewProvider {
             return Promise.resolve(true);
         });
 
-        const config = this.rokuAutomationConfigs[index];
-        for (const [index, step] of config.steps.entries()) {
-            if (stopRunning) {
-                break;
-            }
+        const config = this.rokuAutomationConfigs?.[index];
+        if (config) {
+            for (const [index, step] of config.steps.entries()) {
+                if (stopRunning) {
+                    break;
+                }
 
-            this.updateCurrentRunningStep(index);
-            switch (step.type) {
-                case 'sleep':
-                    await utils.sleep(+step.value * 1000);
-                    break;
-                case 'sendText':
-                    await ecp.sendText(step.value);
-                    break;
-                case 'sendKeyPress':
-                    await ecp.sendKeyPress(step.value as any);
-                    break;
+                this.updateCurrentRunningStep(index);
+                switch (step.type) {
+                    case 'sleep':
+                        await utils.sleep(+step.value * 1000);
+                        break;
+                    case 'sendText':
+                        await ecp.sendText(step.value);
+                        break;
+                    case 'sendKeyPress':
+                        await ecp.sendKeyPress(step.value as any);
+                        break;
+                }
             }
         }
 


### PR DESCRIPTION
Fixes a behind-the-scenes crash in roku-automation-view when there is no config found.

(image of the crash before the fix)
![image](https://github.com/rokucommunity/vscode-brightscript-language/assets/2544493/f23df431-938b-4a55-a30f-7d1747eb015f)
