### PR TITLE
Add syntax highlighting support for bsdoc tags

### DIFF
--- a/src/grammar/brightscript.tmLanguage.spec.ts
+++ b/src/grammar/brightscript.tmLanguage.spec.ts
@@ -224,6 +224,10 @@ describe('brightscript.tmlanguage.json', () => {
         `);
     });
 
+    /**
+     * @param test comment 123
+     */
+
     it('handles comments following interface fields', async () => {
         await testGrammar(`
             interface Person
@@ -252,6 +256,123 @@ describe('brightscript.tmlanguage.json', () => {
                '    ^^^^ entity.name.function.member.brs
                '^^^ storage.type.function.brs
         `);
+    });
+
+    describe('bsdoc', () => {
+        //the grammar tester doesn't like testing standalone comments, so prefix all of the testable lines of code in this block with a single `t` identifier
+
+        it('colorizes generic tags correctly', async () => {
+            await testGrammar(`
+                t'@unknownparam just comments
+                '               ^^^^^^^^^^^^^ comment.block.documentation.brs
+                '  ^^^^^^^^^^^^ storage.type.class.bsdoc
+                ' ^ storage.type.class.bsdoc
+                '^ comment.line.apostrophe.brs
+            `);
+        });
+
+        /**
+         * @param p1 comment one
+         * @param {string} p1 comment one
+         */
+        it('colorizes @param without type', async () => {
+            await testGrammar(`
+                t'@param p1
+                '        ^^ variable.other.bsdoc
+                '  ^^^^^ storage.type.class.bsdoc
+                ' ^ storage.type.class.bsdoc
+                '^ comment.line.apostrophe.brs
+            `);
+        });
+
+        it('colorizes @param', async () => {
+            await testGrammar(`
+                t'@param {boolean} p1
+                '                  ^^ variable.other.bsdoc
+                '                ^ punctuation.definition.bracket.curly.end.bsdoc
+                '         ^^^^^^^ entity.name.type.instance.bsdoc
+                '        ^ punctuation.definition.bracket.curly.begin.bsdoc
+                '  ^^^^^ storage.type.class.bsdoc
+                ' ^ storage.type.class.bsdoc
+                '^ comment.line.apostrophe.brs
+            `);
+        });
+
+        it('colorizes @param without name', async () => {
+            await testGrammar(`
+                t'@param {boolean}
+                '                ^ punctuation.definition.bracket.curly.end.bsdoc
+                '         ^^^^^^^ entity.name.type.instance.bsdoc
+                '        ^ punctuation.definition.bracket.curly.begin.bsdoc
+                '  ^^^^^ storage.type.class.bsdoc
+                ' ^ storage.type.class.bsdoc
+                '^ comment.line.apostrophe.brs
+            `);
+        });
+
+        it('colorizes @param with comment', async () => {
+            await testGrammar(`
+                t'@param {boolean} p1 this is a comment
+                '                     ^^^^^^^^^^^^^^^^^ comment.block.documentation.brs
+                '                  ^^ variable.other.bsdoc
+                '                ^ punctuation.definition.bracket.curly.end.bsdoc
+                '         ^^^^^^^ entity.name.type.instance.bsdoc
+                '        ^ punctuation.definition.bracket.curly.begin.bsdoc
+                '  ^^^^^ storage.type.class.bsdoc
+                ' ^ storage.type.class.bsdoc
+                '^ comment.line.apostrophe.brs
+            `);
+        });
+
+        it('colorizes @type without type', async () => {
+            await testGrammar(`
+                t'@type p1
+                '       ^^ variable.other.bsdoc
+                '  ^^^^ storage.type.class.bsdoc
+                ' ^ storage.type.class.bsdoc
+                '^ comment.line.apostrophe.brs
+            `);
+        });
+
+        it('colorizes @param', async () => {
+            await testGrammar(`
+                t'@type {boolean} p1
+                '                 ^^ variable.other.bsdoc
+                '               ^ punctuation.definition.bracket.curly.end.bsdoc
+                '        ^^^^^^^ entity.name.type.instance.bsdoc
+                '       ^ punctuation.definition.bracket.curly.begin.bsdoc
+                '  ^^^^ storage.type.class.bsdoc
+                ' ^ storage.type.class.bsdoc
+                '^ comment.line.apostrophe.brs
+            `);
+        });
+
+        it('colorizes @param without name', async () => {
+            await testGrammar(`
+                t'@type {boolean}
+                '               ^ punctuation.definition.bracket.curly.end.bsdoc
+                '        ^^^^^^^ entity.name.type.instance.bsdoc
+                '       ^ punctuation.definition.bracket.curly.begin.bsdoc
+                '  ^^^^ storage.type.class.bsdoc
+                ' ^ storage.type.class.bsdoc
+                '^ comment.line.apostrophe.brs
+            `);
+        });
+
+        it('colorizes @param with comment', async () => {
+            await testGrammar(`
+                t'@type {boolean} p1 this is a comment
+                '                    ^^^^^^^^^^^^^^^^^ comment.block.documentation.brs
+                '                 ^^ variable.other.bsdoc
+                '               ^ punctuation.definition.bracket.curly.end.bsdoc
+                '        ^^^^^^^ entity.name.type.instance.bsdoc
+                '       ^ punctuation.definition.bracket.curly.begin.bsdoc
+                '  ^^^^ storage.type.class.bsdoc
+                ' ^ storage.type.class.bsdoc
+                '^ comment.line.apostrophe.brs
+            `);
+        });
+
     });
 
     it.skip('handles `as Function` parameters properly', async () => {

--- a/syntaxes/brightscript.tmLanguage.json
+++ b/syntaxes/brightscript.tmLanguage.json
@@ -20,6 +20,9 @@
                     "include": "#regex"
                 },
                 {
+                    "include": "#bsdoc"
+                },
+                {
                     "include": "#if_with_paren"
                 },
                 {
@@ -996,6 +999,62 @@
         "vscode_rale_tracker_entry_comment": {
             "match": "('\\s*vscode_rale_tracker_entry[^\\S\\r\\n]*)",
             "name": "keyword.preprocessor.brs"
+        },
+        "bsdoc": {
+            "patterns": [
+                {
+                    "include": "#bsdoc_param_and_type"
+                },
+                {
+                    "include": "#bsdoc_generic"
+                }
+            ]
+        },
+        "bsdoc_generic": {
+            "match": "(?i:\\s*(rem|')\\s*(@)(\\w+)(.*$))",
+            "captures": {
+                "1": {
+                    "name": "comment.line.apostrophe.brs"
+                },
+                "2": {
+                    "name": "punctuation.definition.block.tag.bsdoc storage.type.class.bsdoc"
+                },
+                "3": {
+                    "name": "punctuation.definition.block.tag.bsdoc storage.type.class.bsdoc"
+                },
+                "4": {
+                    "name": "comment.block.documentation.brs"
+                }
+            }
+        },
+        "bsdoc_param_and_type": {
+            "match": "(?i:\\s*(rem|')\\s*(@)(param|type)\\s*(?:(\\{)\\s*([^\\}]+)\\s*(\\}))?\\s*([a-z0-9_.]+)?(.*))",
+            "captures": {
+                "1": {
+                    "name": "comment.line.apostrophe.brs"
+                },
+                "2": {
+                    "name": "punctuation.definition.block.tag.bsdoc storage.type.class.bsdoc"
+                },
+                "3": {
+                    "name": "punctuation.definition.block.tag.bsdoc storage.type.class.bsdoc"
+                },
+                "4": {
+                    "name": "punctuation.definition.bracket.curly.begin.bsdoc"
+                },
+                "5": {
+                    "name": " comment.block.documentation.brs entity.name.type.instance.bsdoc"
+                },
+                "6": {
+                    "name": "punctuation.definition.bracket.curly.end.bsdoc"
+                },
+                "7": {
+                    "name": "variable.other.bsdoc"
+                },
+                "8": {
+                    "name": "comment.block.documentation.brs"
+                }
+            }
         },
         "annotation": {
             "patterns": [

--- a/syntaxes/brightscript.tmLanguage.json
+++ b/syntaxes/brightscript.tmLanguage.json
@@ -1011,7 +1011,7 @@
             ]
         },
         "bsdoc_generic": {
-            "match": "(?i:\\s*(rem|')\\s*(@)(\\w+)(.*$))",
+            "match": "(?i:\\s*(rem|'+)\\s*(@)(\\w+)(.*$))",
             "captures": {
                 "1": {
                     "name": "comment.line.apostrophe.brs"
@@ -1028,7 +1028,7 @@
             }
         },
         "bsdoc_param_and_type": {
-            "match": "(?i:\\s*(rem|')\\s*(@)(param|type)\\s*(?:(\\{)\\s*([^\\}]+)\\s*(\\}))?\\s*([a-z0-9_.]+)?(.*))",
+            "match": "(?i:\\s*(rem|'+)\\s*(@)(param|type)\\s*(?:(\\{)\\s*([^\\}]+)\\s*(\\}))?\\s*([a-z0-9_.]+)?(.*))",
             "captures": {
                 "1": {
                     "name": "comment.line.apostrophe.brs"

--- a/syntaxes/brightscript.tmLanguage.json
+++ b/syntaxes/brightscript.tmLanguage.json
@@ -1028,7 +1028,7 @@
             }
         },
         "bsdoc_param_and_type": {
-            "match": "(?i:\\s*(rem|'+)\\s*(@)(param|type)\\s*(?:(\\{)\\s*([^\\}]+)\\s*(\\}))?\\s*([a-z0-9_.]+)?(.*))",
+            "match": "(?i:\\s*(rem|'+)\\s*(@)(param|type)\\s+(?:(\\{)\\s*([^\\}]+)\\s*(\\}))?\\s*([a-z0-9_.]+)?(.*))",
             "captures": {
                 "1": {
                     "name": "comment.line.apostrophe.brs"


### PR DESCRIPTION
Adds support for syntax highlighting of bsdoc tags and types.

![image](https://github.com/user-attachments/assets/279bd2db-4e4d-4eb8-a250-025d29ef0887)
