### PR TITLE
Move common user input into a dedicated manager

### DIFF
--- a/src/DebugConfigurationProvider.spec.ts
+++ b/src/DebugConfigurationProvider.spec.ts
@@ -3,15 +3,13 @@ import * as path from 'path';
 import type { SinonStub } from 'sinon';
 import { createSandbox } from 'sinon';
 import type { WorkspaceFolder } from 'vscode';
-import { QuickPickItemKind } from 'vscode';
 import Uri from 'vscode-uri';
 import type { BrightScriptLaunchConfiguration } from './DebugConfigurationProvider';
-import { manualHostItemId } from './DebugConfigurationProvider';
+import { UserInputManager } from './managers/UserInputManager';
 import { BrightScriptDebugConfigurationProvider } from './DebugConfigurationProvider';
 import { vscode } from './mockVscode.spec';
 import { standardizePath as s } from 'brighterscript';
 import * as fsExtra from 'fs-extra';
-import type { RokuDeviceDetails } from './ActiveDeviceManager';
 import { ActiveDeviceManager } from './ActiveDeviceManager';
 import { rokuDeploy } from 'roku-deploy';
 import { GlobalStateManager } from './GlobalStateManager';
@@ -38,6 +36,7 @@ describe('BrightScriptConfigurationProvider', () => {
     let configProvider: BrightScriptDebugConfigurationProvider;
     let folder: WorkspaceFolder;
     let globalStateManager: GlobalStateManager;
+    let userInputManager: UserInputManager;
 
     beforeEach(() => {
         fsExtra.emptyDirSync(tempDir);
@@ -52,13 +51,15 @@ describe('BrightScriptConfigurationProvider', () => {
         //prevent the 'start' method from actually running
         sinon.stub(ActiveDeviceManager.prototype as any, 'start').callsFake(() => { });
         let activeDeviceManager = new ActiveDeviceManager();
+        userInputManager = new UserInputManager(activeDeviceManager);
 
         configProvider = new BrightScriptDebugConfigurationProvider(
             vscode.context,
             activeDeviceManager,
             null,
             vscode.window.createOutputChannel('Extension'),
-            globalStateManager
+            globalStateManager,
+            userInputManager
         );
     });
 
@@ -329,135 +330,6 @@ describe('BrightScriptConfigurationProvider', () => {
                 rootDir: '${env:TEST_ENV_VAR}/123'
             });
             expect(config.rootDir).to.eql('./somePath/123');
-        });
-    });
-
-    describe('createHostQuickPickList', () => {
-        const devices: Array<RokuDeviceDetails> = [{
-            deviceInfo: {
-                'user-device-name': 'roku1',
-                'serial-number': 'alpha',
-                'model-number': 'model1'
-            },
-            id: '1',
-            ip: '1.1.1.1',
-            location: '???'
-        }, {
-            deviceInfo: {
-                'user-device-name': 'roku2',
-                'serial-number': 'beta',
-                'model-number': 'model2'
-            },
-            id: '2',
-            ip: '1.1.1.2',
-            location: '???'
-        }, {
-            deviceInfo: {
-                'user-device-name': 'roku3',
-                'serial-number': 'charlie',
-                'model-number': 'model3'
-            },
-            id: '3',
-            ip: '1.1.1.3',
-            location: '???'
-        }];
-        function label(device: RokuDeviceDetails) {
-            return `${device.ip} | ${device.deviceInfo['user-device-name']} - ${device.deviceInfo['serial-number']} - ${device.deviceInfo['model-number']}`;
-        }
-
-        it('includes "manual', () => {
-            expect(
-                configProvider['createHostQuickPickList']([], undefined)
-            ).to.eql([{
-                label: 'Enter manually',
-                device: {
-                    id: manualHostItemId
-                }
-            }]);
-        });
-
-        it('includes separators for devices and manual options', () => {
-            expect(
-                configProvider['createHostQuickPickList']([devices[0]], undefined)
-            ).to.eql([
-                {
-                    kind: QuickPickItemKind.Separator,
-                    label: 'devices'
-                },
-                {
-                    label: '1.1.1.1 | roku1 - alpha - model1',
-                    device: devices[0]
-                },
-                {
-                    kind: QuickPickItemKind.Separator,
-                    label: ' '
-                }, {
-                    label: 'Enter manually',
-                    device: {
-                        id: manualHostItemId
-                    }
-                }]
-            );
-        });
-
-        it('moves active device to the top', () => {
-            expect(
-                configProvider['createHostQuickPickList']([devices[0], devices[1], devices[2]], devices[1]).map(x => x.label)
-            ).to.eql([
-                'last used',
-                label(devices[1]),
-                'other devices',
-                label(devices[0]),
-                label(devices[2]),
-                ' ',
-                'Enter manually'
-            ]);
-        });
-
-        it('includes the spinner text when "last used" and "other devices" separators are both present', () => {
-            expect(
-                configProvider['createHostQuickPickList'](devices, devices[1]).map(x => x.label)
-            ).to.eql([
-                'last used',
-                label(devices[1]),
-                'other devices',
-                label(devices[0]),
-                label(devices[2]),
-                ' ',
-                'Enter manually'
-            ]);
-        });
-
-        it('includes the spinner text if "devices" separator is present', () => {
-            expect(
-                configProvider['createHostQuickPickList'](devices, null).map(x => x.label)
-            ).to.eql([
-                'devices',
-                label(devices[0]),
-                label(devices[1]),
-                label(devices[2]),
-                ' ',
-                'Enter manually'
-            ]);
-        });
-
-        it('includes the spinner text if only "last used" separator is present', () => {
-            expect(
-                configProvider['createHostQuickPickList']([devices[0]], devices[0]).map(x => x.label)
-            ).to.eql([
-                'last used',
-                label(devices[0]),
-                ' ',
-                'Enter manually'
-            ]);
-        });
-
-        it('includes the spinner text when no other device entries are present', () => {
-            expect(
-                configProvider['createHostQuickPickList']([], null).map(x => x.label)
-            ).to.eql([
-                'Enter manually'
-            ]);
         });
     });
 

