### PR TITLE
Make device picker name same as tree view item

### DIFF
--- a/src/DebugConfigurationProvider.ts
+++ b/src/DebugConfigurationProvider.ts
@@ -416,7 +416,7 @@ export class BrightScriptDebugConfigurationProvider implements DebugConfiguratio
                     // Create the Quick Picker option items
                     for (const key of Object.keys(activeDevices)) {
                         let device = activeDevices[key];
-                        let itemText = `${device.ip} | ${device.deviceInfo['default-device-name']} - ${device.deviceInfo['model-number']}`;
+                        let itemText = `${device.ip} | ${device.deviceInfo['user-device-name']} - ${device.deviceInfo['serial-number']} - ${device.deviceInfo['model-number']}`;
 
                         if (this.activeDeviceManager.lastUsedDevice && device.deviceInfo['default-device-name'] === this.activeDeviceManager.lastUsedDevice) {
                             items.unshift(itemText);


### PR DESCRIPTION
Aligns the name of the device in the device picker with the name from the devices tree view panel by adding in the user-defined name. 

**Before:**
![image](https://github.com/rokucommunity/vscode-brightscript-language/assets/2544493/fd473bd8-957d-42dc-aa34-eeecb61a14ab)


**After:**
![image](https://github.com/rokucommunity/vscode-brightscript-language/assets/2544493/ad97a8c3-507a-411d-bb4f-d5fae360b582)
