### PR TITLE
Auto-enable debug protocol on 12.5 devices

### DIFF
--- a/src/GlobalStateManager.ts
+++ b/src/GlobalStateManager.ts
@@ -12,7 +12,8 @@ export class GlobalStateManager {
         lastRunExtensionVersion: 'lastRunExtensionVersion',
         lastSeenReleaseNotesVersion: 'lastSeenReleaseNotesVersion',
         sendRemoteTextHistory: 'sendRemoteTextHistory',
-        suppressDebugProtocolAutoEnabledMessage: 'suppressDebugProtocolAutoEnabledMessage'
+        debugProtocolPopupSnoozeUntilDate: 'debugProtocolPopupSnoozeUntilDate',
+        debugProtocolPopupSnoozeValue: 'debugProtocolPopupSnoozeValue'
     };
     private remoteTextHistoryLimit: number;
     private remoteTextHistoryEnabled: boolean;
@@ -37,15 +38,25 @@ export class GlobalStateManager {
         void this.context.globalState.update(this.keys.lastSeenReleaseNotesVersion, value);
     }
 
-    /**
-     * Should the "we auto-enabled the debug protocol for you" message be suppressed? Defaults to false.
-     */
-    public get suppressDebugProtocolAutoEnabledMessage() {
-        return this.context.globalState.get<boolean>(this.keys.suppressDebugProtocolAutoEnabledMessage) === true;
+
+    public get debugProtocolPopupSnoozeUntilDate(): Date {
+        const epoch = this.context.globalState.get<number>(this.keys.debugProtocolPopupSnoozeUntilDate);
+        if (epoch) {
+            return new Date(epoch);
+        }
     }
-    public set suppressDebugProtocolAutoEnabledMessage(value: boolean) {
-        void this.context.globalState.update(this.keys.suppressDebugProtocolAutoEnabledMessage, value);
+    public set debugProtocolPopupSnoozeUntilDate(value: Date) {
+        void this.context.globalState.update(this.keys.debugProtocolPopupSnoozeUntilDate, value?.getTime());
     }
+
+
+    public get debugProtocolPopupSnoozeValue(): boolean {
+        return this.context.globalState.get<boolean>(this.keys.debugProtocolPopupSnoozeValue);
+    }
+    public set debugProtocolPopupSnoozeValue(value: boolean) {
+        void this.context.globalState.update(this.keys.debugProtocolPopupSnoozeValue, value);
+    }
+
 
     public get sendRemoteTextHistory(): string[] {
         return this.context.globalState.get(this.keys.sendRemoteTextHistory) ?? [];

--- a/src/GlobalStateManager.ts
+++ b/src/GlobalStateManager.ts
@@ -11,7 +11,8 @@ export class GlobalStateManager {
     private keys = {
         lastRunExtensionVersion: 'lastRunExtensionVersion',
         lastSeenReleaseNotesVersion: 'lastSeenReleaseNotesVersion',
-        sendRemoteTextHistory: 'sendRemoteTextHistory'
+        sendRemoteTextHistory: 'sendRemoteTextHistory',
+        suppressDebugProtocolAutoEnabledMessage: 'suppressDebugProtocolAutoEnabledMessage'
     };
     private remoteTextHistoryLimit: number;
     private remoteTextHistoryEnabled: boolean;
@@ -36,10 +37,19 @@ export class GlobalStateManager {
         void this.context.globalState.update(this.keys.lastSeenReleaseNotesVersion, value);
     }
 
+    /**
+     * Should the "we auto-enabled the debug protocol for you" message be suppressed? Defaults to false.
+     */
+    public get suppressDebugProtocolAutoEnabledMessage() {
+        return this.context.globalState.get<boolean>(this.keys.suppressDebugProtocolAutoEnabledMessage) === true;
+    }
+    public set suppressDebugProtocolAutoEnabledMessage(value: boolean) {
+        void this.context.globalState.update(this.keys.suppressDebugProtocolAutoEnabledMessage, value);
+    }
+
     public get sendRemoteTextHistory(): string[] {
         return this.context.globalState.get(this.keys.sendRemoteTextHistory) ?? [];
     }
-
     public set sendRemoteTextHistory(history: string[]) {
         history ??= [];
         // only update the results if the user has the the history enabled

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -1,0 +1,8 @@
+import * as fsExtra from 'fs-extra';
+
+export let ROKU_DEBUG_VERSION: string;
+try {
+    ROKU_DEBUG_VERSION = fsExtra.readJsonSync(__dirname + '/../node_modules/roku-debug/package.json').version;
+} catch (e) { }
+
+export const EXTENSION_ID = 'RokuCommunity.brightscript';

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -130,7 +130,7 @@ export class Extension {
         );
 
         //register the debug configuration provider
-        let configProvider = new BrightScriptDebugConfigurationProvider(context, activeDeviceManager, this.telemetryManager, this.extensionOutputChannel);
+        let configProvider = new BrightScriptDebugConfigurationProvider(context, activeDeviceManager, this.telemetryManager, this.extensionOutputChannel, this.globalStateManager);
         context.subscriptions.push(
             vscode.debug.registerDebugConfigurationProvider('brightscript', configProvider)
         );

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -27,8 +27,7 @@ import { RtaManager } from './managers/RtaManager';
 import { WebviewViewProviderManager } from './managers/WebviewViewProviderManager';
 import { ViewProviderId } from './viewProviders/ViewProviderId';
 import { DiagnosticManager } from './managers/DiagnosticManager';
-
-const EXTENSION_ID = 'RokuCommunity.brightscript';
+import { EXTENSION_ID } from './constants';
 
 export class Extension {
     public outputChannel: vscode.OutputChannel;

--- a/src/managers/TelemetryManager.ts
+++ b/src/managers/TelemetryManager.ts
@@ -32,18 +32,29 @@ export class TelemetryManager implements Disposable {
     /**
      * Track when a debug session has been started
      */
-    public sendStartDebugSessionEvent(event: BrightScriptLaunchConfiguration & { preLaunchTask: string }, deviceInfo?: DeviceInfo) {
+    public sendStartDebugSessionEvent(initialConfig: BrightScriptLaunchConfiguration & { preLaunchTask: string }, finalConfig: BrightScriptLaunchConfiguration, deviceInfo?: DeviceInfo) {
+        let debugConnectionType: 'debugProtocol' | 'telnet';
+        let enableDebugProtocol = finalConfig?.enableDebugProtocol ?? initialConfig?.enableDebugProtocol;
+        if (enableDebugProtocol === true) {
+            debugConnectionType = 'debugProtocol';
+        } else if (enableDebugProtocol === false) {
+            debugConnectionType = 'telnet';
+        } else {
+            debugConnectionType = undefined;
+        }
+
         this.reporter.sendTelemetryEvent('startDebugSession', {
-            enableDebugProtocol: boolToString(event.enableDebugProtocol),
-            retainDeploymentArchive: boolToString(event.retainDeploymentArchive),
-            retainStagingFolder: boolToString(event.retainStagingFolder),
-            injectRaleTrackerTask: boolToString(event.injectRaleTrackerTask),
-            isFilesDefined: isDefined(event.files),
-            isPreLaunchTaskDefined: isDefined(event.preLaunchTask),
-            isComponentLibrariesDefined: isDefined(event.componentLibraries),
-            isDeepLinkUrlDefined: isDefined(event.deepLinkUrl),
-            isStagingFolderPathDefined: isDefined(event.stagingFolderPath),
-            isLogfilePathDefined: isDefined(event.logfilePath),
+            enableDebugProtocol: boolToString(initialConfig.enableDebugProtocol),
+            debugConnectionType: debugConnectionType?.toString(),
+            retainDeploymentArchive: boolToString(initialConfig.retainDeploymentArchive),
+            retainStagingFolder: boolToString(initialConfig.retainStagingFolder),
+            injectRaleTrackerTask: boolToString(initialConfig.injectRaleTrackerTask),
+            isFilesDefined: isDefined(initialConfig.files),
+            isPreLaunchTaskDefined: isDefined(initialConfig.preLaunchTask),
+            isComponentLibrariesDefined: isDefined(initialConfig.componentLibraries),
+            isDeepLinkUrlDefined: isDefined(initialConfig.deepLinkUrl),
+            isStagingFolderPathDefined: isDefined(initialConfig.stagingFolderPath),
+            isLogfilePathDefined: isDefined(initialConfig.logfilePath),
             isExtensionLogfilePathDefined: isDefined(
                 vscode.workspace.getConfiguration('brightscript').get<string>('extensionLogfilePath')
             ),

--- a/src/mockVscode.spec.ts
+++ b/src/mockVscode.spec.ts
@@ -206,6 +206,9 @@ export let vscode = {
             } as OutputChannel;
         },
         registerTreeDataProvider: function(viewId: string, treeDataProvider: TreeDataProvider<any>) { },
+        showWarningMessage: function(message: string) {
+
+        },
         showErrorMessage: function(message: string) {
 
         },

--- a/src/mockVscode.spec.ts
+++ b/src/mockVscode.spec.ts
@@ -206,6 +206,9 @@ export let vscode = {
             } as OutputChannel;
         },
         registerTreeDataProvider: function(viewId: string, treeDataProvider: TreeDataProvider<any>) { },
+        showInformationMessage: function(message: string) {
+
+        },
         showWarningMessage: function(message: string) {
 
         },

--- a/src/util.ts
+++ b/src/util.ts
@@ -5,6 +5,9 @@ import * as url from 'url';
 import { debounce } from 'debounce';
 import * as vscode from 'vscode';
 import { Cache } from 'brighterscript/dist/Cache';
+import undent from 'undent';
+import { EXTENSION_ID, ROKU_DEBUG_VERSION } from './constants';
+import type { DeviceInfo } from 'roku-deploy';
 
 class Util {
     public async readDir(dirPath: string) {
@@ -380,6 +383,31 @@ class Util {
      */
     public escapeRegex(text: string) {
         return text?.toString().replace(/[-\/\\^$*+?.()|[\]{}]/g, '\\$&');
+    }
+
+    public async openIssueReporter(options: { title?: string; body?: string; deviceInfo?: DeviceInfo }) {
+        if (!options.body) {
+            options.body = undent`
+                Please describe the issue you are experiencing:
+
+                Steps to reproduce:
+
+                Additional feedback:
+            `;
+        }
+        options.body += `\n\nroku-debug version: ${ROKU_DEBUG_VERSION}`;
+        if (options.deviceInfo) {
+            options.body += '\n' + undent`
+                Device firmware: ${options.deviceInfo.softwareVersion}.${options.deviceInfo.softwareBuild}
+                Debug protocol version: ${options.deviceInfo.brightscriptDebuggerVersion}
+                Device model: ${options.deviceInfo.modelNumber}
+            `;
+        }
+        await vscode.commands.executeCommand('vscode.openIssueReporter', {
+            extensionId: EXTENSION_ID,
+            issueTitle: options.title ?? 'Problem with Debug Protocol',
+            issueBody: options.body
+        });
     }
 }
 


### PR DESCRIPTION
Auto-enables the debug protocol for any launch to a 12.5 devices that doesn't explicitly have `enableDebugProtocol` defined. 

We intend on running this as a trial period for a week to see what issues are uncovered. If the test goes smoothly, we'll leave this feature enabled indefinitely. If issues are discovered, we'll disable the protocol until we can fix the issues and then try again in the future. The goal of this is to tell the user we've enabled the protocol, but still give them an option for using telnet instead. However, it's in the user's best interest to give the debug protocol a thorough test, because it _will_ become the default debug mode in the near future. 


Users are presented with this popup:

![image](https://github.com/rokucommunity/vscode-brightscript-language/assets/2544493/846ed0f8-86bf-4edf-87f2-77aacd800f17)

Then after 2  clicks of the "Use telnet" button, we switch to this so the user can hide the popup for 12 hours.
![image](https://github.com/rokucommunity/vscode-brightscript-language/assets/2544493/63fe6aa9-c079-426e-826e-2a734f95a253)

here's the "report issue" dialog:
![image](https://github.com/rokucommunity/vscode-brightscript-language/assets/2544493/bd5447e0-e258-4684-95b2-f2dbdcaa3728)
