### PR TITLE
Add support for opening SceneGraph Inspector in panel

### DIFF
--- a/package.json
+++ b/package.json
@@ -3048,7 +3048,7 @@
                 "command": "extension.brightscript.openSceneGraphInspectorInPanel",
                 "title": "Open SceneGraph Inspector In New Window",
                 "category": "BrighterScript",
-                "icon": "$(empty-window)"
+                "icon": "$(link-external)"
             }
         ],
         "keybindings": [

--- a/package.json
+++ b/package.json
@@ -384,9 +384,13 @@
                     "group": "navigation@1"
                 },
                 {
+                    "command": "extension.brightscript.openSceneGraphInspectorInPanel",
+                    "when": "view == sceneGraphInspectorView",
+                    "group": "navigation@1"
+                }, {
                     "command": "extension.brightscript.disconnectFromDevice",
                     "when": "view == sceneGraphInspectorView && brightscript.isOnDeviceComponentAvailable",
-                    "group": "navigation@1"
+                    "group": "navigation@2"
                 }
             ],
             "webview/context": [
@@ -3035,16 +3039,16 @@
                 "icon": "$(clippy)"
             },
             {
-                "command": "extension.brightscript.sceneGraphInspectorView.refreshNodeTree",
-                "title": "Refresh Nodetree",
-                "category": "BrighterScript",
-                "icon": "$(refresh)"
-            },
-            {
                 "command": "extension.brightscript.disconnectFromDevice",
                 "title": "Disconnect From Roku Device",
                 "category": "BrighterScript",
                 "icon": "$(debug-disconnect)"
+            },
+            {
+                "command": "extension.brightscript.openSceneGraphInspectorInPanel",
+                "title": "Open SceneGraph Inspector In New Window",
+                "category": "BrighterScript",
+                "icon": "$(empty-window)"
             }
         ],
         "keybindings": [

--- a/src/commands/VscodeCommand.ts
+++ b/src/commands/VscodeCommand.ts
@@ -18,5 +18,6 @@ export enum VscodeCommand {
     rokuAppOverlaysViewAddNewOverlay = 'extension.brightscript.rokuAppOverlaysView.addNewOverlay',
     rokuAppOverlaysViewRemoveAllOverlays = 'extension.brightscript.rokuAppOverlaysView.removeAllOverlays',
     rokuFileSystemViewRefresh = 'extension.brightscript.rokuFileSystemView.refresh',
-    disconnectFromDevice = 'extension.brightscript.disconnectFromDevice'
+    disconnectFromDevice = 'extension.brightscript.disconnectFromDevice',
+    openSceneGraphInspectorInPanel = 'extension.brightscript.openSceneGraphInspectorInPanel'
 }

--- a/src/viewProviders/BaseWebviewViewProvider.ts
+++ b/src/viewProviders/BaseWebviewViewProvider.ts
@@ -104,7 +104,7 @@ export abstract class BaseWebviewViewProvider implements vscode.WebviewViewProvi
         this.messageCommandCallbacks[command] = callback;
     }
 
