### PR TITLE
Reenable the `deferScopeLoading` launch option

### DIFF
--- a/src/DebugConfigurationProvider.ts
+++ b/src/DebugConfigurationProvider.ts
@@ -57,7 +57,7 @@ export class BrightScriptDebugConfigurationProvider implements DebugConfiguratio
         enableVariablesPanel: true,
         deferScopeLoading: false,
         autoResolveVirtualVariables: false,
-        enhanceREPLCompletions: false,
+        enhanceREPLCompletions: true,
         showHiddenVariables: false,
         enableDebuggerAutoRecovery: false,
         stopDebuggerOnAppExit: false,


### PR DESCRIPTION
Reenable the `deferScopeLoading` launch option now that the underlying crash has been fixed. 