### PR TITLE
Prompt to restart lsp if it has stopped

### DIFF
--- a/src/LanguageServerManager.spec.ts
+++ b/src/LanguageServerManager.spec.ts
@@ -28,7 +28,7 @@ Module.prototype.require = function hijacked(file) {
 
 const tempDir = s`${process.cwd()}/.tmp`;
 
-describe('extension', () => {
+describe('LanguageServerManager', () => {
     let languageServerManager: LanguageServerManager;
 
     beforeEach(() => {
@@ -53,6 +53,15 @@ describe('extension', () => {
     afterEach(() => {
         sinon.restore();
         fsExtra.removeSync(tempDir);
+    });
+
+    describe('updateStatusbar', () => {
+        it('does not crash when undefined', () => {
+            delete languageServerManager['statusbarItem'];
+            //the test passes if these don't throw
+            languageServerManager['updateStatusbar'](true);
+            languageServerManager['updateStatusbar'](false);
+        });
     });
 
     it('registers referenceProvider', () => {


### PR DESCRIPTION
Whenever the language server crashes, vscode will restart it. After the 5th crash, they'll leave it permanently crashed. There seems to be no time limit on adding up to the 5, so even after a few days, vscode may still terminate the language server. 

This PR adds tracking for when language server is stopped and then not started back up again after a period of time.
For example, 20 seconds after after the final failure, this event fires so that we can show a "wanna restart it" popup.

![image](https://github.com/rokucommunity/vscode-brightscript-language/assets/2544493/f9c128d9-09cc-4b67-834d-81e7df4d8252)
