### PR TITLE
Fix crashes where workspaceFolders was undefined

### DIFF
--- a/src/BrightScriptCommands.ts
+++ b/src/BrightScriptCommands.ts
@@ -454,8 +454,8 @@ export class BrightScriptCommands {
         this.workspacePath = await this.context.workspaceState.get('workspacePath');
         //let folderUri: vscode.Uri;
         if (!this.workspacePath) {
-            if (vscode.workspace.workspaceFolders.length === 1) {
-                this.workspacePath = vscode.workspace.workspaceFolders[0].uri.fsPath;
+            if (vscode.workspace.workspaceFolders?.length === 1) {
+                this.workspacePath = vscode.workspace.workspaceFolders?.[0].uri.fsPath;
             } else {
                 //there are multiple workspaces, ask the user to specify which one they want to use
                 let workspaceFolder = await vscode.window.showWorkspaceFolderPick();

--- a/src/DebugConfigurationProvider.ts
+++ b/src/DebugConfigurationProvider.ts
@@ -234,7 +234,7 @@ export class BrightScriptDebugConfigurationProvider implements DebugConfiguratio
             folderUri = folder.uri;
 
             //if there's only one workspace, use that workspace's folder path
-        } else if (vscode.workspace.workspaceFolders.length === 1) {
+        } else if (vscode.workspace.workspaceFolders?.length === 1) {
             folderUri = vscode.workspace.workspaceFolders[0].uri;
         } else {
             //there are multiple workspaces, ask the user to specify which one they want to use

--- a/src/DeclarationProvider.ts
+++ b/src/DeclarationProvider.ts
@@ -49,7 +49,7 @@ export class WorkspaceEncoding {
 
     public reset() {
         this.encoding = [];
-        for (const folder of vscode.workspace.workspaceFolders) {
+        for (const folder of vscode.workspace.workspaceFolders ?? []) {
             this.encoding.push([folder.uri.fsPath, this.getConfiguration(folder.uri)]);
         }
     }

--- a/src/LanguageServerManager.ts
+++ b/src/LanguageServerManager.ts
@@ -468,14 +468,14 @@ export class LanguageServerManager {
         }
 
         //collect `brightscript.bsdk` setting value from each workspaceFolder
-        const folderResults = vscode.workspace.workspaceFolders.reduce((acc, workspaceFolder) => {
+        const folderResults = vscode.workspace.workspaceFolders?.reduce((acc, workspaceFolder) => {
             const versionInfo = vscode.workspace.getConfiguration('brightscript', workspaceFolder).get<string>('bsdk');
             const parsed = this.parseVersionInfo(versionInfo, workspaceFolder.uri.fsPath);
             if (parsed) {
                 acc.set(parsed.value, parsed);
             }
             return acc;
-        }, new Map<string, ParsedVersionInfo>());
+        }, new Map<string, ParsedVersionInfo>()) ?? new Map<string, ParsedVersionInfo>();
 
         //no results found, use the embedded version
         if (folderResults.size === 0) {

--- a/src/commands/LanguageServerInfoCommand.ts
+++ b/src/commands/LanguageServerInfoCommand.ts
@@ -141,7 +141,7 @@ export class LanguageServerInfoCommand {
      */
     public async selectBrighterScriptVersion(): Promise<string> {
         const quickPickItems = this.discoverBrighterScriptVersions(
-            vscode.workspace.workspaceFolders.map(x => this.getWorkspaceOrFolderPath(x.uri.fsPath))
+            vscode.workspace.workspaceFolders?.map(x => this.getWorkspaceOrFolderPath(x.uri.fsPath)) ?? []
         );
 
         //start the request right now, we will leverage it later


### PR DESCRIPTION
Fix several spots where workspaceFolders was not being safely accessed, since it can sometimes be `undefined`.

Originally reported in #588 