### PR TITLE
Fix crash when trying to copy numeric values to the clipboard

### DIFF
--- a/src/BrightScriptCommands.ts
+++ b/src/BrightScriptCommands.ts
@@ -252,7 +252,10 @@ export class BrightScriptCommands {
 
         this.registerCommand('copyToClipboard', async (value: string) => {
             try {
-                await vscode.env.clipboard.writeText(value);
+                if (util.isNullish(value)) {
+                    throw new Error('Cannot copy ${value} to clipboard');
+                }
+                await vscode.env.clipboard.writeText(value?.toString());
                 await vscode.window.showInformationMessage(`Copied to clipboard: ${value}`);
             } catch (error) {
                 await vscode.window.showErrorMessage(`Could not copy value to clipboard`);


### PR DESCRIPTION
Fixes an error when copying a numeric value to clipboard from the device panel

**Before:**
![image](https://github.com/rokucommunity/vscode-brightscript-language/assets/2544493/265adae4-8c2d-4a9f-80fa-0d49b91ac0a8)

**After:**
![image](https://github.com/rokucommunity/vscode-brightscript-language/assets/2544493/357065a7-09e3-4eee-8718-23c4aa79a362)