--- a/src/DebugConfigurationProvider.ts
+++ b/src/DebugConfigurationProvider.ts
@@ -1,4 +1,4 @@
-import { Deferred, util as bslangUtil } from 'brighterscript';
+import { util as bslangUtil } from 'brighterscript';
 import * as semver from 'semver';
 import * as dotenv from 'dotenv';
 import * as path from 'path';
@@ -8,9 +8,7 @@ import * as rta from 'roku-test-automation';
 import type {
     CancellationToken,
     DebugConfigurationProvider,
-    Disposable,
     ExtensionContext,
-    QuickPickItem,
     WorkspaceFolder
 } from 'vscode';
 import * as vscode from 'vscode';
@@ -18,18 +16,14 @@ import type { LaunchConfiguration } from 'roku-debug';
 import { fileUtils } from 'roku-debug';
 import { util } from './util';
 import type { TelemetryManager } from './managers/TelemetryManager';
-import type { ActiveDeviceManager, RokuDeviceDetails } from './ActiveDeviceManager';
+import type { ActiveDeviceManager } from './ActiveDeviceManager';
 // eslint-disable-next-line @typescript-eslint/no-require-imports
 import cloneDeep = require('clone-deep');
 import { rokuDeploy } from 'roku-deploy';
 import type { DeviceInfo } from 'roku-deploy';
 import type { GlobalStateManager } from './GlobalStateManager';
+import type { UserInputManager } from './managers/UserInputManager';
 
