### PR TITLE
Inverted keys `PageUp` and `PageDown` mapping on remote control mode

### DIFF
--- a/docs/Debugging/remote-control-mode.md
+++ b/docs/Debugging/remote-control-mode.md
@@ -1,7 +1,7 @@
 # Remote Control Mode
 **Remote Control Mode** is a convenient way to send remote control commands to a Roku entirely from your keyboard in vscode without needing to pick up a physical Roku remote. 
 
-## 
+##
 ### From the status bar
 Click the remote icon in the status bar to toggle remote mode on or off
 
@@ -14,7 +14,7 @@ Click the remote icon in the status bar to toggle remote mode on or off
 Press `ctrl+k` on windows or `cmd+k` on mac.
 
 ## How it works
-When Remote Control Mode is activated, we enable about 100 key bindings that capture most of the standard US keyboard keys. At this point, you may use your keyboard to send text input, use the arrow keys to send left/right/up/down button presses, etc. Most keyboard strokes will be sent to the Roku device as input rather then to your editor. Some notable exceptions include when: the command pallet is open, an input box is open, or you are focused on other input areas like a search box. Once you're finished, simply disable **remote control mode**. 
+When Remote Control Mode is activated, we enable about 100 key bindings that capture most of the standard US keyboard keys. At this point, you may use your keyboard to send text input, use the arrow keys to send left/right/up/down button presses, etc. Most keyboard strokes will be sent to the Roku device as input rather then to your editor. Some notable exceptions include when: the command pallet is open, an input box is open, or you are focused on other input areas like a search box. Once you're finished, simply disable **remote control mode**.
 
 **Remote Control Mode** has support for full text input from the keyboard. For example, if you pressed `shift+b` while **Remote Control Mode** is active we will send `B` to the device. We support all the single press and shift press ascii characters on the keyboard (excluding the num pad). For example: `a-z`, `A-Z`, `0-9`, and all the primary symbols such as `!`, `@`, `#`, `'`, `"`, etc...
 
@@ -38,17 +38,17 @@ Here are many of the registered key bindings. You can see the full list in the [
 | `Ctrl+Backspace`     | `Cmd+Backspace`      | Backspace       | Delete the character to the left of the cursor in an input box                                  |
 | `Ctrl+Enter`         | `Cmd+Enter`          | Play/Pause      |                                                                                                 |
 | `End`                | `End`                | Play/Pause      |                                                                                                 |
-| `MediaPlayPause`     | `MediaPlayPause`     | Play/Pause      | VSCode does not block this button's system action, so only use this if you're not playing audio | 
+| `MediaPlayPause`     | `MediaPlayPause`     | Play/Pause      | VSCode does not block this button's system action, so only use this if you're not playing audio |
 | `Ctrl+Left`          | `Cmd+Left`           | Rewind          |                                                                                                 |
-| `PageDown`           | `PageDown`           | Rewind          |                                                                                                 |
-| `MediaTrackPrevious` | `MediaTrackPrevious` | Rewind          | VSCode does not block this button's system action, so only use this if you're not playing audio | 
+| `PageUp`             | `PageUp`             | Rewind          |                                                                                                 |
+| `MediaTrackPrevious` | `MediaTrackPrevious` | Rewind          | VSCode does not block this button's system action, so only use this if you're not playing audio |
 | `Ctrl+Right`         | `Cmd+Right`          | Fast Forward    |                                                                                                 |
-| `PageUp`             | `PageUp`             | Fast Forward    |                                                                                                 |
-| `MediaTrackNext`     | `MediaTrackNext`     | Fast Forward    | VSCode does not block this button's system action, so only use this if you're not playing audio | 
+| `PageDown`           | `PageDown`           | Fast Forward    |                                                                                                 |
+| `MediaTrackNext`     | `MediaTrackNext`     | Fast Forward    | VSCode does not block this button's system action, so only use this if you're not playing audio |
 | `Ctrl+8`             | `Cmd+8`              | Star            |                                                                                                 |
 | `Ctrl+Shift+8`       | `Cmd+Shift+8`        | Star            |                                                                                                 |
 | `Insert`             | `Insert`             | Star            |                                                                                                 |
-| `AudioVolumeMute`    | `AudioVolumeMute`    | Volume Mute     | VSCode does not block this button's system action, so only use this if you're not playing audio | 
+| `AudioVolumeMute`    | `AudioVolumeMute`    | Volume Mute     | VSCode does not block this button's system action, so only use this if you're not playing audio |
 
 ## Customizing Keybindings
 You can create your own keybindings by modifying the [keybindings.json](https://code.visualstudio.com/docs/getstarted/keybindings#_advanced-customization) file in vscode. Here's an example entry. Make sure to use the `when` clause from the following example if you want your keyboard shortcuts to be restricted to **Remote Control Mode**.

--- a/package.json
+++ b/package.json
@@ -3371,7 +3371,7 @@
             },
             {
                 "command": "extension.brightscript.pressRevButton",
-                "key": "PageDown",
+                "key": "PageUp",
                 "when": "!searchInputBoxFocus && !findInputFocussed && !inCommandsPicker && !inQuickOpen && brightscript.isRemoteControlMode"
             },
             {
@@ -3399,7 +3399,7 @@
             },
             {
                 "command": "extension.brightscript.pressFwdButton",
-                "key": "PageUp",
+                "key": "PageDown",
                 "when": "!searchInputBoxFocus && !findInputFocussed && !inCommandsPicker && !inQuickOpen && brightscript.isRemoteControlMode"
             },
             {


### PR DESCRIPTION
When using the remote control mode the navigation keys `PageUp` and `PageDown` were mapped to `FF` and `Rewind` respectively, that causes inverted behavior when navigating in `LabelList` and `CheckList` nodes for instance, when you press `PageDown` instead of going down in the list it goes up.

This PR inverts the behavior to be in the way any user would expect.