### PR TITLE
bug fix syntax highlighting on return statements

### DIFF
--- a/syntaxes/brightscript.tmLanguage.json
+++ b/syntaxes/brightscript.tmLanguage.json
@@ -134,10 +134,10 @@
                     "include": "#operators"
                 },
                 {
-                    "include": "#support_functions"
+                    "include": "#variables_and_params"
                 },
                 {
-                    "include": "#variables_and_params"
+                    "include": "#support_functions"
                 },
                 {
                     "include": "#annotation"

--- a/syntaxes/brightscript.tmLanguage.json
+++ b/syntaxes/brightscript.tmLanguage.json
@@ -80,6 +80,9 @@
                     "include": "#keyword_logical_operator"
                 },
                 {
+                    "include": "#keyword_return"
+                },
+                {
                     "include": "#function_call"
                 },
                 {
@@ -96,9 +99,6 @@
                 },
                 {
                     "include": "#m_and_global"
-                },
-                {
-                    "include": "#keyword_return"
                 },
                 {
                     "include": "#primitive_literal_expression"


### PR DESCRIPTION
This bug fix is a follow up to https://github.com/rokucommunity/vscode-brightscript-language/pull/627

I identified that return statements in function calls were receiving the incorrect syntax highlighting (yellow) due to the order of operations in which they are processed.

The order has been updated to account for the very first position that `keyword_return` received the correct syntax highlighting within the repo-patterns hierarchy.
