### PR TITLE
Task/new remote commands

### DIFF
--- a/package.json
+++ b/package.json
@@ -177,6 +177,7 @@
         "onCommand:extension.brightscript.pressVolumeDown",
         "onCommand:extension.brightscript.pressVolumeMute",
         "onCommand:extension.brightscript.pressVolumeUp",
+        "onCommand:extension.brightscript.setVolume",
         "onCommand:extension.brightscript.pressPowerOff",
         "onCommand:extension.brightscript.pressChannelUp",
         "onCommand:extension.brightscript.pressChannelDown",
@@ -2855,6 +2856,12 @@
             {
                 "command": "extension.brightscript.pressVolumeUp",
                 "title": "Press the VolumeUp button on the Roku remote",
+                "category": "Brightscript"
+            },
+            {
+                "command": "extension.brightscript.setVolume",
+                "title": "Set a target volume level by repeatedly pressing VolumeDown followed by VolumeUp buttons on the Roku remote",
+                "shortTitle": "Set Volume target volume level",
                 "category": "Brightscript"
             },
             {

--- a/package.json
+++ b/package.json
@@ -2865,7 +2865,7 @@
             },
             {
                 "command": "extension.brightscript.setVolume",
-                "title": "Set a target volume level by repeatedly pressing VolumeDown followed by VolumeUp buttons on the Roku remote",
+                "title": "Set the volume on a volume-enabled Roku device to the specified value (0-100)",
                 "shortTitle": "Set Volume target volume level",
                 "category": "Brightscript"
             },

--- a/package.json
+++ b/package.json
@@ -181,6 +181,11 @@
         "onCommand:extension.brightscript.pressPowerOff",
         "onCommand:extension.brightscript.pressChannelUp",
         "onCommand:extension.brightscript.pressChannelDown",
+        "onCommand:extension.brightscript.pressBlue",
+        "onCommand:extension.brightscript.pressGreen",
+        "onCommand:extension.brightscript.pressRed",
+        "onCommand:extension.brightscript.pressYellow",
+        "onCommand:extension.brightscript.pressExit",
         "onCommand:extension.brightscript.changeTvInput",
         "onCommand:extension.brightscript.sendRemoteText",
         "onCommand:brighterscript.showPreview",
@@ -2882,6 +2887,31 @@
             {
                 "command": "extension.brightscript.pressChannelDown",
                 "title": "Press the ChannelDown button on the Roku remote",
+                "category": "Brightscript"
+            },
+            {
+                "command": "extension.brightscript.pressBlue",
+                "title": "Press the Blue button on the Roku remote",
+                "category": "Brightscript"
+            },
+            {
+                "command": "extension.brightscript.pressGreen",
+                "title": "Press the Green button on the Roku remote",
+                "category": "Brightscript"
+            },
+            {
+                "command": "extension.brightscript.pressRed",
+                "title": "Press the Red button on the Roku remote",
+                "category": "Brightscript"
+            },
+            {
+                "command": "extension.brightscript.pressYellow",
+                "title": "Press the Yellow button on the Roku remote",
+                "category": "Brightscript"
+            },
+            {
+                "command": "extension.brightscript.pressExit",
+                "title": "Press the Exit button on the Roku remote",
                 "category": "Brightscript"
             },
             {

--- a/src/BrightScriptCommands.ts
+++ b/src/BrightScriptCommands.ts
@@ -236,6 +236,26 @@ export class BrightScriptCommands {
             await this.sendRemoteCommand('ChannelDown');
         });
 
+        this.registerCommand('pressBlue', async () => {
+            await this.sendRemoteCommand('Blue');
+        });
+
+        this.registerCommand('pressGreen', async () => {
+            await this.sendRemoteCommand('Green');
+        });
+
+        this.registerCommand('pressRed', async () => {
+            await this.sendRemoteCommand('Red');
+        });
+
+        this.registerCommand('pressYellow', async () => {
+            await this.sendRemoteCommand('Yellow');
+        });
+
+        this.registerCommand('pressExit', async () => {
+            await this.sendRemoteCommand('Exit');
+        });
+
         this.registerCommand('changeTvInput', async (host?: string) => {
             const selectedInput = await vscode.window.showQuickPick([
                 'InputHDMI1',

--- a/src/BrightScriptCommands.ts
+++ b/src/BrightScriptCommands.ts
@@ -180,6 +180,46 @@ export class BrightScriptCommands {
             await this.sendRemoteCommand('VolumeUp');
         });
 
+        this.registerCommand('setVolume', async () => {
+            let result = await vscode.window.showInputBox({
+                placeHolder: 'The target volume level (0-100)',
+                value: '',
+                validateInput: (text: string) => {
+                    const num = Number(text);
+                    if (isNaN(num)) {
+                        return 'Value must be a number';
+                    } else if (num < 0 || num > 100) {
+                        return 'Please enter a number between 0 and 100';
+                    }
+                    return null;
+                }
+            });
+            const targetVolume = Number(result);
+
+            if (!isNaN(targetVolume)) {
+                await vscode.window.withProgress({
+                    location: vscode.ProgressLocation.Notification,
+                    title: 'Setting volume'
+                }, async (progress) => {
+                    const totalCommands = 100 + targetVolume;
+                    const incrementValue = 100 / totalCommands;
+                    let executedCommands = 0;
+
+                    for (let i = 0; i < 100; i++) {
+                        await this.sendRemoteCommand('VolumeDown');
+                        executedCommands++;
+                        progress.report({ increment: incrementValue, message: `decreasing volume - ${Math.round((executedCommands / totalCommands) * 100)}%` });
+                    }
+
+                    for (let i = 0; i < targetVolume; i++) {
+                        await this.sendRemoteCommand('VolumeUp');
+                        executedCommands++;
+                        progress.report({ increment: incrementValue, message: `increasing volume - ${Math.round((executedCommands / totalCommands) * 100)}%` });
+                    }
+                });
+            }
+        });
+
         this.registerCommand('pressPowerOff', async () => {
             await this.sendRemoteCommand('PowerOff');
         });

--- a/src/BrightScriptCommands.ts
+++ b/src/BrightScriptCommands.ts
@@ -177,7 +177,7 @@ export class BrightScriptCommands {
         });
 
         this.registerCommand('pressVolumeUp', async () => {
-            await this.sendRemoteCommand('FindVolumeUp');
+            await this.sendRemoteCommand('VolumeUp');
         });
 
         this.registerCommand('pressPowerOff', async () => {


### PR DESCRIPTION
**Added the following new commands:**
- `extension.brightscript.setVolume`: Set a target volume level by repeatedly pressing VolumeDown followed by VolumeUp buttons on the Roku remote
- `extension.brightscript.pressBlue`: Press the Blue button on the Roku remote
- `extension.brightscript.pressGreen`: Press the Green button on the Roku remote
- `extension.brightscript.pressRed`: Press the Red button on the Roku remote
- `extension.brightscript.pressYellow`: Press the Yellow button on the Roku remote
- `extension.brightscript.pressExit`: Press the Exit button on the Roku remote

**Fixed the following commands:**
- `extension.brightscript.pressVolumeUp`: This was sending the wrong value to the device resulting in an error and failing to execute