### PR TITLE
Syntax highlighting but for object functions

### DIFF
--- a/src/grammar/brightscript.tmLanguage.spec.ts
+++ b/src/grammar/brightscript.tmLanguage.spec.ts
@@ -535,6 +535,246 @@ describe('brightscript.tmlanguage.json', () => {
         `);
     });
 
+    it('handles named function declarations', async () => {
+        await testGrammar(`
+             sub write()
+            '    ^^^^^ entity.name.function.brs
+            '^^^ keyword.declaration.function.brs
+
+             end sub
+            '^^^^^^^ keyword.declaration.function.brs
+        `);
+
+        await testGrammar(`
+             sub write ()
+            '    ^^^^^ entity.name.function.brs
+            '^^^ keyword.declaration.function.brs
+
+             end sub
+            '^^^^^^^ keyword.declaration.function.brs
+        `);
+
+        await testGrammar(`
+             sub write() as string
+            '               ^^^^^^ storage.type.brs
+            '            ^^ keyword.control.brs
+            '    ^^^^^ entity.name.function.brs
+            '^^^ keyword.declaration.function.brs
+
+             end sub
+            '^^^^^^^ keyword.declaration.function.brs
+        `);
+
+        await testGrammar(`
+             sub write(param as function) as string
+            '                                ^^^^^^ storage.type.brs
+            '                             ^^ keyword.control.brs
+            '                   ^^^^^^^^ storage.type.brs
+            '                ^^ keyword.control.brs
+            '          ^^^^^ entity.name.variable.local.brs
+            '    ^^^^^ entity.name.function.brs
+            '^^^ keyword.declaration.function.brs
+
+             end sub
+            '^^^^^^^ keyword.declaration.function.brs
+        `);
+    });
+
+    it('handles named public/protected/private function declarations', async () => {
+        await testGrammar(`
+             public sub write()
+            '           ^^^^^ entity.name.function.brs
+            '       ^^^ keyword.declaration.function.brs
+            '^^^^^^ storage.modifier.brs
+
+             end sub
+            '^^^^^^^ keyword.declaration.function.brs
+        `);
+
+        await testGrammar(`
+             protected sub write()
+            '              ^^^^^ entity.name.function.brs
+            '          ^^^ keyword.declaration.function.brs
+            '^^^^^^^^^ storage.modifier.brs
+
+             end sub
+            '^^^^^^^ keyword.declaration.function.brs
+        `);
+
+        await testGrammar(`
+             private sub write()
+            '            ^^^^^ entity.name.function.brs
+            '        ^^^ keyword.declaration.function.brs
+            '^^^^^^^ storage.modifier.brs
+
+             end sub
+            '^^^^^^^ keyword.declaration.function.brs
+        `);
+
+        await testGrammar(`
+             public sub write() as string
+            '                      ^^^^^^ storage.type.brs
+            '                   ^^ keyword.control.brs
+            '           ^^^^^ entity.name.function.brs
+            '       ^^^ keyword.declaration.function.brs
+            '^^^^^^ storage.modifier.brs
+
+             end sub
+            '^^^^^^^ keyword.declaration.function.brs
+        `);
+
+        await testGrammar(`
+             public sub write(param as function) as string
+            '                                       ^^^^^^ storage.type.brs
+            '                                    ^^ keyword.control.brs
+            '                          ^^^^^^^^ storage.type.brs
+            '                       ^^ keyword.control.brs
+            '                 ^^^^^ entity.name.variable.local.brs
+            '           ^^^^^ entity.name.function.brs
+            '       ^^^ keyword.declaration.function.brs
+            '^^^^^^ storage.modifier.brs
+
+             end sub
+            '^^^^^^^ keyword.declaration.function.brs
+        `);
+    });
+
+    it('handles named public/protected/private with override function declarations', async () => {
+        await testGrammar(`
+             public override sub write()
+            '                    ^^^^^ entity.name.function.brs
+            '                ^^^ keyword.declaration.function.brs
+            '       ^^^^^^^^ storage.modifier.brs
+            '^^^^^^ storage.modifier.brs
+
+             end sub
+            '^^^^^^^ keyword.declaration.function.brs
+        `);
+
+        await testGrammar(`
+             protected override sub write()
+            '                       ^^^^^ entity.name.function.brs
+            '                   ^^^ keyword.declaration.function.brs
+            '          ^^^^^^^^ storage.modifier.brs
+            '^^^^^^^^^ storage.modifier.brs
+
+             end sub
+            '^^^^^^^ keyword.declaration.function.brs
+        `);
+
+        await testGrammar(`
+             private override sub write()
+            '                     ^^^^^ entity.name.function.brs
+            '                 ^^^ keyword.declaration.function.brs
+            '        ^^^^^^^^ storage.modifier.brs
+            '^^^^^^^ storage.modifier.brs
+
+             end sub
+            '^^^^^^^ keyword.declaration.function.brs
+        `);
+
+        await testGrammar(`
+             public override sub write() as string
+            '                               ^^^^^^ storage.type.brs
+            '                            ^^ keyword.control.brs
+            '                    ^^^^^ entity.name.function.brs
+            '                ^^^ keyword.declaration.function.brs
+            '       ^^^^^^^^ storage.modifier.brs
+            '^^^^^^ storage.modifier.brs
+
+             end sub
+            '^^^^^^^ keyword.declaration.function.brs
+        `);
+
+        await testGrammar(`
+             public override sub write(param as function) as string
+            '                                                ^^^^^^ storage.type.brs
+            '                                             ^^ keyword.control.brs
+            '                                   ^^^^^^^^ storage.type.brs
+            '                                ^^ keyword.control.brs
+            '                          ^^^^^ entity.name.variable.local.brs
+            '                    ^^^^^ entity.name.function.brs
+            '                ^^^ keyword.declaration.function.brs
+            '       ^^^^^^^^ storage.modifier.brs
+            '^^^^^^ storage.modifier.brs
+
+             end sub
+            '^^^^^^^ keyword.declaration.function.brs
+        `);
+    });
+
+    it('handles anon function declarations', async () => {
+        await testGrammar(`
+             var = function ()
+            '      ^^^^^^^^ keyword.declaration.function.brs
+            '^^^ entity.name.variable.local.brs
+
+             end function
+            '^^^^^^^ keyword.declaration.function.brs
+        `);
+
+        await testGrammar(`
+             var = function()
+            '      ^^^^^^^^ keyword.declaration.function.brs
+            '^^^ entity.name.variable.local.brs
+
+             end function
+            '^^^^^^^ keyword.declaration.function.brs
+        `);
+
+        await testGrammar(`
+             var = function() as string
+            '                    ^^^^^^ storage.type.brs
+            '                 ^^ keyword.control.brs
+            '      ^^^^^^^^ keyword.declaration.function.brs
+            '^^^ entity.name.variable.local.brs
+
+             end function
+            '^^^^^^^ keyword.declaration.function.brs
+        `);
+
+        await testGrammar(`
+             var = function(param as function) as string
+            '                                     ^^^^^^ storage.type.brs
+            '                                  ^^ keyword.control.brs
+            '                        ^^^^^^^^ storage.type.brs
+            '                     ^^ keyword.control.brs
+            '               ^^^^^ entity.name.variable.local.brs
+            '      ^^^^^^^^ keyword.declaration.function.brs
+            '^^^ entity.name.variable.local.brs
+
+             end function
+            '^^^^^^^ keyword.declaration.function.brs
+        `);
+
+        await testGrammar(`
+             var = {
+                name: function() as string
+              '                     ^^^^^^ storage.type.brs
+              '                  ^^ keyword.control.brs
+              '       ^^^^^^^^ keyword.declaration.function.brs
+
+               end function
+              '^^^^^^^ keyword.declaration.function.brs
+             }
+        `);
+
+        await testGrammar(`
+             var = {
+                name: function(param as function) as string
+              '                                      ^^^^^^ storage.type.brs
+              '                                   ^^ keyword.control.brs
+              '                         ^^^^^^^^ storage.type.brs
+              '                      ^^ keyword.control.brs
+              '                ^^^^^ entity.name.variable.local.brs
+              '       ^^^^^^^^ keyword.declaration.function.brs
+
+               end function
+              '^^^^^^^ keyword.declaration.function.brs
+             }
+        `);
+    });
+
     it.skip('colorizes class fields properly', async () => {
         //TODO the properties have the wrong scope...this should get fixed when we improve the class textmate scope flow
         await testGrammar(`

--- a/syntaxes/brightscript.tmLanguage.json
+++ b/syntaxes/brightscript.tmLanguage.json
@@ -510,7 +510,7 @@
                     "name": "entity.name.function.brs"
                 }
             },
