### PR TITLE
syntax highlighting keyword modifier class

### DIFF
--- a/syntaxes/brightscript.tmLanguage.json
+++ b/syntaxes/brightscript.tmLanguage.json
@@ -134,10 +134,10 @@
                     "include": "#operators"
                 },
                 {
-                    "include": "#support_functions"
+                    "include": "#variables_and_params"
                 },
                 {
-                    "include": "#variables_and_params"
+                    "include": "#support_functions"
                 },
                 {
                     "include": "#annotation"

--- a/syntaxes/brightscript.tmLanguage.json
+++ b/syntaxes/brightscript.tmLanguage.json
@@ -80,6 +80,9 @@
                     "include": "#keyword_logical_operator"
                 },
                 {
+                    "include": "#keyword_return"
+                },
+                {
                     "include": "#function_call"
                 },
                 {
@@ -96,9 +99,6 @@
                 },
                 {
                     "include": "#m_and_global"
-                },
-                {
-                    "include": "#keyword_return"
                 },
                 {
                     "include": "#primitive_literal_expression"

--- a/syntaxes/brightscript.tmLanguage.json
+++ b/syntaxes/brightscript.tmLanguage.json
@@ -80,6 +80,9 @@
                     "include": "#keyword_logical_operator"
                 },
                 {
+                    "include": "#keyword_modifier"
+                },
+                {
                     "include": "#keyword_return"
                 },
                 {
@@ -649,6 +652,16 @@
             "match": "(?i:\\b(and|or|not)\\b)",
             "name": "keyword.operator.logical.word"
         },
+        "keyword_modifier": {
+            "comment": "Capture modifiers that alter the declaration of a type of variable.",
+            "match": "(?i:\\b(optional)\\b)",
+            "name": "keyword.modifier.word",
+            "captures": {
+                "1": {
+                    "name": "keyword.modifier.brs"
+                }
+            }
+        },
         "keyword_return": {
             "comment": "The return statements in functions",
             "captures": {
@@ -771,6 +784,9 @@
                 },
                 {
                     "include": "#interface_field"
+                },
+                {
+                    "include": "#keyword_modifier"
                 }
             ],
             "end": "(?i)[\\s\\t]*(end[\\s\\t]*interface)",
@@ -781,7 +797,7 @@
             }
         },
         "interface_field": {
-            "begin": "(?i)\\s*\\b([a-z0-9_]+)(?:[\\s\\t]*(as))?",
+            "begin": "(?i)\\s*\\b([a-z0-9_]+)(?:[\\s\\t]*(as))",
             "beginCaptures": {
                 "1": {
                     "name": "variable.object.property.brs"


### PR DESCRIPTION
This PR adds the keyword modifier class for syntax highlighting when the "optional" keyword is used in interface declarations. 

Note: There may very well be a separate class that we would like to store this value in instead. if so please LMK and I will make the necessary adjustments.

Before:
![image](https://github.com/user-attachments/assets/63568176-a039-42ed-b636-04d921b8cf17)

After:
![image](https://github.com/user-attachments/assets/1eacfd00-a34d-4017-9f95-1f5071f1fe8b)

