### PR TITLE
bsdoc return and type syntax highlighting

### DIFF
--- a/src/grammar/brightscript.tmLanguage.spec.ts
+++ b/src/grammar/brightscript.tmLanguage.spec.ts
@@ -486,6 +486,58 @@ describe('brightscript.tmlanguage.json', () => {
             `);
         });
 
+        it('colorizes @return', async () => {
+            await testGrammar(`
+                t'@return
+                '  ^^^^^^ storage.type.class.bsdoc
+                ' ^ storage.type.class.bsdoc
+                '^ comment.line.apostrophe.brs
+            `);
+        });
+
+        it('colorizes @returns', async () => {
+            await testGrammar(`
+                t'@returns
+                '  ^^^^^^^ storage.type.class.bsdoc
+                ' ^ storage.type.class.bsdoc
+                '^ comment.line.apostrophe.brs
+            `);
+        });
+
+        it('colorizes @return with type', async () => {
+            await testGrammar(`
+                t'@return {boolean}
+                '                 ^ punctuation.definition.bracket.curly.end.bsdoc
+                '          ^^^^^^^ entity.name.type.instance.bsdoc
+                '         ^ punctuation.definition.bracket.curly.begin.bsdoc
+                '  ^^^^^^ storage.type.class.bsdoc
+                ' ^ storage.type.class.bsdoc
+                '^ comment.line.apostrophe.brs
+            `);
+        });
+
+        it('colorizes @return with comment', async () => {
+            await testGrammar(`
+                t'@return this is a comment
+                '         ^^^^^^^^^^^^^^^^^ comment.block.documentation.brs
+                '  ^^^^^^ storage.type.class.bsdoc
+                ' ^ storage.type.class.bsdoc
+                '^ comment.line.apostrophe.brs
+            `);
+        });
+
+        it('colorizes @return with type and comment', async () => {
+            await testGrammar(`
+                t'@return {boolean} this is a comment
+                '                   ^^^^^^^^^^^^^^^^^ comment.block.documentation.brs
+                '                 ^ punctuation.definition.bracket.curly.end.bsdoc
+                '          ^^^^^^^ entity.name.type.instance.bsdoc
+                '         ^ punctuation.definition.bracket.curly.begin.bsdoc
+                '  ^^^^^^ storage.type.class.bsdoc
+                ' ^ storage.type.class.bsdoc
+                '^ comment.line.apostrophe.brs
+            `);
+        });
     });
 
     it.skip('handles `as Function` parameters properly', async () => {

--- a/syntaxes/brightscript.tmLanguage.json
+++ b/syntaxes/brightscript.tmLanguage.json
@@ -1031,7 +1031,7 @@
             }
         },
         "bsdoc_return_and_type": {
-            "match": "(?i:\\s*(rem|'+)\\s*(@)(return)\\s+(?:(\\{)\\s*([^\\}]+)\\s*(\\}))?\\s*([a-z0-9_.]+.*))",
+            "match": "(?i:\\s*(rem|'+)\\s*(@)(return|returns)\\s+(?:(\\{)\\s*([^\\}]+)\\s*(\\}))?\\s*([a-z0-9_.]+.*)?)",
             "captures": {
                 "1": {
                     "name": "comment.line.apostrophe.brs"

--- a/syntaxes/brightscript.tmLanguage.json
+++ b/syntaxes/brightscript.tmLanguage.json
@@ -977,6 +977,9 @@
                     "include": "#bsdoc_param_and_type"
                 },
                 {
+                    "include": "#bsdoc_return_and_type"
+                },
+                {
                     "include": "#bsdoc_generic"
                 }
             ]
@@ -1023,6 +1026,32 @@
                     "name": "variable.other.bsdoc"
                 },
                 "8": {
+                    "name": "comment.block.documentation.brs"
+                }
+            }
+        },
+        "bsdoc_return_and_type": {
+            "match": "(?i:\\s*(rem|'+)\\s*(@)(return)\\s+(?:(\\{)\\s*([^\\}]+)\\s*(\\}))?\\s*([a-z0-9_.]+.*))",
+            "captures": {
+                "1": {
+                    "name": "comment.line.apostrophe.brs"
+                },
+                "2": {
+                    "name": "punctuation.definition.block.tag.bsdoc storage.type.class.bsdoc"
+                },
+                "3": {
+                    "name": "punctuation.definition.block.tag.bsdoc storage.type.class.bsdoc"
+                },
+                "4": {
+                    "name": "punctuation.definition.bracket.curly.begin.bsdoc"
+                },
+                "5": {
+                    "name": " comment.block.documentation.brs entity.name.type.instance.bsdoc"
+                },
+                "6": {
+                    "name": "punctuation.definition.bracket.curly.end.bsdoc"
+                },
+                "7": {
                     "name": "comment.block.documentation.brs"
                 }
             }


### PR DESCRIPTION
Fixes bug: https://github.com/rokucommunity/vscode-brightscript-language/issues/633

Adds "return-and-type" to test bsdoc for syntax highlighting on {return|returns} 

![image](https://github.com/user-attachments/assets/323299ec-0024-4550-bc63-60d5d9c85b5a)
