### PR TITLE
Fix watch-all problem matcher and output

### DIFF
--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -9,7 +9,10 @@
                 "group": "watch",
             },
             "isBackground": true,
-            "problemMatcher": "$tsc-watch"
+            "problemMatcher": {
+                "base": "$tsc-watch",
+                "fileLocation": "absolute"
+            }
         },
         {
             "label": "watch",

--- a/scripts/watch-all.ts
+++ b/scripts/watch-all.ts
@@ -119,7 +119,7 @@ const printStatus = debounce(() => {
                 logger.writeLine(`${chalk.red(project.name)} diagnostics:\n`);
                 for (const diagnostic of project.diagnostics ?? []) {
                     logger.writeLine(
-                        diagnostic.raw?.replace(diagnostic.path!, path.normalize(path.join('../', diagnostic.path!)))
+                        diagnostic.raw?.replace(diagnostic.path!, path.normalize(path.join(project.path, diagnostic.path!)))
                     );
                 }
             }


### PR DESCRIPTION
Fix the problem matcher in the `watch-all` task when running the workspace. This is fixed by emitting absolute paths instead of relative paths, which then work for both the workspace and individual folders