-    protected setupViewMessageObserver(webview: vscode.Webview) {
+    private setupViewMessageObserver(webview: vscode.Webview) {
         webview.onDidReceiveMessage(async (message) => {
             try {
                 const command = message.command;

--- a/src/viewProviders/BaseWebviewViewProvider.ts
+++ b/src/viewProviders/BaseWebviewViewProvider.ts
@@ -31,6 +31,7 @@ export abstract class BaseWebviewViewProvider implements vscode.WebviewViewProvi
      */
     public readonly abstract id: string;
 
+    protected panel?: vscode.WebviewPanel;
     protected view?: vscode.WebviewView;
     protected webviewBasePath: string;
     private outDirWatcher: AsyncSubscription;
@@ -87,6 +88,10 @@ export abstract class BaseWebviewViewProvider implements vscode.WebviewViewProvi
         this.view?.webview.postMessage(message).then(null, (reason) => {
             console.log('postMessage failed: ', reason);
         });
+
+        this.panel?.webview.postMessage(message).then(null, (reason) => {
+            console.log('postMessage failed: ', reason);
+        });
     }
 
     private postQueuedMessages() {
@@ -99,7 +104,7 @@ export abstract class BaseWebviewViewProvider implements vscode.WebviewViewProvi
         this.messageCommandCallbacks[command] = callback;
     }
 
-    private setupViewMessageObserver(webview: vscode.Webview) {
+    protected setupViewMessageObserver(webview: vscode.Webview) {
         webview.onDidReceiveMessage(async (message) => {
             try {
                 const command = message.command;
@@ -257,5 +262,55 @@ export abstract class BaseWebviewViewProvider implements vscode.WebviewViewProvi
             ]
         };
         webview.html = await this.getHtmlForWebview();
+    }
+
+    protected async createOrRevealWebviewPanel() {
+        // See if we need to make the panel or not
+        let createPanel = false;
+        if (!this.panel) {
+            createPanel = true;
+        } else {
+            try {
+                if (!this.panel.active) {
+                    // If we still exist and aren't active then reveal the panel
+                    this.panel.reveal();
+                }
+            } catch (e) {
+                createPanel = true;
+            }
+        }
+
+        if (createPanel) {
+            this.panel = vscode.window.createWebviewPanel(
+                this.id,
+                await this.getViewNameById(this.id),
+                vscode.ViewColumn.Active,
+                {
+                    // Enable javascript in the webview
+                    enableScripts: true,
+                    localResourceRoots: [
+                        vscode.Uri.file(this.webviewBasePath)
+                    ]
+                }
+            );
+
+            this.setupViewMessageObserver(this.panel.webview);
+
+            const html = await this.getHtmlForWebview();
+            this.panel.webview.html = html;
+        }
+    }
+
+    private async getViewNameById(viewId) {
+        const packageJsonPath = path.join(this.extensionContext.extensionPath, 'package.json');
+        const packageJson = JSON.parse(await fsExtra.readFile(packageJsonPath, 'utf8'));
+
+        for (const view of [...packageJson.contributes.views.debug, ...packageJson.contributes.views['vscode-brightscript-language']]) {
+            if (view.id === viewId) {
+                return view.name;
+            }
+        }
+
+        return null;
     }
 }

--- a/src/viewProviders/SceneGraphInspectorViewProvider.ts
+++ b/src/viewProviders/SceneGraphInspectorViewProvider.ts
@@ -1,6 +1,7 @@
 import type * as vscode from 'vscode';
 import { BaseRdbViewProvider } from './BaseRdbViewProvider';
 import { ViewProviderId } from './ViewProviderId';
+import { VscodeCommand } from '../commands/VscodeCommand';
 
 export class SceneGraphInspectorViewProvider extends BaseRdbViewProvider {
     public readonly id = ViewProviderId.sceneGraphInspectorView;
@@ -8,6 +9,8 @@ export class SceneGraphInspectorViewProvider extends BaseRdbViewProvider {
     constructor(context: vscode.ExtensionContext, dependencies) {
         super(context, dependencies);
 
-        this.registerCommandWithWebViewNotifier(context, 'extension.brightscript.sceneGraphInspectorView.refreshNodeTree');
+        this.registerCommand(context, VscodeCommand.openSceneGraphInspectorInPanel, async () => {
+            await this.createOrRevealWebviewPanel();
+        });
     }
 }


### PR DESCRIPTION
This PR allows opening the SceneGraph Inspector as a WebViewPanel in the current window. As of the April 2024 release of Visual Studio Code, you can also move that panel from the current window to a new window as well although there is currently no way to programmatically do this.
![Apr-09-2024 12-47-46](https://github.com/rokucommunity/vscode-brightscript-language/assets/1753881/c66486f4-543d-4b9b-b765-09670da672b7)
