### PR TITLE
Added this property to support component libraries packaged via custom command

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,8 +37,8 @@
                 "postman-request": "^2.88.1-postman.32",
                 "pretty-bytes": "^5.6.0",
                 "resolve": "^1.22.8",
-                "roku-debug": "^0.22.3",
-                "roku-deploy": "^3.14.4",
+                "roku-debug": "^0.22.4",
+                "roku-deploy": "^3.15.0",
                 "roku-test-automation": "^2.2.1",
                 "semver": "^7.1.3",
                 "source-map": "^0.7.3",
@@ -9192,9 +9192,9 @@
             }
         },
         "node_modules/roku-debug": {
-            "version": "0.22.3",
-            "resolved": "https://registry.npmjs.org/roku-debug/-/roku-debug-0.22.3.tgz",
-            "integrity": "sha512-Pd+73Y0szLn7qQChL5Q0mFPZz4MNdLeadzbGBUjhSwrQXrrYS9VwV5i6EKg/Mh5iM5td9RmHI2r9nb9UywLOHQ==",
+            "version": "0.22.4",
+            "resolved": "https://registry.npmjs.org/roku-debug/-/roku-debug-0.22.4.tgz",
+            "integrity": "sha512-Noq0IW6i+Luke0U7sWQtaJxzl8Ee7N0p1kX33FplBfA1KooRbvhUbOmI4L7UDmGsYQXgEKWK9Co9uCeIarU8FA==",
             "dependencies": {
                 "@rokucommunity/logger": "^0.3.11",
                 "@types/request": "^2.48.8",
@@ -9214,7 +9214,7 @@
                 "postman-request": "^2.88.1-postman.40",
                 "replace-in-file": "^6.3.2",
                 "replace-last": "^1.2.6",
-                "roku-deploy": "^3.14.4",
+                "roku-deploy": "^3.15.0",
                 "semver": "^7.5.4",
                 "serialize-error": "^8.1.0",
                 "smart-buffer": "^4.2.0",
@@ -9265,9 +9265,9 @@
             }
         },
         "node_modules/roku-deploy": {
-            "version": "3.14.4",
-            "resolved": "https://registry.npmjs.org/roku-deploy/-/roku-deploy-3.14.4.tgz",
-            "integrity": "sha512-JWx+VetKadMPnGrc80cQCSaJSuTtR1tAA/3JiygFBJiK7gPYBCx8/2c9fq1wajuJ+t/0dqP7XYD/6v33nliFwA==",
+            "version": "3.15.0",
+            "resolved": "https://registry.npmjs.org/roku-deploy/-/roku-deploy-3.15.0.tgz",
+            "integrity": "sha512-8RkGnW1a/Wwr0iiNMHQ2YHEL2Sposb8gcnmHaohkTFuynaQ7dkwL6Epd6zC7/Nj38uqfwX5cAgNrsMq38I7P2g==",
             "dependencies": {
                 "@types/request": "^2.47.0",
                 "chalk": "^2.4.2",

--- a/package.json
+++ b/package.json
@@ -80,8 +80,8 @@
         "postman-request": "^2.88.1-postman.32",
         "pretty-bytes": "^5.6.0",
         "resolve": "^1.22.8",
-        "roku-debug": "^0.22.3",
-        "roku-deploy": "^3.14.4",
+        "roku-debug": "^0.22.4",
+        "roku-deploy": "^3.15.0",
         "roku-test-automation": "^2.2.1",
         "semver": "^7.1.3",
         "source-map": "^0.7.3",
@@ -506,6 +506,11 @@
                                             "examples": [
                                                 "${workspaceFolder}/LibDir/"
                                             ]
+                                        },
+                                        "avoidPostfix": {
+                                            "type": "boolean",
+                                            "description": "When true, this avoids adding a postfix to the files. Useful when you want to debug component libraries that get packaged using custom command.",
+                                            "default": false
                                         },
                                         "outFile": {
                                             "type": "string",


### PR DESCRIPTION
Adds support for debugging of libraries packaged using custom commands.

1. adds latest roku-deploy and roku-debug, which support
2. adds entry in launch.json configuration to support setting avoidPostfix: true to enable this behavior.

In order for this to work add the following in your config in launch.json inside .vscode folder

` "sourceDirs": [
                "${workspaceFolder}/<folder name for component library>"
            ],`