-/**
- * An id to represent the "Enter manually" option in the host picker
- */
-export const manualHostItemId = `${Number.MAX_SAFE_INTEGER}`;
-const manualLabel = 'Enter manually';
 
 export class BrightScriptDebugConfigurationProvider implements DebugConfigurationProvider {
 
@@ -38,7 +32,8 @@ export class BrightScriptDebugConfigurationProvider implements DebugConfiguratio
         private activeDeviceManager: ActiveDeviceManager,
         private telemetryManager: TelemetryManager,
         private extensionOutputChannel: vscode.OutputChannel,
-        private globalStateManager: GlobalStateManager
+        private globalStateManager: GlobalStateManager,
+        private userInputManager: UserInputManager
     ) {
         this.context = context;
         this.activeDeviceManager = activeDeviceManager;
@@ -456,10 +451,6 @@ export class BrightScriptDebugConfigurationProvider implements DebugConfiguratio
         return config;
     }
 
-    private async promptForHostManual() {
-        return this.openInputBox('The IP address of your Roku device');
-    }
-
     /**
      * Validates the host parameter in the config and opens an input ui if set to ${promptForHost}
      * @param config  current config object
@@ -467,9 +458,9 @@ export class BrightScriptDebugConfigurationProvider implements DebugConfiguratio
     private async processHostParameter(config: BrightScriptLaunchConfiguration): Promise<BrightScriptLaunchConfiguration> {
         if (config.host.trim() === '${promptForHost}' || (config?.deepLinkUrl?.includes('${promptForHost}'))) {
             if (this.activeDeviceManager.enabled) {
-                config.host = await this.promptForHost();
+                config.host = await this.userInputManager.promptForHost();
             } else {
-                config.host = await this.promptForHostManual();
+                config.host = await this.userInputManager.promptForHostManual();
             }
         }
 
@@ -481,192 +472,6 @@ export class BrightScriptDebugConfigurationProvider implements DebugConfiguratio
         }
 
         return config;
-    }
-
-    /**
-     * Prompt the user to pick a host from a list of devices
-     */
-    private async promptForHost() {
-        const deferred = new Deferred<{ ip: string; manual?: boolean } | { ip?: string; manual: true }>();
-        const disposables: Array<Disposable> = [];
-
-        const discoveryTime = 5_000;
-
-        //create the quickpick item
-        const quickPick = vscode.window.createQuickPick();
-        disposables.push(quickPick);
-        quickPick.placeholder = `Please Select a Roku or manually type an IP address`;
-        quickPick.keepScrollPosition = true;
-
-        function dispose() {
-            for (const disposable of disposables) {
-                disposable.dispose();
-            }
-        }
-
-        //detect if the user types an IP address into the picker and presses enter.
-        quickPick.onDidAccept(() => {
-            deferred.resolve({
-                ip: quickPick.value
-            });
-        });
-
-        let activeChangesSinceRefresh = 0;
-        let activeItem: QuickPickItem;
-
-        // remember the currently active item so we can maintain active selection when refreshing the list
-        quickPick.onDidChangeActive((items) => {
-            // reset our activeChanges tracker since users cannot cause items.length to be 0 (meaning a refresh has just happened)
-            if (items.length === 0) {
-                activeChangesSinceRefresh = 0;
-                return;
-            }
-            if (activeChangesSinceRefresh > 0) {
-                activeItem = items[0];
-            }
-            activeChangesSinceRefresh++;
-        });
-
-        const itemCache = new Map<string, QuickPickHostItem>();
-        quickPick.show();
-        const refreshList = () => {
-            const items = this.createHostQuickPickList(
-                this.activeDeviceManager.getActiveDevices(),
-                this.activeDeviceManager.lastUsedDevice,
-                itemCache
-            );
-            quickPick.items = items;
-
-            // update the busy spinner based on how long it's been since the last discovered device
-            quickPick.busy = this.activeDeviceManager.timeSinceLastDiscoveredDevice < discoveryTime;
-            setTimeout(() => {
-                quickPick.busy = this.activeDeviceManager.timeSinceLastDiscoveredDevice < discoveryTime;
-            }, discoveryTime - this.activeDeviceManager.timeSinceLastDiscoveredDevice + 20);
-
-            // clear the activeItem if we can't find it in the list
-            if (!quickPick.items.includes(activeItem)) {
-                activeItem = undefined;
-            }
-
-            // if the user manually selected an item, re-focus that item now that we refreshed the list
-            if (activeItem) {
-                quickPick.activeItems = [activeItem];
-            }
-            // quickPick.show();
-        };
-
-        //anytime the device picker adds/removes a device, update the list
-        this.activeDeviceManager.on('device-found', refreshList, disposables);
-        this.activeDeviceManager.on('device-expired', refreshList, disposables);
-
-        quickPick.onDidHide(() => {
-            dispose();
-            deferred.reject(new Error('No host was selected'));
-        });
-
-        quickPick.onDidChangeSelection(selection => {
-            const selectedItem = selection[0];
-            if (selectedItem) {
-                if (selectedItem.kind === vscode.QuickPickItemKind.Separator) {
-                    // Handle separator selection
-                } else {
-                    if (selectedItem.label === manualLabel) {
-                        deferred.resolve({ manual: true });
-                    } else {
-                        const device = (selectedItem as any).device as RokuDeviceDetails;
-                        this.activeDeviceManager.lastUsedDevice = device;
-                        deferred.resolve(device);
-                    }
-                    quickPick.dispose();
-                }
-            }
-        });
-        //run the list refresh once to show the popup
-        refreshList();
-        const result = await deferred.promise;
-        dispose();
-        if (result?.manual === true) {
-            return this.promptForHostManual();
-        } else {
-            return result?.ip;
-        }
-    }
-
-    /**
-     * Generate the label used when showing "host" entries in a quick picker
-     * @param device the device containing all the info
-     * @returns a properly formatted host string
-     */
-    private createHostLabel(device: RokuDeviceDetails) {
-        return `${device.ip} | ${device.deviceInfo['user-device-name']} - ${device.deviceInfo['serial-number']} - ${device.deviceInfo['model-number']}`;
-    }
-
-    /**
-     * Generate the item list for the `this.promptForHost()` call
-     */
-    private createHostQuickPickList(devices: RokuDeviceDetails[], lastUsedDevice: RokuDeviceDetails, cache = new Map<string, QuickPickHostItem>()) {
-        //the collection of items we will eventually return
-        let items: QuickPickHostItem[] = [];
-
-        //find the lastUsedDevice from the devices list if possible, or use the data from the lastUsedDevice if not
-        lastUsedDevice = devices.find(x => x.id === lastUsedDevice?.id) ?? lastUsedDevice;
-        //remove the lastUsedDevice from the devices list so we can more easily reason with the rest of the list
-        devices = devices.filter(x => x.id !== lastUsedDevice?.id);
-
-        // Ensure the most recently used device is at the top of the list
-        if (lastUsedDevice) {
-            //add a separator for "last used"
-            items.push({
-                label: 'last used',
-                kind: vscode.QuickPickItemKind.Separator
-            });
-
-            //add the device
-            items.push({
-                label: this.createHostLabel(lastUsedDevice),
-                device: lastUsedDevice
-            });
-        }
-
-        //add all other devices
-        if (devices.length > 0) {
-            items.push({
-                label: lastUsedDevice ? 'other devices' : 'devices',
-                kind: vscode.QuickPickItemKind.Separator
-            });
-
-            //add each device
-            for (const device of devices) {
-                //add the device
-                items.push({
-                    label: this.createHostLabel(device),
-                    device: device
-                });
-            }
-        }
-
-        //include a divider between devices and "manual" option (only if we have devices)
-        if (lastUsedDevice || devices.length) {
-            items.push({ label: ' ', kind: vscode.QuickPickItemKind.Separator });
-        }
-
-        // allow user to manually type an IP address
-        items.push(
-            { label: 'Enter manually', device: { id: manualHostItemId } } as any
-        );
-
-        // replace items with their cached versions if found (to maintain references)
-        for (let i = 0; i < items.length; i++) {
-            const item = items[i];
-            if (cache.has(item.label)) {
-                items[i] = cache.get(item.label);
-                items[i].device = item.device;
-            } else {
-                cache.set(item.label, item);
-            }
-        }
-
-        return items;
     }
 
     /**
@@ -787,5 +592,3 @@ export interface BrightScriptLaunchConfiguration extends LaunchConfiguration {
      */
     remoteControlMode?: { activateOnSessionStart?: boolean; deactivateOnSessionEnd?: boolean };
 }
