### PR TITLE
Better messaging around debugProtocol popup

### DIFF
--- a/src/DebugConfigurationProvider.spec.ts
+++ b/src/DebugConfigurationProvider.spec.ts
@@ -477,14 +477,14 @@ describe('BrightScriptConfigurationProvider', () => {
         });
 
         it('sets true and flips global state when clicked "okay"', async () => {
-            value = `Okay (and dont warn again)`;
+            value = `Okay (ask less often)`;
             expect(globalStateManager.debugProtocolPopupSnoozeUntilDate).to.eql(undefined);
             const config = await configProvider['processEnableDebugProtocolParameter']({} as any, { softwareVersion: '12.5.0' });
             expect(config.enableDebugProtocol).to.eql(true);
             //2 weeks after now
             expect(
                 globalStateManager.debugProtocolPopupSnoozeUntilDate.getTime()
-            ).closeTo(Date.now() + (14 * 24 * 60 * 60 * 1000), 1000);
+            ).closeTo(Date.now() + (12 * 60 * 60 * 1000), 1000);
             expect(globalStateManager.debugProtocolPopupSnoozeValue).to.eql(true);
         });
 
@@ -506,26 +506,12 @@ describe('BrightScriptConfigurationProvider', () => {
         });
 
         it('sets to true and does not prompt when "dont show again" was clicked', async () => {
-            value = `Okay (and dont warn again)`;
+            value = `Okay (ask less often)`;
             globalStateManager.debugProtocolPopupSnoozeUntilDate = new Date(Date.now() + (60 * 1000));
             globalStateManager.debugProtocolPopupSnoozeValue = true;
             let config = await configProvider['processEnableDebugProtocolParameter']({} as any, { softwareVersion: '12.5.0' });
             expect(config.enableDebugProtocol).to.eql(true);
             expect(stub.called).to.be.false;
-        });
-
-        it('shows the alternate telnet prompt after 2 debug sessions', async () => {
-            value = `Use telnet`;
-
-            await configProvider['processEnableDebugProtocolParameter']({} as any, { softwareVersion: '12.5.0' });
-            expect(stub.getCall(stub.callCount - 1).args[4]).to.eql('Use telnet');
-
-            await configProvider['processEnableDebugProtocolParameter']({} as any, { softwareVersion: '12.5.0' });
-            expect(stub.getCall(stub.callCount - 1).args[4]).to.eql('Use telnet');
-
-            value = 'Use telnet (and ask less often)';
-            await configProvider['processEnableDebugProtocolParameter']({} as any, { softwareVersion: '12.5.0' });
-            expect(stub.getCall(stub.callCount - 1).args[4]).to.eql('Use telnet (and ask less often)');
         });
 
         it('shows the issue picker when selected', async () => {

--- a/src/DebugConfigurationProvider.ts
+++ b/src/DebugConfigurationProvider.ts
@@ -83,11 +83,6 @@ export class BrightScriptDebugConfigurationProvider implements DebugConfiguratio
     private configDefaults: any;
 
     /**
-     * A counter used to track how often the user clicks the "use telnet" button in the popup
-     */
-    private useTelnetCounter = 0;
-
-    /**
      * Massage a debug configuration just before a debug session is being launched,
      * e.g. add all missing attributes to the debug configuration.
      */
@@ -153,22 +148,19 @@ export class BrightScriptDebugConfigurationProvider implements DebugConfiguratio
         //enable the debug protocol by default if the user hasn't defined this prop, and the target RokuOS is 12.5 or greater
         const result = await vscode.window.showInformationMessage('New Debug Protocol Enabled', {
             modal: true,
-            detail: `We've activated Roku's debug protocol for this session. This will become the default choice in the future and may be implemented without additional notice. Your feedback during this testing phase is invaluable.`
-        }, 'Okay', `Okay (and dont warn again)`, this.useTelnetCounter < 2 ? 'Use telnet' : 'Use telnet (and ask less often)', 'Report an issue');
-
+            detail: `We've activated Roku's debug protocol for this session (an alternative to the telnet debugger). This will become the default choice sometime in the future and may be implemented without additional notice. Your feedback during this testing phase is invaluable.`
+        }, 'Okay', `Okay (ask less often)`, 'Use telnet', 'Use telnet (ask less often)', 'Report an issue');
 
         if (result === 'Okay') {
             config.enableDebugProtocol = true;
-        } else if (result === `Okay (and dont warn again)`) {
+        } else if (result === `Okay (ask less often)`) {
             config.enableDebugProtocol = true;
             this.globalStateManager.debugProtocolPopupSnoozeValue = config.enableDebugProtocol;
             //snooze for 2 weeks
-            this.globalStateManager.debugProtocolPopupSnoozeUntilDate = new Date(Date.now() + (14 * 24 * 60 * 60 * 1000));
+            this.globalStateManager.debugProtocolPopupSnoozeUntilDate = new Date(Date.now() + (12 * 60 * 60 * 1000));
         } else if (result === 'Use telnet') {
-            this.useTelnetCounter++;
             config.enableDebugProtocol = false;
-        } else if (result === 'Use telnet (and ask less often)') {
-            this.useTelnetCounter = 0;
+        } else if (result === 'Use telnet (ask less often)') {
             config.enableDebugProtocol = false;
             this.globalStateManager.debugProtocolPopupSnoozeValue = config.enableDebugProtocol;
             //snooze for 12 hours


### PR DESCRIPTION
- Always show the "ask less often" option for telnet.
- change the debug protocol "ask less often" choice to 12 hours (was 2 weeks)
- add slight explanation about what debug protocol is

![image](https://github.com/rokucommunity/vscode-brightscript-language/assets/2544493/e275e500-9fc4-471a-976e-3aaa6c140e94)

