### PR TITLE
Adds syntax highlighting for `alias` statements

### DIFF
--- a/src/grammar/brightscript.tmLanguage.spec.ts
+++ b/src/grammar/brightscript.tmLanguage.spec.ts
@@ -6,6 +6,32 @@ import { standardizePath as s } from 'brighterscript';
 const brightscriptTmlanguagePath = s`${__dirname}/../../syntaxes/brightscript.tmLanguage.json`;
 
 describe('brightscript.tmlanguage.json', () => {
+    it('colors alias statement properly', async () => {
+        await testGrammar(`
+             alias alpha = beta
+                          '^^^^ entity.name.variable.local.brs
+                        '^ keyword.operator.assignment.brs
+                  '^^^^^ entity.name.variable.brs
+            '^^^^^ keyword.declaration.alias.brs
+        `);
+
+        await testGrammar(`
+            alias alpha=beta
+                       '^^^^ entity.name.variable.local.brs
+                      '^ keyword.operator.assignment.brs
+                 '^^^^^ entity.name.variable.brs
+           '^^^^^ keyword.declaration.alias.brs
+        `);
+
+        await testGrammar(`
+           alias alpha = beta.charlie.delta
+                        '^^^^ entity.name.variable.local.brs
+                      '^ keyword.operator.assignment.brs
+                '^^^^^ entity.name.variable.brs
+          '^^^^^ keyword.declaration.alias.brs
+        `);
+    });
+
     it('colors normal conditional compile statements properly', async () => {
         await testGrammar(`
              #if true

--- a/syntaxes/brightscript.tmLanguage.json
+++ b/syntaxes/brightscript.tmLanguage.json
@@ -38,6 +38,9 @@
                     "include": "#import_statement"
                 },
                 {
+                    "include": "#alias_statement"
+                },
+                {
                     "include": "#namespace_declaration"
                 },
                 {
@@ -390,6 +393,20 @@
                 },
                 "2": {
                     "name": "string.quoted.double.brs"
+                }
+            }
+        },
+        "alias_statement": {
+            "match": "(?i:(alias)\\s+([a-z0-9_]+)\\s*(=)\\s*)",
+            "captures": {
+                "1": {
+                    "name": "keyword.declaration.alias.brs"
+                },
+                "2": {
+                    "name": "entity.name.variable.brs"
+                },
+                "3": {
+                    "name": "keyword.operator.assignment.brs"
                 }
             }
         },


### PR DESCRIPTION
Adds syntax highlighting for the [alias statement](https://github.com/rokucommunity/brighterscript/pull/1151) coming in v1.

Before:
![image](https://github.com/rokucommunity/vscode-brightscript-language/assets/2544493/e6d1a05f-461c-445b-8212-7eba5264865c)

After:
![image](https://github.com/rokucommunity/vscode-brightscript-language/assets/2544493/7bd5b2dc-ecc3-42c5-9dd3-6c133a70354a)
