### PR TITLE
Add a few missing brightscript.debug settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -2307,6 +2307,35 @@
                         "default": false,
                         "description": "Delete any currently installed dev channel before starting the debug session",
                         "scope": "resource"
+                    },
+                    "brightscript.debug.sceneGraphDebugCommandsPort": {
+                        "type": "number",
+                        "default": 8080,
+                        "description": "Port for sending SceneGraph debug commands",
+                        "scope": "resource"
+                    },
+                    "brightscript.debug.remoteControlMode": {
+                        "oneOf": [
+                            {
+                                "type": "object",
+                                "description": "Options for activating and deactivating remote control mode",
+                                "properties": {
+                                    "activateOnSessionStart": {
+                                        "type": "boolean",
+                                        "description": "Activate remote control mode on debug session start"
+                                    },
+                                    "deactivateOnSessionEnd": {
+                                        "type": "boolean",
+                                        "description": "Deactivate remote control mode on session end"
+                                    }
+                                }
+                            },
+                            {
+                                "type": "boolean",
+                                "description": "Activate on session start, deactivate on session end."
+                            }
+                        ],
+                        "scope": "resource"
                     }
                 }
             },


### PR DESCRIPTION
Adds a few missing `brightscript.debug` settings to user/workspace settings. 