### PR TITLE
bugfix enum field inline comment syntax highlighting

### DIFF
--- a/src/grammar/brightscript.tmLanguage.spec.ts
+++ b/src/grammar/brightscript.tmLanguage.spec.ts
@@ -697,6 +697,41 @@ describe('brightscript.tmlanguage.json', () => {
         `);
     });
 
+    it(`handles annotations in enums`, async () => {
+        await testGrammar(`
+             enum DeviceContext
+            '     ^^^^^^^^^^^^^ entity.name.type.enum.brs
+            '^^^^ storage.type.enum.brs
+
+             @primary() one = 1
+            '                 ^ constant.numeric.brs
+            '               ^ keyword.operator.assignment.brs
+            '           ^^^ variable.object.enummember.brs
+            '        ^^ meta.enum.declaration.brs
+            ' ^^^^^^^ meta.function-call.brs
+            '^ punctuation.decorator.brs
+
+             @secondary()
+            '          ^^ meta.enum.declaration.brs
+            ' ^^^^^^^^^ meta.function-call.brs
+            '^ punctuation.decorator.brs
+
+             @tertiary() ' This is a comment
+            '            ^^^^^^^^^^^^^^^^^^^ punctuation.definition.comment.brs
+            '         ^^ meta.enum.declaration.brs
+            ' ^^^^^^^^ meta.function-call.brs
+            '^ punctuation.decorator.brs
+
+             two = 2
+            '      ^ constant.numeric.brs
+            '    ^ keyword.operator.assignment.brs
+            '^^^ variable.object.enummember.brs
+
+             end enum
+            '^^^^^^^^ storage.type.enum.brs
+        `);
+    });
+
     it('handles named function declarations', async () => {
         await testGrammar(`
              sub write()

--- a/src/grammar/brightscript.tmLanguage.spec.ts
+++ b/src/grammar/brightscript.tmLanguage.spec.ts
@@ -598,20 +598,6 @@ describe('brightscript.tmlanguage.json', () => {
         `);
     });
 
-    it(`handles enum declaration with comments`, async () => {
-        await testGrammar(`
-             enum DeviceContext
-            '     ^^^^^^^^^^^^^ entity.name.type.enum.brs
-            '^^^^ storage.type.enum.brs
-
-             ' This is a comment
-            '^^^^^^^^^^^^^^^^^^^ punctuation.definition.comment.brs
-
-             end enum
-            '^^^^^^^^ storage.type.enum.brs
-        `);
-    });
-
     it(`handles enum field without value assignment`, async () => {
         await testGrammar(`
              enum DeviceContext

--- a/src/grammar/brightscript.tmLanguage.spec.ts
+++ b/src/grammar/brightscript.tmLanguage.spec.ts
@@ -587,6 +587,130 @@ describe('brightscript.tmlanguage.json', () => {
         `);
     });
 
+    it(`handles named enum declaration`, async () => {
+        await testGrammar(`
+             enum DeviceContext
+            '     ^^^^^^^^^^^^^ entity.name.type.enum.brs
+            '^^^^ storage.type.enum.brs
+
+             end enum
+            '^^^^^^^^ storage.type.enum.brs
+        `);
+    });
+
+    it(`handles enum declaration with comments`, async () => {
+        await testGrammar(`
+             enum DeviceContext
+            '     ^^^^^^^^^^^^^ entity.name.type.enum.brs
+            '^^^^ storage.type.enum.brs
+
+             ' This is a comment
+            '^^^^^^^^^^^^^^^^^^^ punctuation.definition.comment.brs
+
+             end enum
+            '^^^^^^^^ storage.type.enum.brs
+        `);
+    });
+
+    it(`handles enum field without value assignment`, async () => {
+        await testGrammar(`
+             enum DeviceContext
+            '     ^^^^^^^^^^^^^ entity.name.type.enum.brs
+            '^^^^ storage.type.enum.brs
+
+             value
+            '^^^^^ variable.object.enummember.brs
+
+             end enum
+            '^^^^^^^^ storage.type.enum.brs
+        `);
+    });
+
+    it(`handles enum field with string type`, async () => {
+        await testGrammar(`
+             enum DeviceContext
+            '     ^^^^^^^^^^^^^ entity.name.type.enum.brs
+            '^^^^ storage.type.enum.brs
+
+             value = "hello world"
+            '        ^^^^^^^^^^^^^ string.quoted.double.brs
+            '      ^ keyword.operator.assignment.brs
+            '^^^^^ variable.object.enummember.brs
+
+             end enum
+            '^^^^^^^^ storage.type.enum.brs
+        `);
+    });
+
+    it(`handles enum field with numeric type`, async () => {
+        await testGrammar(`
+             enum DeviceContext
+            '     ^^^^^^^^^^^^^ entity.name.type.enum.brs
+            '^^^^ storage.type.enum.brs
+
+             value = 84
+            '        ^^ constant.numeric.brs
+            '      ^ keyword.operator.assignment.brs
+            '^^^^^ variable.object.enummember.brs
+
+             end enum
+            '^^^^^^^^ storage.type.enum.brs
+        `);
+    });
+
+    it(`handles enum field with bool type`, async () => {
+        await testGrammar(`
+             enum DeviceContext
+            '     ^^^^^^^^^^^^^ entity.name.type.enum.brs
+            '^^^^ storage.type.enum.brs
+
+             value = true
+            '        ^^^^ constant.language.boolean.true.brs
+            '      ^ keyword.operator.assignment.brs
+            '^^^^^ variable.object.enummember.brs
+
+             value2 = false
+            '         ^^^^^ constant.language.boolean.false.brs
+            '       ^ keyword.operator.assignment.brs
+            '^^^^^^ variable.object.enummember.brs
+
+             end enum
+            '^^^^^^^^ storage.type.enum.brs
+        `);
+    });
+
+    it(`handles enum field with comments after value assignment`, async () => {
+        await testGrammar(`
+             enum DeviceContext
+            '     ^^^^^^^^^^^^^ entity.name.type.enum.brs
+            '^^^^ storage.type.enum.brs
+
+             value = true ' This is a comment
+            '             ^^^^^^^^^^^^^^^^^^^ punctuation.definition.comment.brs
+            '        ^^^^ constant.language.boolean.true.brs
+            '      ^ keyword.operator.assignment.brs
+            '^^^^^ variable.object.enummember.brs
+
+             end enum
+            '^^^^^^^^ storage.type.enum.brs
+        `);
+    });
+
+    it(`handles enum field with comments after no-value assignment`, async () => {
+        await testGrammar(`
+             enum DeviceContext
+            '     ^^^^^^^^^^^^^ entity.name.type.enum.brs
+            '^^^^ storage.type.enum.brs
+
+             value ' This is a comment
+            '      ^^^^^^^^^^^^^^^^^^^ punctuation.definition.comment.brs
+            '^^^^^ variable.object.enummember.brs
+
+             end enum
+            '^^^^^^^^ storage.type.enum.brs
+        `);
+    });
+
     it('handles named function declarations', async () => {
         await testGrammar(`
              sub write()

--- a/syntaxes/brightscript.tmLanguage.json
+++ b/syntaxes/brightscript.tmLanguage.json
@@ -875,21 +875,7 @@
                     "include": "#annotation"
                 },
                 {
-                    "begin": "(?i)\\s*\\b([a-z0-9_]+)(?:[ \\t]*(=))?",
-                    "beginCaptures": {
-                        "1": {
-                            "name": "variable.object.enummember.brs"
-                        },
-                        "2": {
-                            "name": "keyword.operator.assignment.brs"
-                        }
-                    },
-                    "patterns": [
-                        {
-                            "include": "#primitive_literal_expression"
-                        }
-                    ],
-                    "end": "\r?\n"
+                    "include": "#enum_field"
                 }
             ],
             "end": "(?i)[ \\t]*(end[ \\t]*enum)",
@@ -898,6 +884,29 @@
                     "name": "storage.type.enum.brs"
                 }
             }
+        },
+        "enum_field":  {
+            "begin": "(?i)\\s*\\b([a-z0-9_]+)(?:[ \\t]*(=))?",
+            "beginCaptures": {
+                "1": {
+                    "name": "variable.object.enummember.brs"
+                },
+                "2": {
+                    "name": "keyword.operator.assignment.brs"
+                }
+            },
+            "patterns": [
+                {
+                    "include": "#primitive_literal_expression"
+                },
+                {
+                    "include": "#comment"
+                },
+                {
+                    "include": "#annotation"
+                }
+            ],
+            "end": "\r?\n"
         },
         "type_expression": {
             "patterns": [


### PR DESCRIPTION
This PR adds syntax highlighting to inline comments made on enum fields, see bug for more details --> https://github.com/rokucommunity/vscode-brightscript-language/issues/362

![image](https://github.com/user-attachments/assets/0a53c4db-d420-434c-867e-c6c8be4d6b8f)

