### PR TITLE
Remove duplicate 'clearLogOutput' command

### DIFF
--- a/package.json
+++ b/package.json
@@ -2541,11 +2541,6 @@
                 "category": "Brightscript"
             },
             {
-                "command": "extension.brightscript.clearLogOutput",
-                "title": "Clear the brightscript log output",
-                "category": "Brightscript"
-            },
-            {
                 "command": "extension.brightscript.toggleRemoteControlMode",
                 "title": "Toggle remote control mode",
                 "category": "Brightscript"
@@ -2693,7 +2688,7 @@
             },
             {
                 "command": "extension.brightscript.clearLogOutput",
-                "title": "Clear Log Output",
+                "title": "Clear the brightscript log output",
                 "category": "Brightscript"
             },
             {


### PR DESCRIPTION
Removes a duplicate command called `clearLogOutput` that was duplicated in the package.json for some reason. 