### PR TITLE
Fix incorrect brs:disable-line docs

### DIFF
--- a/docs/Editing/error-handling.md
+++ b/docs/Editing/error-handling.md
@@ -3,25 +3,25 @@ title: Ignoring Errors and Warnings
 ---
 # Ignore errors and warnings on a per-line basis
 In addition to disabling an entire class of errors in the `ignoreErrorCodes` array in `bsconfig.json`, you may also disable errors for a subset of the complier rules within a file with the following comment flags:
- - `brs:disable-next-line`
- - `brs:disable-next-line: code1 code2 code3`
- - `brs:disable-line`
- - `brs:disable-line: code1 code2 code3`
+ - `bs:disable-next-line`
+ - `bs:disable-next-line: code1 code2 code3`
+ - `bs:disable-line`
+ - `bs:disable-line: code1 code2 code3`
 
 Here are some examples:
 
 ```vb
 sub Main()
     'disable errors about invalid syntax here
-    'brs:disable-next-line
+    'bs:disable-next-line
     DoSomething(
 
-    DoSomething( 'brs:disable-line
+    DoSomething( 'bs:disable-line
 
     'disable errors about wrong parameter count
-    DoSomething(1,2,3) 'brs:disable-next-line
+    DoSomething(1,2,3) 'bs:disable-next-line
 
-    DoSomething(1,2,3) 'brs:disable-next-line:1002
+    DoSomething(1,2,3) 'bs:disable-next-line:1002
 end sub
 
 sub DoSomething()


### PR DESCRIPTION
Fixes incorrect docs related to the `bs:disable-line` comment.