### PR TITLE
chore: fix incorrect artifact-paths for creating releases

### DIFF
--- a/.github/workflows/make-release-artifacts.yml
+++ b/.github/workflows/make-release-artifacts.yml
@@ -14,7 +14,7 @@ jobs:
     with:
       branch: ${{ github.event.pull_request.head.ref }}
       node-version: "18.18.2"
-      artifact-paths: "./*.tgz" # "*.vsix"
+      artifact-paths: "*.vsix"
     secrets: inherit
 
   success-or-skip:


### PR DESCRIPTION
Release 2.56.0 failed to upload any artifacts because the artifact-paths was incorrectly looking for `*.tgz`. This fixes the issue by looking for `*.vsix`