### PR TITLE
Always request screenshot on initial load, add ability to copy screenshot

### DIFF
--- a/package.json
+++ b/package.json
@@ -302,6 +302,11 @@
                     "group": "navigation@3"
                 },
                 {
+                    "command": "extension.brightscript.rokuDeviceView.copyScreenshot",
+                    "when": "view == rokuDeviceView && !brightscript.rokuDeviceView.enableScreenshotCapture",
+                    "group": "navigation@4"
+                },
+                {
                     "command": "extension.brightscript.rokuAutomationView.startRecording",
                     "when": "view == rokuAutomationView && !brightscript.rokuAutomationView.isRecording",
                     "group": "navigation"
@@ -320,6 +325,12 @@
                     "command": "extension.brightscript.rokuAutomationView.disableAutorunOnDeploy",
                     "when": "view == rokuAutomationView && brightscript.rokuAutomationView.autorunOnDeploy",
                     "group": "navigation@2"
+                }
+            ],
+            "webview/context": [
+                {
+                    "command": "extension.brightscript.rokuDeviceView.copyScreenshot",
+                    "when": "webviewId == rokuDeviceView"
                 }
             ],
             "commandPalette": []
@@ -2837,6 +2848,12 @@
                 "title": "Device View: Refresh Screenshot",
                 "category": "BrighterScript",
                 "icon": "$(refresh)"
+            },
+            {
+                "command": "extension.brightscript.rokuDeviceView.copyScreenshot",
+                "title": "Copy Screenshot",
+                "category": "BrighterScript",
+                "icon": "$(clippy)"
             },
             {
                 "command": "extension.brightscript.sceneGraphInspectorView.refreshNodeTree",

--- a/package.json
+++ b/package.json
@@ -303,7 +303,7 @@
                 },
                 {
                     "command": "extension.brightscript.rokuDeviceView.copyScreenshot",
-                    "when": "view == rokuDeviceView && !brightscript.rokuDeviceView.enableScreenshotCapture",
+                    "when": "view == rokuDeviceView",
                     "group": "navigation@4"
                 },
                 {

--- a/src/commands/VscodeCommand.ts
+++ b/src/commands/VscodeCommand.ts
@@ -2,6 +2,7 @@ export enum VscodeCommand {
     rokuDeviceViewRefreshScreenshot = 'extension.brightscript.rokuDeviceView.refreshScreenshot',
     rokuDeviceViewResumeScreenshotCapture = 'extension.brightscript.rokuDeviceView.resumeScreenshotCapture',
     rokuDeviceViewPauseScreenshotCapture = 'extension.brightscript.rokuDeviceView.pauseScreenshotCapture',
+    rokuDeviceViewCopyScreenshot = 'extension.brightscript.rokuDeviceView.copyScreenshot',
     rokuDeviceViewEnableNodeInspector = 'extension.brightscript.rokuDeviceView.enableNodeInspector',
     rokuDeviceViewDisableNodeInspector = 'extension.brightscript.rokuDeviceView.disableNodeInspector',
     rokuRegistryExportRegistry = 'extension.brightscript.rokuRegistry.exportRegistry',

--- a/src/viewProviders/BaseWebviewViewProvider.ts
+++ b/src/viewProviders/BaseWebviewViewProvider.ts
@@ -124,14 +124,21 @@ export abstract class BaseWebviewViewProvider implements vscode.WebviewViewProvi
         });
     }
 
-    protected registerCommandWithWebViewNotifier(context: vscode.ExtensionContext, command: string) {
-        context.subscriptions.push(vscode.commands.registerCommand(command, () => {
+    protected registerCommandWithWebViewNotifier(context: vscode.ExtensionContext, command: string, callback: (() => any) | undefined = undefined) {
+        this.registerCommand(context, command, async () => {
+            if (callback) {
+                await callback();
+            }
             const message = this.createEventMessage(ViewProviderEvent.onVscodeCommandReceived, {
                 commandName: command
             });
 
             this.postOrQueueMessage(message);
-        }));
+        });
+    }
+
+    protected registerCommand(context: vscode.ExtensionContext, command: string, callback: (...args: any[]) => any) {
+        context.subscriptions.push(vscode.commands.registerCommand(command, callback));
     }
 
     protected onViewReady() { }

--- a/src/viewProviders/RokuDeviceViewViewProvider.ts
+++ b/src/viewProviders/RokuDeviceViewViewProvider.ts
@@ -15,6 +15,11 @@ export class RokuDeviceViewViewProvider extends BaseRdbViewProvider {
         this.registerCommandWithWebViewNotifier(context, VscodeCommand.rokuDeviceViewRefreshScreenshot);
         this.registerCommandWithWebViewNotifier(context, VscodeCommand.rokuDeviceViewPauseScreenshotCapture);
         this.registerCommandWithWebViewNotifier(context, VscodeCommand.rokuDeviceViewResumeScreenshotCapture);
+        this.registerCommandWithWebViewNotifier(context, VscodeCommand.rokuDeviceViewCopyScreenshot, () => {
+            // In order for copy to be successful the webview has to have focus
+            this.view.show(false);
+        });
+
 
         this.addMessageCommandCallback(ViewProviderCommand.getScreenshot, async (message) => {
             try {


### PR DESCRIPTION
Some small improvements to screenshot capability to make it easier to share screenshots from device. Changed it to request an initial screenshot where as before if you didn't have continuous screenshot capture on it would not request any on its own unless you clicked refresh