-
-type QuickPickHostItem = QuickPickItem & { device?: RokuDeviceDetails };

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -28,6 +28,7 @@ import { WebviewViewProviderManager } from './managers/WebviewViewProviderManage
 import { ViewProviderId } from './viewProviders/ViewProviderId';
 import { DiagnosticManager } from './managers/DiagnosticManager';
 import { EXTENSION_ID } from './constants';
+import { UserInputManager } from './managers/UserInputManager';
 
 export class Extension {
     public outputChannel: vscode.OutputChannel;
@@ -63,6 +64,9 @@ export class Extension {
 
         this.telemetryManager.sendStartupEvent();
         let activeDeviceManager = new ActiveDeviceManager();
+        let userInputManager = new UserInputManager(
+            activeDeviceManager
+        );
 
         this.remoteControlManager = new RemoteControlManager(this.telemetryManager);
         this.brightScriptCommands = new BrightScriptCommands(
@@ -132,7 +136,7 @@ export class Extension {
         );
 
         //register the debug configuration provider
-        let configProvider = new BrightScriptDebugConfigurationProvider(context, activeDeviceManager, this.telemetryManager, this.extensionOutputChannel, this.globalStateManager);
+        let configProvider = new BrightScriptDebugConfigurationProvider(context, activeDeviceManager, this.telemetryManager, this.extensionOutputChannel, this.globalStateManager, userInputManager);
         context.subscriptions.push(
             vscode.debug.registerDebugConfigurationProvider('brightscript', configProvider)
         );

--- a/src/managers/UserInputManager.spec.ts
+++ b/src/managers/UserInputManager.spec.ts
@@ -1,0 +1,173 @@
+import { expect } from 'chai';
+import * as path from 'path';
+import { createSandbox } from 'sinon';
+import { QuickPickItemKind } from 'vscode';
+import { UserInputManager, manualHostItemId } from './UserInputManager';
+import { vscode } from '../mockVscode.spec';
+import { standardizePath as s } from 'brighterscript';
+import * as fsExtra from 'fs-extra';
+import type { RokuDeviceDetails } from '../ActiveDeviceManager';
+import { ActiveDeviceManager } from '../ActiveDeviceManager';
+
+const sinon = createSandbox();
+const Module = require('module');
+const cwd = s`${path.dirname(__dirname)}`;
+const tempDir = s`${cwd}/.tmp`;
+
+//override the "require" call to mock certain items
+const { require: oldRequire } = Module.prototype;
+Module.prototype.require = function hijacked(file) {
+    if (file === 'vscode') {
+        return vscode;
+    } else {
+        return oldRequire.apply(this, arguments);
+    }
+};
+
+describe('UserInputManager', () => {
+
+    let userInputManager: UserInputManager;
+
+    beforeEach(() => {
+        fsExtra.emptyDirSync(tempDir);
+
+        //prevent the 'start' method from actually running
+        sinon.stub(ActiveDeviceManager.prototype as any, 'start').callsFake(() => { });
+        let activeDeviceManager = new ActiveDeviceManager();
+        userInputManager = new UserInputManager(activeDeviceManager);
+    });
+
+    afterEach(() => {
+        fsExtra.emptyDirSync(tempDir);
+        sinon.restore();
+    });
+
+    describe('createHostQuickPickList', () => {
+        const devices: Array<RokuDeviceDetails> = [{
+            deviceInfo: {
+                'user-device-name': 'roku1',
+                'serial-number': 'alpha',
+                'model-number': 'model1'
+            },
+            id: '1',
+            ip: '1.1.1.1',
+            location: '???'
+        }, {
+            deviceInfo: {
+                'user-device-name': 'roku2',
+                'serial-number': 'beta',
+                'model-number': 'model2'
+            },
+            id: '2',
+            ip: '1.1.1.2',
+            location: '???'
+        }, {
+            deviceInfo: {
+                'user-device-name': 'roku3',
+                'serial-number': 'charlie',
+                'model-number': 'model3'
+            },
+            id: '3',
+            ip: '1.1.1.3',
+            location: '???'
+        }];
+        function label(device: RokuDeviceDetails) {
+            return `${device.ip} | ${device.deviceInfo['user-device-name']} - ${device.deviceInfo['serial-number']} - ${device.deviceInfo['model-number']}`;
+        }
+
+        it('includes "manual', () => {
+            expect(
+                userInputManager['createHostQuickPickList']([], undefined)
+            ).to.eql([{
+                label: 'Enter manually',
+                device: {
+                    id: manualHostItemId
+                }
+            }]);
+        });
+
+        it('includes separators for devices and manual options', () => {
+            expect(
+                userInputManager['createHostQuickPickList']([devices[0]], undefined)
+            ).to.eql([
+                {
+                    kind: QuickPickItemKind.Separator,
+                    label: 'devices'
+                },
+                {
+                    label: '1.1.1.1 | roku1 - alpha - model1',
+                    device: devices[0]
+                },
+                {
+                    kind: QuickPickItemKind.Separator,
+                    label: ' '
+                }, {
+                    label: 'Enter manually',
+                    device: {
+                        id: manualHostItemId
+                    }
+                }]
+            );
+        });
+
+        it('moves active device to the top', () => {
+            expect(
+                userInputManager['createHostQuickPickList']([devices[0], devices[1], devices[2]], devices[1]).map(x => x.label)
+            ).to.eql([
+                'last used',
+                label(devices[1]),
+                'other devices',
+                label(devices[0]),
+                label(devices[2]),
+                ' ',
+                'Enter manually'
+            ]);
+        });
+
+        it('includes the spinner text when "last used" and "other devices" separators are both present', () => {
+            expect(
+                userInputManager['createHostQuickPickList'](devices, devices[1]).map(x => x.label)
+            ).to.eql([
+                'last used',
+                label(devices[1]),
+                'other devices',
+                label(devices[0]),
+                label(devices[2]),
+                ' ',
+                'Enter manually'
+            ]);
+        });
+
+        it('includes the spinner text if "devices" separator is present', () => {
+            expect(
+                userInputManager['createHostQuickPickList'](devices, null).map(x => x.label)
+            ).to.eql([
+                'devices',
+                label(devices[0]),
+                label(devices[1]),
+                label(devices[2]),
+                ' ',
+                'Enter manually'
+            ]);
+        });
+
+        it('includes the spinner text if only "last used" separator is present', () => {
+            expect(
+                userInputManager['createHostQuickPickList']([devices[0]], devices[0]).map(x => x.label)
+            ).to.eql([
+                'last used',
+                label(devices[0]),
+                ' ',
+                'Enter manually'
+            ]);
+        });
+
+        it('includes the spinner text when no other device entries are present', () => {
+            expect(
+                userInputManager['createHostQuickPickList']([], null).map(x => x.label)
+            ).to.eql([
+                'Enter manually'
+            ]);
+        });
+    });
+});

--- a/src/managers/UserInputManager.ts
+++ b/src/managers/UserInputManager.ts
@@ -1,0 +1,218 @@
+import { Deferred } from 'brighterscript';
+import type {
+    Disposable,
+    QuickPickItem
+} from 'vscode';
+import * as vscode from 'vscode';
+import type { ActiveDeviceManager, RokuDeviceDetails } from '../ActiveDeviceManager';
+
+/**
+ * An id to represent the "Enter manually" option in the host picker
+ */
+export const manualHostItemId = `${Number.MAX_SAFE_INTEGER}`;
+const manualLabel = 'Enter manually';
+
+export class UserInputManager {
+
+    public constructor(
+        private activeDeviceManager: ActiveDeviceManager
+    ) { }
+
+    public async promptForHostManual() {
+        return vscode.window.showInputBox({
+            placeHolder: 'Please enter the IP address of your Roku device',
+            value: ''
+        });
+    }
+
+    /**
+     * Prompt the user to pick a host from a list of devices
+     */
+    public async promptForHost(options?: { defaultValue?: string }) {
+        const deferred = new Deferred<{ ip: string; manual?: boolean } | { ip?: string; manual: true }>();
+        const disposables: Array<Disposable> = [];
+
+        const discoveryTime = 5_000;
+
+        //create the quickpick item
+        const quickPick = vscode.window.createQuickPick();
+        disposables.push(quickPick);
+        quickPick.placeholder = `Please Select a Roku or manually type an IP address`;
+        quickPick.keepScrollPosition = true;
+
+        function dispose() {
+            for (const disposable of disposables) {
+                disposable.dispose();
+            }
+        }
+
+        //detect if the user types an IP address into the picker and presses enter.
+        quickPick.onDidAccept(() => {
+            deferred.resolve({
+                ip: quickPick.value
+            });
+        });
+
+        let activeChangesSinceRefresh = 0;
+        let activeItem: QuickPickItem;
+
+        // remember the currently active item so we can maintain active selection when refreshing the list
+        quickPick.onDidChangeActive((items) => {
+            // reset our activeChanges tracker since users cannot cause items.length to be 0 (meaning a refresh has just happened)
+            if (items.length === 0) {
+                activeChangesSinceRefresh = 0;
+                return;
+            }
+            if (activeChangesSinceRefresh > 0) {
+                activeItem = items[0];
+            }
+            activeChangesSinceRefresh++;
+        });
+
+        const itemCache = new Map<string, QuickPickHostItem>();
+        if (options?.defaultValue) {
+            quickPick.value = options?.defaultValue;
+        }
+        quickPick.show();
+        const refreshList = () => {
+            const items = this.createHostQuickPickList(
+                this.activeDeviceManager.getActiveDevices(),
+                this.activeDeviceManager.lastUsedDevice,
+                itemCache
+            );
+            quickPick.items = items;
+
+            // update the busy spinner based on how long it's been since the last discovered device
+            quickPick.busy = this.activeDeviceManager.timeSinceLastDiscoveredDevice < discoveryTime;
+            setTimeout(() => {
+                quickPick.busy = this.activeDeviceManager.timeSinceLastDiscoveredDevice < discoveryTime;
+            }, discoveryTime - this.activeDeviceManager.timeSinceLastDiscoveredDevice + 20);
+
+            // clear the activeItem if we can't find it in the list
+            if (!quickPick.items.includes(activeItem)) {
+                activeItem = undefined;
+            }
+
+            // if the user manually selected an item, re-focus that item now that we refreshed the list
+            if (activeItem) {
+                quickPick.activeItems = [activeItem];
+            }
+            // quickPick.show();
+        };
+
+        //anytime the device picker adds/removes a device, update the list
+        this.activeDeviceManager.on('device-found', refreshList, disposables);
+        this.activeDeviceManager.on('device-expired', refreshList, disposables);
+
+        quickPick.onDidHide(() => {
+            dispose();
+            deferred.reject(new Error('No host was selected'));
+        });
+
+        quickPick.onDidChangeSelection(selection => {
+            const selectedItem = selection[0];
+            if (selectedItem) {
+                if (selectedItem.kind === vscode.QuickPickItemKind.Separator) {
+                    // Handle separator selection
+                } else {
+                    if (selectedItem.label === manualLabel) {
+                        deferred.resolve({ manual: true });
+                    } else {
+                        const device = (selectedItem as any).device as RokuDeviceDetails;
+                        this.activeDeviceManager.lastUsedDevice = device;
+                        deferred.resolve(device);
+                    }
+                    quickPick.dispose();
+                }
+            }
+        });
+        //run the list refresh once to show the popup
+        refreshList();
+        const result = await deferred.promise;
+        dispose();
+        if (result?.manual === true) {
+            return this.promptForHostManual();
+        } else {
+            return result?.ip;
+        }
+    }
+
+    /**
+     * Generate the label used when showing "host" entries in a quick picker
+     * @param device the device containing all the info
+     * @returns a properly formatted host string
+     */
+    private createHostLabel(device: RokuDeviceDetails) {
+        return `${device.ip} | ${device.deviceInfo['user-device-name']} - ${device.deviceInfo['serial-number']} - ${device.deviceInfo['model-number']}`;
+    }
+
+    /**
+     * Generate the item list for the `this.promptForHost()` call
+     */
+    private createHostQuickPickList(devices: RokuDeviceDetails[], lastUsedDevice: RokuDeviceDetails, cache = new Map<string, QuickPickHostItem>()) {
+        //the collection of items we will eventually return
+        let items: QuickPickHostItem[] = [];
+
+        //find the lastUsedDevice from the devices list if possible, or use the data from the lastUsedDevice if not
+        lastUsedDevice = devices.find(x => x.id === lastUsedDevice?.id) ?? lastUsedDevice;
+        //remove the lastUsedDevice from the devices list so we can more easily reason with the rest of the list
+        devices = devices.filter(x => x.id !== lastUsedDevice?.id);
+
+        // Ensure the most recently used device is at the top of the list
+        if (lastUsedDevice) {
+            //add a separator for "last used"
+            items.push({
+                label: 'last used',
+                kind: vscode.QuickPickItemKind.Separator
+            });
+
+            //add the device
+            items.push({
+                label: this.createHostLabel(lastUsedDevice),
+                device: lastUsedDevice
+            });
+        }
+
+        //add all other devices
+        if (devices.length > 0) {
+            items.push({
+                label: lastUsedDevice ? 'other devices' : 'devices',
+                kind: vscode.QuickPickItemKind.Separator
+            });
+
+            //add each device
+            for (const device of devices) {
+                //add the device
+                items.push({
+                    label: this.createHostLabel(device),
+                    device: device
+                });
+            }
+        }
+
+        //include a divider between devices and "manual" option (only if we have devices)
+        if (lastUsedDevice || devices.length) {
+            items.push({ label: ' ', kind: vscode.QuickPickItemKind.Separator });
+        }
+
+        // allow user to manually type an IP address
+        items.push(
+            { label: 'Enter manually', device: { id: manualHostItemId } } as any
+        );
+
+        // replace items with their cached versions if found (to maintain references)
+        for (let i = 0; i < items.length; i++) {
+            const item = items[i];
+            if (cache.has(item.label)) {
+                items[i] = cache.get(item.label);
+                items[i].device = item.device;
+            } else {
+                cache.set(item.label, item);
+            }
+        }
+
+        return items;
+    }
+}
+
+type QuickPickHostItem = QuickPickItem & { device?: RokuDeviceDetails };


### PR DESCRIPTION
Moves the `promptForHost` command into a `UserInputManager` class so we can start centralizing our user input flows and sharing them to unify the experience across the extension. 