### PR TITLE
Track bsConst telemetry usage in launch.json

### DIFF
--- a/src/managers/TelemetryManager.ts
+++ b/src/managers/TelemetryManager.ts
@@ -61,6 +61,7 @@ export class TelemetryManager implements Disposable {
             isDeepLinkUrlDefined: isDefined(initialConfig.deepLinkUrl),
             isStagingFolderPathDefined: isDefined(initialConfig.stagingFolderPath),
             isLogfilePathDefined: isDefined(initialConfig.logfilePath),
+            isBsConstDefined: isDefined(initialConfig.bsConst),
             isExtensionLogfilePathDefined: isDefined(
                 vscode.workspace.getConfiguration('brightscript').get<string>('extensionLogfilePath')
             ),


### PR DESCRIPTION
Add telemetry tracking for the `bsConst` entry in launch.json