### PR TITLE
Fix bug with m.top colorization

### DIFF
--- a/src/grammar/brightscript.tmLanguage.spec.ts
+++ b/src/grammar/brightscript.tmLanguage.spec.ts
@@ -31,6 +31,27 @@ describe('brightscript.tmlanguage.json', () => {
        `);
     });
 
+    it('does not color `top` as a variable name', async () => {
+        await testGrammar(`
+            top = true
+           '^^^ entity.name.variable.local.brs
+        `);
+    });
+
+    it('does not color `top` when part of another variable name', async () => {
+        await testGrammar(`
+             m.top1 = true
+            '  ^^^^ variable.other.object.property.brs
+            '^ keyword.other.this.brs
+        `);
+
+        await testGrammar(`
+            m.1top = true
+           '  ^^^^ variable.other.object.property.brs
+           '^ keyword.other.this.brs
+       `);
+    });
+
     it('colors alias statement properly', async () => {
         await testGrammar(`
              alias alpha = beta

--- a/syntaxes/brightscript.tmLanguage.json
+++ b/syntaxes/brightscript.tmLanguage.json
@@ -657,7 +657,7 @@
                     "name": "keyword.other.this.brs"
                 }
             },
-            "match": "(?i:(?<!\\.)\\b(m|super)\\b(?:\\s*\\.\\s*(top|global))?)"
+            "match": "(?i:(?<!\\.)\\b(m|super)\\b(?:\\s*\\.\\s*(top|global)\\b)?)"
         },
         "variables_and_params": {
             "match": "(?i:(?:\\b(new)\\s)?\\b(?<!\\.)([a-z_][a-z0-9_\\$%!#]*)\\b)",


### PR DESCRIPTION
Fixes syntax highlighting bug related to `.top`

Before:
![image](https://github.com/user-attachments/assets/3d050870-ddea-4fd9-a5a4-7cad73562f00)

After:
![image](https://github.com/user-attachments/assets/2bc8ceac-3484-4bdc-b63c-0b2c28dc628a)
