### PR TITLE
Retain original newlines in BrightScript Log output panel, and also strip ansii colors

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -42,6 +42,7 @@
                 "roku-test-automation": "^2.0.10",
                 "semver": "^7.1.3",
                 "source-map": "^0.7.3",
+                "strip-ansi": "^5.2.0",
                 "thenby": "^1.3.4",
                 "undent": "^0.1.0",
                 "uuid": "^9.0.1",
@@ -2368,11 +2369,11 @@
             }
         },
         "node_modules/ansi-regex": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+            "version": "4.1.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-4.1.1.tgz",
+            "integrity": "sha512-ILlv4k/3f6vfQ4OoP2AGvirOktlQ98ZEL1k9FaQjxa3L1abBgbuTDAdPOpvbGncC0BTVQrl+OM8xZGK6tWXt7g==",
             "engines": {
-                "node": ">=8"
+                "node": ">=6"
             }
         },
         "node_modules/ansi-styles": {
@@ -2884,6 +2885,14 @@
                 "bsfmt": "dist/cli.js"
             }
         },
+        "node_modules/brighterscript-formatter/node_modules/ansi-regex": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/brighterscript-formatter/node_modules/cliui": {
             "version": "8.0.1",
             "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
@@ -2923,6 +2932,17 @@
                 "emoji-regex": "^8.0.0",
                 "is-fullwidth-code-point": "^3.0.0",
                 "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/brighterscript-formatter/node_modules/strip-ansi": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
             },
             "engines": {
                 "node": ">=8"
@@ -3440,6 +3460,14 @@
                 "wrap-ansi": "^7.0.0"
             }
         },
+        "node_modules/cliui/node_modules/ansi-regex": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/cliui/node_modules/emoji-regex": {
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -3461,6 +3489,17 @@
                 "emoji-regex": "^8.0.0",
                 "is-fullwidth-code-point": "^3.0.0",
                 "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/cliui/node_modules/strip-ansi": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
             },
             "engines": {
                 "node": ">=8"
@@ -4820,6 +4859,15 @@
                 "node": "^12.22.0 || ^14.17.0 || >=16.0.0"
             }
         },
+        "node_modules/eslint/node_modules/ansi-regex": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/eslint/node_modules/argparse": {
             "version": "2.0.1",
             "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
@@ -4894,6 +4942,18 @@
             "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.2.tgz",
             "integrity": "sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==",
             "dev": true
+        },
+        "node_modules/eslint/node_modules/strip-ansi": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "dev": true,
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
         },
         "node_modules/esniff": {
             "version": "2.0.1",
@@ -5742,6 +5802,14 @@
                 "glob-all": "bin/glob-all"
             }
         },
+        "node_modules/glob-all/node_modules/ansi-regex": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/glob-all/node_modules/cliui": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
@@ -5821,6 +5889,17 @@
                 "emoji-regex": "^8.0.0",
                 "is-fullwidth-code-point": "^3.0.0",
                 "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/glob-all/node_modules/strip-ansi": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
             },
             "engines": {
                 "node": ">=8"
@@ -8010,6 +8089,15 @@
                 "node": ">=8.9"
             }
         },
+        "node_modules/nyc/node_modules/ansi-regex": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/nyc/node_modules/cliui": {
             "version": "6.0.0",
             "resolved": "https://registry.npmjs.org/cliui/-/cliui-6.0.0.tgz",
@@ -8106,6 +8194,18 @@
                 "emoji-regex": "^8.0.0",
                 "is-fullwidth-code-point": "^3.0.0",
                 "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/nyc/node_modules/strip-ansi": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "dev": true,
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
             },
             "engines": {
                 "node": ">=8"
@@ -9137,6 +9237,14 @@
                 "node": ">=10"
             }
         },
+        "node_modules/replace-in-file/node_modules/ansi-regex": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/replace-in-file/node_modules/cliui": {
             "version": "8.0.1",
             "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
@@ -9171,6 +9279,17 @@
                 "emoji-regex": "^8.0.0",
                 "is-fullwidth-code-point": "^3.0.0",
                 "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/replace-in-file/node_modules/strip-ansi": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
             },
             "engines": {
                 "node": ">=8"
@@ -10071,6 +10190,15 @@
                 "statigen": "dist/cli.js"
             }
         },
+        "node_modules/statigen/node_modules/ansi-regex": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+            "dev": true,
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/statigen/node_modules/cliui": {
             "version": "8.0.1",
             "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
