### PR TITLE
Fix spelling mistake in lsp message

### DIFF
--- a/src/LanguageServerManager.ts
+++ b/src/LanguageServerManager.ts
@@ -326,7 +326,7 @@ export class LanguageServerManager {
         } catch (e) {
             console.error(e);
             //fall back to the embedded version, and show a popup
-            await vscode.window.showErrorMessage(`Can't find language sever at "${bsdkPath}". Using embedded version v${this.embeddedBscInfo.version} instead.`);
+            await vscode.window.showErrorMessage(`Can't find language server at "${bsdkPath}". Using embedded version v${this.embeddedBscInfo.version} instead.`);
             this.selectedBscInfo = this.embeddedBscInfo;
         }
 


### PR DESCRIPTION
Fix a spelling mistake in the "Can't find language server" error message. 

Thanks @triwav for finding this!