### PR TITLE
Shorten the timeout for device-info query

### DIFF
--- a/src/DebugConfigurationProvider.spec.ts
+++ b/src/DebugConfigurationProvider.spec.ts
@@ -175,17 +175,16 @@ describe('BrightScriptConfigurationProvider', () => {
             expect(config.remotePort).to.equal(5678);
         });
 
-        [
-            { input: true, expected: { activateOnSessionStart: true, deactivateOnSessionEnd: true } },
-            { input: false, expected: { activateOnSessionStart: false, deactivateOnSessionEnd: false } },
-            { input: undefined, expected: { activateOnSessionStart: false, deactivateOnSessionEnd: false } }
-        ].forEach(({ input, expected }) => {
-            it('allows using a bool value for remoteConfigMode', async () => {
+        it('allows using a bool value for remoteConfigMode', async () => {
+            async function doTest(remoteControlMode: boolean, expected: any) {
                 let config = await configProvider.resolveDebugConfiguration(folder, <any>{
-                    remoteControlMode: input
+                    remoteControlMode: remoteControlMode
                 });
                 expect(config.remoteControlMode).to.deep.equal(expected);
-            });
+            }
+            await doTest(true, { activateOnSessionStart: true, deactivateOnSessionEnd: true });
+            await doTest(false, { activateOnSessionStart: false, deactivateOnSessionEnd: false });
+            await doTest(undefined, { activateOnSessionStart: false, deactivateOnSessionEnd: false });
         });
     });
 

--- a/src/DebugConfigurationProvider.ts
+++ b/src/DebugConfigurationProvider.ts
@@ -103,12 +103,16 @@ export class BrightScriptDebugConfigurationProvider implements DebugConfiguratio
             result = await this.processDeepLinkUrlParameter(result);
             result = await this.processLogfilePath(folder, result);
 
+            const statusbarItem = vscode.window.createStatusBarItem(vscode.StatusBarAlignment.Right, 9_999_999);
+            statusbarItem.text = '$(sync~spin) Fetching device info';
+            statusbarItem.show();
             try {
                 deviceInfo = await rokuDeploy.getDeviceInfo({ host: result.host, remotePort: result.remotePort, enhance: true, timeout: 4000 });
             } catch (e) {
                 // a failed deviceInfo request should NOT fail the launch
                 console.error(`Failed to fetch device info for ${result.host}`, e);
             }
+            statusbarItem.dispose();
 
             if (deviceInfo && !deviceInfo.developerEnabled) {
                 throw new Error(`Cannot deploy: developer mode is disabled on '${result.host}'`);

--- a/src/DebugConfigurationProvider.ts
+++ b/src/DebugConfigurationProvider.ts
@@ -104,7 +104,7 @@ export class BrightScriptDebugConfigurationProvider implements DebugConfiguratio
             result = await this.processLogfilePath(folder, result);
 
             try {
-                deviceInfo = await rokuDeploy.getDeviceInfo({ host: result.host, remotePort: result.remotePort, enhance: true });
+                deviceInfo = await rokuDeploy.getDeviceInfo({ host: result.host, remotePort: result.remotePort, enhance: true, timeout: 4000 });
             } catch (e) {
                 // a failed deviceInfo request should NOT fail the launch
                 console.error(`Failed to fetch device info for ${result.host}`, e);

--- a/src/mockVscode.spec.ts
+++ b/src/mockVscode.spec.ts
@@ -157,7 +157,8 @@ export let vscode = {
             return {
                 clear: () => { },
                 text: '',
-                show: () => { }
+                show: () => { },
+                dispose: () => { }
             };
         },
         createQuickPick: () => {


### PR DESCRIPTION
- Sets a shorter timeout for the device-info query so the user isn't just stuck waiting forever wondering what's happening. 
- show a spinning statusbar item when device-info is being requested.

![loading-picker](https://github.com/rokucommunity/vscode-brightscript-language/assets/2544493/ef64921e-fe2e-40f2-9858-980d46fb0e46)