@@ -10135,6 +10263,18 @@
                 "emoji-regex": "^8.0.0",
                 "is-fullwidth-code-point": "^3.0.0",
                 "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/statigen/node_modules/strip-ansi": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "dev": true,
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
             },
             "engines": {
                 "node": ">=8"
@@ -10326,14 +10466,14 @@
             }
         },
         "node_modules/strip-ansi": {
-            "version": "6.0.1",
-            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
-            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "version": "5.2.0",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-5.2.0.tgz",
+            "integrity": "sha512-DuRs1gKbBqsMKIZlrffwlug8MHkcnpjs5VPmL1PAh+mA30U0DTotfDZ0d2UUsXpPmPmMMJ6W773MaA3J+lbiWA==",
             "dependencies": {
-                "ansi-regex": "^5.0.1"
+                "ansi-regex": "^4.1.0"
             },
             "engines": {
-                "node": ">=8"
+                "node": ">=6"
             }
         },
         "node_modules/strip-bom": {
@@ -11384,6 +11524,14 @@
                 "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
             }
         },
+        "node_modules/wrap-ansi/node_modules/ansi-regex": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/wrap-ansi/node_modules/emoji-regex": {
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -11405,6 +11553,17 @@
                 "emoji-regex": "^8.0.0",
                 "is-fullwidth-code-point": "^3.0.0",
                 "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/wrap-ansi/node_modules/strip-ansi": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
             },
             "engines": {
                 "node": ">=8"
@@ -11542,6 +11701,14 @@
                 "node": ">=8"
             }
         },
