### PR TITLE
Pass the modal property from the PopupMessageEvent

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,7 +32,7 @@
                 "node-ssdp": "^4.0.0",
                 "postman-request": "^2.88.1-postman.32",
                 "pretty-bytes": "^5.6.0",
-                "roku-debug": "^0.20.14",
+                "roku-debug": "^0.20.15",
                 "roku-deploy": "^3.11.1",
                 "roku-test-automation": "2.0.0-beta.22",
                 "semver": "^7.1.3",
@@ -2463,9 +2463,9 @@
             }
         },
         "node_modules/brighterscript": {
-            "version": "0.65.12",
-            "resolved": "https://registry.npmjs.org/brighterscript/-/brighterscript-0.65.12.tgz",
-            "integrity": "sha512-sXPLEH2CgjrPLFWi9tp2PXTNjS1S/6Xoa6EmafFauzYJBgXPKJd/ajzRNs5UPIJ4pqG0cst6NDWDHm7y2y4nEw==",
+            "version": "0.65.16",
+            "resolved": "https://registry.npmjs.org/brighterscript/-/brighterscript-0.65.16.tgz",
+            "integrity": "sha512-2RJMF8itkrPXtZ92JkJf3emvzcCl5ETXGVyPsdO/hMKbUGinEGMRFG07FR0bzjRotbALzsozGE/Hjzw412Sjww==",
             "dependencies": {
                 "@rokucommunity/bslib": "^0.1.1",
                 "@xml-tools/parser": "^1.0.7",
@@ -2490,7 +2490,7 @@
                 "parse-ms": "^2.1.0",
                 "readline": "^1.3.0",
                 "require-relative": "^0.8.7",
-                "roku-deploy": "^3.11.1",
+                "roku-deploy": "^3.11.2",
                 "serialize-error": "^7.0.1",
                 "source-map": "^0.7.4",
                 "vscode-languageserver": "7.0.0",
@@ -8724,13 +8724,13 @@
             }
         },
         "node_modules/roku-debug": {
-            "version": "0.20.14",
-            "resolved": "https://registry.npmjs.org/roku-debug/-/roku-debug-0.20.14.tgz",
-            "integrity": "sha512-FXfTYoTlF7hh2b9Dgj9TAiwhWs4Zel8UXXTHQcug9cb5xK3dU++VJFWyQIGuT9K3a+rcGgAacTWZNOTbS90xaQ==",
+            "version": "0.20.15",
+            "resolved": "https://registry.npmjs.org/roku-debug/-/roku-debug-0.20.15.tgz",
+            "integrity": "sha512-R1TNGLdD7/N8ShNIyYeZxDxqFm31WCP6Cxw5ojqarOxnkTTPrlUz43w/jq1Ed2cO6IiJGRdyRhRgr2G3ZfeQ0w==",
             "dependencies": {
                 "@rokucommunity/logger": "^0.3.3",
                 "@types/request": "^2.48.8",
-                "brighterscript": "^0.65.12",
+                "brighterscript": "^0.65.16",
                 "dateformat": "^4.6.3",
                 "debounce": "^1.2.1",
                 "eol": "^0.9.1",
@@ -8742,7 +8742,7 @@
                 "postman-request": "^2.88.1-postman.32",
                 "replace-in-file": "^6.3.2",
                 "replace-last": "^1.2.6",
-                "roku-deploy": "^3.11.1",
+                "roku-deploy": "^3.11.2",
                 "semver": "^7.5.4",
                 "serialize-error": "^8.1.0",
                 "smart-buffer": "^4.2.0",
@@ -8817,9 +8817,9 @@
             }
         },
         "node_modules/roku-deploy": {
-            "version": "3.11.1",
-            "resolved": "https://registry.npmjs.org/roku-deploy/-/roku-deploy-3.11.1.tgz",
-            "integrity": "sha512-ri3eJKGyPMexI+pwvBQxpi6I7I3z9670yOidTcVEohpbYhXpnaIHnKdLb2l87kuC+iTtIEsElgmx3fyEdI5Cjg==",
+            "version": "3.11.2",
+            "resolved": "https://registry.npmjs.org/roku-deploy/-/roku-deploy-3.11.2.tgz",
+            "integrity": "sha512-3JDlnbTxv6Xk5GVolQoA3+d34MLZXXwZWMySprHwazZoWLP3LvulYHP92YvFOJAo/aI4IZp/TFA8kR82IrmHKA==",
             "dependencies": {
                 "chalk": "^2.4.2",
                 "dateformat": "^3.0.3",
@@ -12895,9 +12895,9 @@
             }
         },
         "brighterscript": {
-            "version": "0.65.12",
-            "resolved": "https://registry.npmjs.org/brighterscript/-/brighterscript-0.65.12.tgz",
-            "integrity": "sha512-sXPLEH2CgjrPLFWi9tp2PXTNjS1S/6Xoa6EmafFauzYJBgXPKJd/ajzRNs5UPIJ4pqG0cst6NDWDHm7y2y4nEw==",
+            "version": "0.65.16",
+            "resolved": "https://registry.npmjs.org/brighterscript/-/brighterscript-0.65.16.tgz",
+            "integrity": "sha512-2RJMF8itkrPXtZ92JkJf3emvzcCl5ETXGVyPsdO/hMKbUGinEGMRFG07FR0bzjRotbALzsozGE/Hjzw412Sjww==",
             "requires": {
                 "@rokucommunity/bslib": "^0.1.1",
                 "@xml-tools/parser": "^1.0.7",
@@ -12922,7 +12922,7 @@
                 "parse-ms": "^2.1.0",
                 "readline": "^1.3.0",
                 "require-relative": "^0.8.7",
-                "roku-deploy": "^3.11.1",
+                "roku-deploy": "^3.11.2",
                 "serialize-error": "^7.0.1",
                 "source-map": "^0.7.4",
                 "vscode-languageserver": "7.0.0",
@@ -17654,13 +17654,13 @@
             }
         },
         "roku-debug": {
-            "version": "0.20.14",
-            "resolved": "https://registry.npmjs.org/roku-debug/-/roku-debug-0.20.14.tgz",
-            "integrity": "sha512-FXfTYoTlF7hh2b9Dgj9TAiwhWs4Zel8UXXTHQcug9cb5xK3dU++VJFWyQIGuT9K3a+rcGgAacTWZNOTbS90xaQ==",
+            "version": "0.20.15",
+            "resolved": "https://registry.npmjs.org/roku-debug/-/roku-debug-0.20.15.tgz",
+            "integrity": "sha512-R1TNGLdD7/N8ShNIyYeZxDxqFm31WCP6Cxw5ojqarOxnkTTPrlUz43w/jq1Ed2cO6IiJGRdyRhRgr2G3ZfeQ0w==",
             "requires": {
                 "@rokucommunity/logger": "^0.3.3",
                 "@types/request": "^2.48.8",
-                "brighterscript": "^0.65.12",
+                "brighterscript": "^0.65.16",
                 "dateformat": "^4.6.3",
                 "debounce": "^1.2.1",
                 "eol": "^0.9.1",
@@ -17672,7 +17672,7 @@
                 "postman-request": "^2.88.1-postman.32",
                 "replace-in-file": "^6.3.2",
                 "replace-last": "^1.2.6",
-                "roku-deploy": "^3.11.1",
+                "roku-deploy": "^3.11.2",
                 "semver": "^7.5.4",
                 "serialize-error": "^8.1.0",
                 "smart-buffer": "^4.2.0",
@@ -17732,9 +17732,9 @@
             }
         },
         "roku-deploy": {
-            "version": "3.11.1",
-            "resolved": "https://registry.npmjs.org/roku-deploy/-/roku-deploy-3.11.1.tgz",
-            "integrity": "sha512-ri3eJKGyPMexI+pwvBQxpi6I7I3z9670yOidTcVEohpbYhXpnaIHnKdLb2l87kuC+iTtIEsElgmx3fyEdI5Cjg==",
+            "version": "3.11.2",
+            "resolved": "https://registry.npmjs.org/roku-deploy/-/roku-deploy-3.11.2.tgz",
+            "integrity": "sha512-3JDlnbTxv6Xk5GVolQoA3+d34MLZXXwZWMySprHwazZoWLP3LvulYHP92YvFOJAo/aI4IZp/TFA8kR82IrmHKA==",
             "requires": {
                 "chalk": "^2.4.2",
                 "dateformat": "^3.0.3",

--- a/package.json
+++ b/package.json
@@ -74,7 +74,7 @@
         "node-ssdp": "^4.0.0",
         "postman-request": "^2.88.1-postman.32",
         "pretty-bytes": "^5.6.0",
-        "roku-debug": "^0.20.14",
+        "roku-debug": "^0.20.15",
         "roku-deploy": "^3.11.1",
         "roku-test-automation": "2.0.0-beta.22",
         "semver": "^7.1.3",

--- a/src/LogOutputManager.ts
+++ b/src/LogOutputManager.ts
@@ -228,7 +228,7 @@ export class LogOutputManager {
             this.appendLine(e.body.line);
 
         } else if (isPopupMessageEvent(e)) {
-            this.showMessage(e.body.message, e.body.severity);
+            this.showMessage(e.body.message, e.body.severity, e.body.modal);
 
         } else if (isLaunchStartEvent(e)) {
             this.isInMicroDebugger = false;
@@ -244,13 +244,13 @@ export class LogOutputManager {
         }
     }
 
-    private showMessage(message: string, severity: string) {
+    private showMessage(message: string, severity: string, modal: boolean) {
         const methods = {
             error: vscode.window.showErrorMessage,
             info: vscode.window.showInformationMessage,
             warn: vscode.window.showWarningMessage
         };
-        methods[severity](message);
+        methods[severity](message, { modal: modal });
     }
 
     /**


### PR DESCRIPTION
This change utilizes the modal property that was added to the `PopupMessageEvent`. The modal property is being added to make any errors more visible when VSCode fails to launch a channel. The most common example of this is a bad password.

Here's a screen shot of the modal.
<img width="1100" alt="Screenshot 2024-01-08 091210" src="https://github.com/rokucommunity/vscode-brightscript-language/assets/118202694/c6d95683-7c9d-4fff-afa8-c89b93bf09f8">