-            "match": "(?i:(?:(public|protected|private)\\s+)?(?:(override)\\s+)?((?:sub|function)[^\\w])(?:\\s+([a-z_][a-z0-9_]*))?)"
+            "match": "(?i:(?:(public|protected|private)\\s+)?(?:(override)\\s+)?((?:sub|function))(?:\\s+(?:\\(|([a-z_][a-z0-9_]*))))"
         },
         "field": {
             "match": "(?i:(public|protected|private)\\s+([a-z0-9_]+))",
@@ -731,7 +731,7 @@
                     "name": "entity.name.function.brs"
                 }
             },
-            "match": "(?i:(?:(public|protected|private)\\s+)?(?:(override)\\s+)?((?:sub|function)[^\\w])(?:\\s+([a-z_][a-z0-9_]*))?)"
+            "match": "(?i:(?:(public|protected|private)\\s+)?(?:(override)\\s+)?((?:sub|function))(?:\\s+(?:\\(|([a-z_][a-z0-9_]*))))"
         },
         "end_function": {
             "name": "keyword.declaration.function.brs",

--- a/syntaxes/brightscript.tmLanguage.json
+++ b/syntaxes/brightscript.tmLanguage.json
@@ -734,16 +734,16 @@
             "match": "(?i:(?:(public|protected|private)\\s+)?(?:(override)\\s+)?((?:sub|function)[^\\w])(?:\\s+([a-z_][a-z0-9_]*))?)"
         },
         "end_function": {
-            "name": "keyword.declaration.function",
+            "name": "keyword.declaration.function.brs",
             "match": "(?i)[ \\t]*end\\s*(sub|function)"
         },
         "inline_function_declaration": {
             "captures": {
                 "1": {
-                    "name": "keyword.declaration.function"
+                    "name": "keyword.declaration.function.brs"
                 },
                 "2": {
-                    "name": "keyword.declaration.function"
+                    "name": "keyword.declaration.function.brs"
                 }
             },
             "match": "(?i)[^a-z0-9_\"](function|sub)\\s*\\("


### PR DESCRIPTION
Fixes https://github.com/rokucommunity/vscode-brightscript-language/issues/411 syntax highlighting for the `as` keyword in function return types when a parameter is also of type `function`

**Before:**
![image](https://github.com/user-attachments/assets/0afcb88d-0585-4a90-9590-ec33ef406cdc)

**After (notice the `as` is purple now):**
![image](https://github.com/user-attachments/assets/3ad56485-ffb7-4ed0-b174-d86f500f3e90)