+        "node_modules/yargs/node_modules/ansi-regex": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+            "engines": {
+                "node": ">=8"
+            }
+        },
         "node_modules/yargs/node_modules/emoji-regex": {
             "version": "8.0.0",
             "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
@@ -11563,6 +11730,17 @@
                 "emoji-regex": "^8.0.0",
                 "is-fullwidth-code-point": "^3.0.0",
                 "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/yargs/node_modules/strip-ansi": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
             },
             "engines": {
                 "node": ">=8"

--- a/package.json
+++ b/package.json
@@ -177,6 +177,7 @@
         "onCommand:extension.brightscript.pressVolumeDown",
         "onCommand:extension.brightscript.pressVolumeMute",
         "onCommand:extension.brightscript.pressVolumeUp",
+        "onCommand:extension.brightscript.setVolume",
         "onCommand:extension.brightscript.pressPowerOff",
         "onCommand:extension.brightscript.pressChannelUp",
         "onCommand:extension.brightscript.pressChannelDown",
@@ -2855,6 +2856,12 @@
             {
                 "command": "extension.brightscript.pressVolumeUp",
                 "title": "Press the VolumeUp button on the Roku remote",
+                "category": "Brightscript"
+            },
+            {
+                "command": "extension.brightscript.setVolume",
+                "title": "Set a target volume level by repeatedly pressing VolumeDown followed by VolumeUp buttons on the Roku remote",
+                "shortTitle": "Set Volume target volume level",
                 "category": "Brightscript"
             },
             {

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
         "roku-test-automation": "^2.0.10",
         "semver": "^7.1.3",
         "source-map": "^0.7.3",
+        "strip-ansi": "^5.2.0",
         "thenby": "^1.3.4",
         "undent": "^0.1.0",
         "uuid": "^9.0.1",

--- a/package.json
+++ b/package.json
@@ -181,6 +181,11 @@
         "onCommand:extension.brightscript.pressPowerOff",
         "onCommand:extension.brightscript.pressChannelUp",
         "onCommand:extension.brightscript.pressChannelDown",
+        "onCommand:extension.brightscript.pressBlue",
+        "onCommand:extension.brightscript.pressGreen",
+        "onCommand:extension.brightscript.pressRed",
+        "onCommand:extension.brightscript.pressYellow",
+        "onCommand:extension.brightscript.pressExit",
         "onCommand:extension.brightscript.changeTvInput",
         "onCommand:extension.brightscript.sendRemoteText",
         "onCommand:brighterscript.showPreview",
@@ -2882,6 +2887,31 @@
             {
                 "command": "extension.brightscript.pressChannelDown",
                 "title": "Press the ChannelDown button on the Roku remote",
+                "category": "Brightscript"
+            },
+            {
+                "command": "extension.brightscript.pressBlue",
+                "title": "Press the Blue button on the Roku remote",
+                "category": "Brightscript"
+            },
+            {
+                "command": "extension.brightscript.pressGreen",
+                "title": "Press the Green button on the Roku remote",
+                "category": "Brightscript"
+            },
+            {
+                "command": "extension.brightscript.pressRed",
+                "title": "Press the Red button on the Roku remote",
+                "category": "Brightscript"
+            },
+            {
+                "command": "extension.brightscript.pressYellow",
+                "title": "Press the Yellow button on the Roku remote",
+                "category": "Brightscript"
+            },
+            {
+                "command": "extension.brightscript.pressExit",
+                "title": "Press the Exit button on the Roku remote",
                 "category": "Brightscript"
             },
             {

--- a/src/BrightScriptCommands.ts
+++ b/src/BrightScriptCommands.ts
@@ -236,6 +236,26 @@ export class BrightScriptCommands {
             await this.sendRemoteCommand('ChannelDown');
         });
 
+        this.registerCommand('pressBlue', async () => {
+            await this.sendRemoteCommand('Blue');
+        });
+
+        this.registerCommand('pressGreen', async () => {
+            await this.sendRemoteCommand('Green');
+        });
+
+        this.registerCommand('pressRed', async () => {
+            await this.sendRemoteCommand('Red');
+        });
+
+        this.registerCommand('pressYellow', async () => {
+            await this.sendRemoteCommand('Yellow');
+        });
+
+        this.registerCommand('pressExit', async () => {
+            await this.sendRemoteCommand('Exit');
+        });
+
         this.registerCommand('changeTvInput', async (host?: string) => {
             const selectedInput = await vscode.window.showQuickPick([
                 'InputHDMI1',

--- a/src/BrightScriptCommands.ts
+++ b/src/BrightScriptCommands.ts
@@ -180,6 +180,46 @@ export class BrightScriptCommands {
             await this.sendRemoteCommand('VolumeUp');
         });
 
+        this.registerCommand('setVolume', async () => {
+            let result = await vscode.window.showInputBox({
+                placeHolder: 'The target volume level (0-100)',
+                value: '',
+                validateInput: (text: string) => {
+                    const num = Number(text);
+                    if (isNaN(num)) {
+                        return 'Value must be a number';
+                    } else if (num < 0 || num > 100) {
+                        return 'Please enter a number between 0 and 100';
+                    }
+                    return null;
+                }
+            });
+            const targetVolume = Number(result);
+
+            if (!isNaN(targetVolume)) {
+                await vscode.window.withProgress({
+                    location: vscode.ProgressLocation.Notification,
+                    title: 'Setting volume'
+                }, async (progress) => {
+                    const totalCommands = 100 + targetVolume;
+                    const incrementValue = 100 / totalCommands;
+                    let executedCommands = 0;
+
+                    for (let i = 0; i < 100; i++) {
+                        await this.sendRemoteCommand('VolumeDown');
+                        executedCommands++;
+                        progress.report({ increment: incrementValue, message: `decreasing volume - ${Math.round((executedCommands / totalCommands) * 100)}%` });
+                    }
+
+                    for (let i = 0; i < targetVolume; i++) {
+                        await this.sendRemoteCommand('VolumeUp');
+                        executedCommands++;
+                        progress.report({ increment: incrementValue, message: `increasing volume - ${Math.round((executedCommands / totalCommands) * 100)}%` });
+                    }
+                });
+            }
+        });
+
         this.registerCommand('pressPowerOff', async () => {
             await this.sendRemoteCommand('PowerOff');
         });

--- a/src/BrightScriptCommands.ts
+++ b/src/BrightScriptCommands.ts
@@ -177,7 +177,7 @@ export class BrightScriptCommands {
         });
 
         this.registerCommand('pressVolumeUp', async () => {
-            await this.sendRemoteCommand('FindVolumeUp');
+            await this.sendRemoteCommand('VolumeUp');
         });
 
         this.registerCommand('pressPowerOff', async () => {

--- a/src/LogOutputManager.ts
+++ b/src/LogOutputManager.ts
@@ -5,6 +5,7 @@ import type { LogDocumentLinkProvider } from './LogDocumentLinkProvider';
 import { CustomDocumentLink } from './LogDocumentLinkProvider';
 import * as fsExtra from 'fs-extra';
 import type { BrightScriptLaunchConfiguration } from './DebugConfigurationProvider';
+import stripAnsi from 'strip-ansi';
 
 export class LogLine {
     constructor(
@@ -258,6 +259,12 @@ export class LogOutputManager {
      */
     public appendLine(lineText: string, mustInclude = false): void {
         let lines = lineText.split(/\r?\n/g);
+
+        // Remove then last line if it's empty as a result of a trailing newline
+        if (lines[lines.length - 1] === '') {
+            lines.pop();
+        }
+
         for (let line of lines) {
             if (line !== '') {
                 if (!this.includeStackTraces) {
@@ -284,7 +291,9 @@ export class LogOutputManager {
                     }
                 }
             }
-            if (line) {
+            if (typeof line === 'string') {
+                // Strip ANSI color codes
+                line = stripAnsi(line);
                 const logLine = new LogLine(line, mustInclude);
                 this.allLogLines.push(logLine);
                 if (this.shouldLineBeShown(logLine)) {

--- a/src/LogOutputManager.ts
+++ b/src/LogOutputManager.ts
@@ -260,7 +260,7 @@ export class LogOutputManager {
     public appendLine(lineText: string, mustInclude = false): void {
         let lines = lineText.split(/\r?\n/g);
 
-        // Remove then last line if it's empty as a result of a trailing newline
+        // Remove the last line if it's empty as a result of a trailing newline
         if (lines[lines.length - 1] === '') {
             lines.pop();
         }


### PR DESCRIPTION
Retain the original newlines in the `BrightScript Log` output panel that were sent from the device (we had some if statements excluding them). Also strip ansii colors from the output panel because they're very ugly and not supported.