### PR TITLE
Fix conditional compile syntax highlighting

### DIFF
--- a/src/grammar/brightscript.tmLanguage.spec.ts
+++ b/src/grammar/brightscript.tmLanguage.spec.ts
@@ -6,6 +6,54 @@ import { standardizePath as s } from 'brighterscript';
 const brightscriptTmlanguagePath = s`${__dirname}/../../syntaxes/brightscript.tmLanguage.json`;
 
 describe('brightscript.tmlanguage.json', () => {
+    it('colors normal conditional compile statements properly', async () => {
+        await testGrammar(`
+             #if true
+            '^^^ keyword.preprocessor.if.brs
+             #elseif false
+            '^^^^^^^ keyword.preprocessor.elseif.brs
+             #else
+            '^^^^^ keyword.preprocessor.else.brs
+             #endif
+            '^^^^^^ keyword.preprocessor.endif.brs
+        `);
+    });
+
+    it('colors composite keyword conditional compile statements properly', async () => {
+        await testGrammar(`
+             #const IS_DEV_MODE=true
+            '^^^^^^ keyword.preprocessor.const.brs
+             #error Something bad happened
+            '^^^^^^ keyword.preprocessor.error.brs
+             #if true
+            '^^^ keyword.preprocessor.if.brs
+             #else if false
+            '^^^^^^^^ keyword.preprocessor.elseif.brs
+             #else
+            '^^^^^ keyword.preprocessor.else.brs
+             #end if
+            '^^^^^^^ keyword.preprocessor.endif.brs
+        `);
+    });
+
+    it('colors leading whitespace conditional compile statements properly', async () => {
+        //carrots should be shorter by 1 because \t turns into 1 char
+        await testGrammar(`
+             #\t const IS_DEV_MODE=true
+            '^^^^^^^^ keyword.preprocessor.const.brs
+             #\t error Something bad happened
+            '^^^^^^^^ keyword.preprocessor.error.brs
+             #\t if true
+            '^^^^^ keyword.preprocessor.if.brs
+             #\t else if false
+            '^^^^^^^ keyword.preprocessor.elseif.brs
+             #\t else
+            '^^^^^^^ keyword.preprocessor.else.brs
+             #\t end if
+            '^^^^^^^^^ keyword.preprocessor.endif.brs
+        `);
+    });
+
     it('colors `continue for`', async () => {
         await testGrammar(`
             for i = 0 to 10

--- a/syntaxes/brightscript.tmLanguage.json
+++ b/syntaxes/brightscript.tmLanguage.json
@@ -507,24 +507,28 @@
         "preprocessor_keywords": {
             "patterns": [
                 {
-                    "match": "(?i:(#const))",
+                    "match": "(?i:(#[ \t]*const))",
+                    "name": "keyword.preprocessor.const.brs"
+                },
+                {
+                    "match": "(?i:(#[ \t]*if))",
                     "name": "keyword.preprocessor.if.brs"
                 },
                 {
-                    "match": "(?i:(#if))",
-                    "name": "keyword.preprocessor.if.brs"
+                    "match": "(?i:(#[ \t]*else[ \t]*if))",
+                    "name": "keyword.preprocessor.elseif.brs"
                 },
                 {
-                    "match": "(?i:(#else\\s*if))",
-                    "name": "keyword.preprocessor.if.brs"
-                },
-                {
-                    "match": "(?i:(#end\\s*if))",
+                    "match": "(?i:(#[ \t]*end[ \t]*if))",
                     "name": "keyword.preprocessor.endif.brs"
                 },
                 {
-                    "match": "(?i:(#else))",
+                    "match": "(?i:(#[ \t]*else))",
                     "name": "keyword.preprocessor.else.brs"
+                },
+                {
+                    "match": "(?i:(#[ \t]*error))",
+                    "name": "keyword.preprocessor.error.brs"
                 }
             ]
         },


### PR DESCRIPTION
Fix syntax highlighting for conditional compile items with spaces between `#` and the next keyword.

**Before:**
![image](https://github.com/rokucommunity/vscode-brightscript-language/assets/2544493/b9ee64dc-82af-413a-89c8-2a7dd5346285)


**After:**
![image](https://github.com/rokucommunity/vscode-brightscript-language/assets/2544493/4b576c98-71a8-49c5-a601-c0a5ccb0847a)
