### PR TITLE
Fix bug where param named interface breaks syntax highlighting

### DIFF
--- a/src/grammar/brightscript.tmLanguage.spec.ts
+++ b/src/grammar/brightscript.tmLanguage.spec.ts
@@ -460,6 +460,96 @@ describe('brightscript.tmlanguage.json', () => {
             `);
         });
 
+        it('interface as param name does not break later tokens', async () => {
+            await testGrammar(`
+                function test(interface as string)
+                '                          ^^^^^^ storage.type.brs
+                '                       ^^ keyword.control.as.brs
+                '             ^^^^^^^^^ variable.parameter.brs
+                '        ^^^^ entity.name.function.brs
+                '^^^^^^^ keyword.declaration.function.brs
+                end function
+               '^^^^^^^^^^^^ keyword.declaration.function.brs
+            `);
+        });
+
+        it('does not match array literal comma as param separator', async () => {
+            await testGrammar(`
+                function test(items = [1, 2])
+                '                         ^ constant.numeric.brs
+                '             ^^^^^ entity.name.variable.local.brs
+                '        ^^^^ entity.name.function.brs
+            `);
+        });
+
+        it('does not match expression comma as param separator', async () => {
+            await testGrammar(`
+                function test(value = (calc(), 5))
+                '                              ^ constant.numeric.brs
+                '             ^^^^^ entity.name.variable.local.brs
+            `);
+        });
+
+        it('handles param with newline before as keyword', async () => {
+            await testGrammar(`
+                function test(param as string)
+                '                      ^^^^^^ storage.type.brs
+                '                   ^^ keyword.control.as.brs
+            `);
+        });
+
+        it('distinguishes param type from type cast in default value', async () => {
+            await testGrammar(`
+                function test(a as integer, b = val as string)
+                '                                      ^^^^^^ storage.type.brs
+                '                                   ^^ keyword.control.brs
+                '                           ^ entity.name.variable.local.brs
+            `);
+        });
+
+        it('handles multiple spaces between param and as', async () => {
+            await testGrammar(`
+                function test(param     as string)
+                '                          ^^^^^^ storage.type.brs
+                '                       ^^ keyword.control.as.brs
+                '             ^^^^^ variable.parameter.brs
+            `);
+        });
+
+        it('handles function call with comma in default param value', async () => {
+            await testGrammar(`
+                function test(val = call(a, b))
+                '                           ^ entity.name.variable.local.brs
+                '             ^^^ entity.name.variable.local.brs
+            `);
+        });
+
+        it('handles nested function declaration as default value', async () => {
+            await testGrammar(`
+                function outer(cb = function(x as integer)
+                '                                 ^^^^^^^ storage.type.brs
+                '                              ^^ keyword.control.as.brs
+                '                            ^ variable.parameter.brs
+            `);
+        });
+
+        it('does not match interface field as param', async () => {
+            await testGrammar(`
+                interface Test
+                    field as string
+                '            ^^^^^^ storage.type.brs
+                '         ^^ keyword.control.as.brs
+                '   ^^^^^ variable.object.property.brs
+            `);
+        });
+
+        it('handles param starting with number (invalid identifier)', async () => {
+            await testGrammar(`
+                function test(123param as string)
+                '             ^^^ variable.parameter.brs
+            `);
+        });
+
         it('colorizes @param without name', async () => {
             await testGrammar(`
                 t'@type {boolean}
@@ -767,8 +857,8 @@ describe('brightscript.tmlanguage.json', () => {
             '                                ^^^^^^ storage.type.brs
             '                             ^^ keyword.control.brs
             '                   ^^^^^^^^ storage.type.brs
-            '                ^^ keyword.control.brs
-            '          ^^^^^ entity.name.variable.local.brs
+            '                ^^ keyword.control.as.brs
+            '          ^^^^^ variable.parameter.brs
             '    ^^^^^ entity.name.function.brs
             '^^^ keyword.declaration.function.brs
 
@@ -875,8 +965,8 @@ describe('brightscript.tmlanguage.json', () => {
         await testGrammar(`
              sub nameless(rnd as dynamic)
             '                    ^^^^^^^ storage.type.brs
-            '                 ^^ keyword.control.brs
-            '             ^^^ entity.name.variable.local.brs
+            '                 ^^ keyword.control.as.brs
+            '             ^^^ variable.parameter.brs
             '    ^^^^^^^^ entity.name.function.brs
             '^^^ keyword.declaration.function.brs
 
@@ -969,8 +1059,8 @@ describe('brightscript.tmlanguage.json', () => {
         await testGrammar(`
              sub rnd(randomVal as Dynamic, rnd as dynamic)
             '                                     ^^^^^^^ storage.type.brs
-            '                                  ^^ keyword.control.brs
-            '                              ^^^ entity.name.variable.local.brs
+            '                                  ^^ keyword.control.as.brs
+            '                              ^^^ variable.parameter.brs
             '                     ^^^^^^^ storage.type.brs
             '                  ^^ keyword.control.brs
             '        ^^^^^^^^^ entity.name.variable.local.brs
@@ -1120,8 +1210,8 @@ describe('brightscript.tmlanguage.json', () => {
             '                                       ^^^^^^ storage.type.brs
             '                                    ^^ keyword.control.brs
             '                          ^^^^^^^^ storage.type.brs
-            '                       ^^ keyword.control.brs
-            '                 ^^^^^ entity.name.variable.local.brs
+            '                       ^^ keyword.control.as.brs
+            '                 ^^^^^ variable.parameter.brs
             '           ^^^^^ entity.name.function.brs
             '       ^^^ keyword.declaration.function.brs
             '^^^^^^ storage.modifier.brs
@@ -1183,8 +1273,8 @@ describe('brightscript.tmlanguage.json', () => {
             '                                                ^^^^^^ storage.type.brs
             '                                             ^^ keyword.control.brs
             '                                   ^^^^^^^^ storage.type.brs
-            '                                ^^ keyword.control.brs
-            '                          ^^^^^ entity.name.variable.local.brs
+            '                                ^^ keyword.control.as.brs
+            '                          ^^^^^ variable.parameter.brs
             '                    ^^^^^ entity.name.function.brs
             '                ^^^ keyword.declaration.function.brs
             '       ^^^^^^^^ storage.modifier.brs
@@ -1230,8 +1320,8 @@ describe('brightscript.tmlanguage.json', () => {
             '                                     ^^^^^^ storage.type.brs
             '                                  ^^ keyword.control.brs
             '                        ^^^^^^^^ storage.type.brs
-            '                     ^^ keyword.control.brs
-            '               ^^^^^ entity.name.variable.local.brs
+            '                     ^^ keyword.control.as.brs
+            '               ^^^^^ variable.parameter.brs
             '      ^^^^^^^^ keyword.declaration.function.brs
             '^^^ entity.name.variable.local.brs
 
@@ -1257,8 +1347,8 @@ describe('brightscript.tmlanguage.json', () => {
               '                                      ^^^^^^ storage.type.brs
               '                                   ^^ keyword.control.brs
               '                         ^^^^^^^^ storage.type.brs
-              '                      ^^ keyword.control.brs
-              '                ^^^^^ entity.name.variable.local.brs
+              '                      ^^ keyword.control.as.brs
+              '                ^^^^^ variable.parameter.brs
               '       ^^^^^^^^ keyword.declaration.function.brs
 
                end function
@@ -1287,7 +1377,7 @@ describe('brightscript.tmlanguage.json', () => {
     });
 
     it('colorizes class_roku_builtin correctly', async () => {
-        async function testRokuClass (className: string) {
+        async function testRokuClass(className: string) {
             return testGrammar(`
                 var = createObject("${className}")
                '                    ${'^'.repeat(className.length)} support.class.brs
@@ -1577,7 +1667,7 @@ describe('brightscript.tmlanguage.json', () => {
     });
 
     it('does NOT colorize class_roku_builtin if exact match is not found', async () => {
-        async function testRokuClass (className: string) {
+        async function testRokuClass(className: string) {
             return testGrammar(`
                 var = createObject("${className}")
                '                    ${'^'.repeat(className.length)} string.quoted.double.brs

--- a/syntaxes/brightscript.tmLanguage.json
+++ b/syntaxes/brightscript.tmLanguage.json
@@ -116,6 +116,9 @@
                     "include": "#interface_declaration"
                 },
                 {
+                    "include": "#function_param_ish"
+                },
+                {
                     "include": "#storage_types"
                 },
                 {
@@ -745,9 +748,20 @@
             },
             "match": "(?i)[^a-z0-9_\"](function|sub)\\s*\\("
         },
+        "function_param_ish": {
+            "match": "(?i:)(?<=[\\(,])[ \\t]*\\b([a-z0-9_]+)[ \\t]+(as\\b)",
+            "captures": {
+                "1": {
+                    "name": "variable.parameter.brs"
+                },
+                "2": {
+                    "name": "keyword.control.as.brs"
+                }
+            }
+        },
         "interface_declaration": {
             "name": "meta.interface.brs",
-            "begin": "(?i)\\b[\\s\\t]*(interface)[\\s\\t]+([a-zA-Z0-9_]+)\\b",
+            "begin": "(?i)^[\\s\\t]*(interface)[\\s\\t]+([a-zA-Z0-9_]+)\\b",
             "beginCaptures": {
                 "1": {
                     "name": "storage.type.interface.brs"


### PR DESCRIPTION
Fixes syntax highlighting issue where using a param named `interface` would break syntax highlighting later in the file. 

Before:
<img width="823" height="460" alt="image" src="https://github.com/user-attachments/assets/1aa4b2cc-5a83-407b-9ba0-17df83b77f22" />


After:
<img width="793" height="478" alt="image" src="https://github.com/user-attachments/assets/e8362798-fcc5-4a16-8b8d-57ba2ff4f5a4" />
