### PR TITLE
chore: Fix watch-all so it only watches deps installed using `file:`

### DIFF
--- a/scripts/watch-all.ts
+++ b/scripts/watch-all.ts
@@ -6,6 +6,17 @@ import * as chalk from 'chalk';
 import * as dayjs from 'dayjs';
 import * as deferred from 'deferred';
 
+const vscodePackageJson = fsExtra.readJsonSync(path.resolve(__dirname, '..', 'package.json'));
+const allDeps = {
+    ...vscodePackageJson.dependencies,
+    ...vscodePackageJson.devDependencies
+};
+const localFileDeps = new Set(
+    Object.entries(allDeps)
+        .filter(([, version]) => /^(file|link):/.test(version as string))
+        .map(([name]) => name)
+);
+
 class Logger {
     private canReplaceLine = false;
     public writeLine(message = '', isReplaceable = false) {
@@ -61,7 +72,8 @@ const projects = [{
         firstCompletion: deferred() as { resolve: () => void; reject: () => void; resolved: boolean; promise: Promise<any> }
     };
 }).filter(x => {
-    return fsExtra.pathExistsSync(x.path);
+    const isVscodeProject = x.name === path.basename(path.resolve(__dirname, '..'));
+    return fsExtra.pathExistsSync(x.path) && (isVscodeProject || localFileDeps.has(x.name));
 });
 type Project = typeof projects[0];
 


### PR DESCRIPTION
This pull request updates the `scripts/watch-all.ts` script to improve how local file dependencies are handled and which projects are included for watching. The main changes focus on ensuring that only relevant projects—either the main VSCode project or those referenced as local file dependencies—are included in the watch process.

Dependency and project filtering improvements:

* Added logic to read the root `package.json` and collect all dependencies and devDependencies that use a `file:` or `link:` version specifier, storing their names in a `Set` called `localFileDeps`.
* Updated the project filtering logic to include only the main VSCode project or projects that are present in `localFileDeps`, ensuring unnecessary projects are excluded from the watch process.