### PR TITLE
Configured device bug fixes

### DIFF
--- a/src/BrightScriptCommands.ts
+++ b/src/BrightScriptCommands.ts
@@ -64,7 +64,7 @@ export class BrightScriptCommands {
 
         // Refresh a single device (inline button on hover in devices panel)
         this.registerCommand('refreshDevice', async (item: { key: string }) => {
-            await this.deviceManager.checkDeviceHealth({ serialNumber: item.key }, true);
+            await this.deviceManager.healthCheckDevice({ serialNumber: item.key }, true);
         });
 
         this.registerCommand('sendRemoteText', async () => {
@@ -890,7 +890,7 @@ export class BrightScriptCommands {
         if (!activeHost) {
             return undefined;
         }
-        const isHealthy = await this.deviceManager.checkDeviceHealth({ ip: activeHost }, true, false);
+        const isHealthy = await this.deviceManager.healthCheckDevice({ ip: activeHost }, true, false);
         return isHealthy ? activeHost : undefined;
     }
 

--- a/src/DebugConfigurationProvider.ts
+++ b/src/DebugConfigurationProvider.ts
@@ -486,7 +486,7 @@ export class BrightScriptDebugConfigurationProvider implements DebugConfiguratio
 
         // Probe the resolved host so downstream password resolution has fresh SN/deviceInfo.
         // Unreachable or filtered hosts yield no registered device; password resolution handles that.
-        const device = await this.deviceManager.getDevice({ ip: config.host }, { fetch: true });
+        const device = await this.deviceManager.validateAndAddDevice(config.host);
 
         return [config, device];
     }

--- a/src/GlobalStateManager.spec.ts
+++ b/src/GlobalStateManager.spec.ts
@@ -128,4 +128,44 @@ describe('GlobalStateManager', () => {
             expect(manager.getCachedDevice('device-123')).to.be.undefined;
         });
     });
+
+    describe('setSerialNumberForIp', () => {
+        it('stores IP to serial mapping', () => {
+            manager.setSerialNumberForIp(testNetwork, '192.168.1.100', 'serial-123');
+            expect(manager.getSerialNumberForIp('192.168.1.100', testNetwork)).to.equal('serial-123');
+        });
+
+        it('removes old IP entry when serial moves to new IP', () => {
+            manager.setSerialNumberForIp(testNetwork, '192.168.1.100', 'serial-123');
+            manager.setSerialNumberForIp(testNetwork, '192.168.1.200', 'serial-123');
+
+            // Old IP should no longer have the serial
+            expect(manager.getSerialNumberForIp('192.168.1.100', testNetwork)).to.be.undefined;
+            // New IP should have the serial
+            expect(manager.getSerialNumberForIp('192.168.1.200', testNetwork)).to.equal('serial-123');
+        });
+
+        it('allows same serial at same IP (update timestamp)', () => {
+            manager.setSerialNumberForIp(testNetwork, '192.168.1.100', 'serial-123');
+            manager.setSerialNumberForIp(testNetwork, '192.168.1.100', 'serial-123');
+
+            // IP should still have the serial
+            expect(manager.getSerialNumberForIp('192.168.1.100', testNetwork)).to.equal('serial-123');
+        });
+
+        it('allows different serials at different IPs', () => {
+            manager.setSerialNumberForIp(testNetwork, '192.168.1.100', 'serial-123');
+            manager.setSerialNumberForIp(testNetwork, '192.168.1.200', 'serial-456');
+
+            expect(manager.getSerialNumberForIp('192.168.1.100', testNetwork)).to.equal('serial-123');
+            expect(manager.getSerialNumberForIp('192.168.1.200', testNetwork)).to.equal('serial-456');
+        });
+
+        it('replaces serial at same IP', () => {
+            manager.setSerialNumberForIp(testNetwork, '192.168.1.100', 'serial-123');
+            manager.setSerialNumberForIp(testNetwork, '192.168.1.100', 'serial-456');
+
+            expect(manager.getSerialNumberForIp('192.168.1.100', testNetwork)).to.equal('serial-456');
+        });
+    });
 });

--- a/src/GlobalStateManager.ts
+++ b/src/GlobalStateManager.ts
@@ -194,12 +194,22 @@ export class GlobalStateManager {
 
     /**
      * Save IP→serialNumber mapping for the specified network. Called when a device is successfully resolved.
+     * Ensures uniqueness: removes any existing entry with the same serial number (device moved IPs).
+     * IP uniqueness is implicit since IP is the key.
      */
     public setSerialNumberForIp(networkId: string, ip: string, serialNumber: string): void {
         const map = this.context.globalState.get<IpToSerialNumberMap>(this.keys.serialNumberByIpForNetwork) || {};
         if (!map[networkId]) {
             map[networkId] = {};
         }
+
+        // Remove any existing entry with the same serial number (device moved IPs)
+        for (const existingIp in map[networkId]) {
+            if (map[networkId][existingIp].serialNumber === serialNumber && existingIp !== ip) {
+                delete map[networkId][existingIp];
+            }
+        }
+
         map[networkId][ip] = { serialNumber: serialNumber, timestamp: Date.now() };
         void this.context.globalState.update(this.keys.serialNumberByIpForNetwork, map);
     }

--- a/src/deviceDiscovery/DeviceManager.spec.ts
+++ b/src/deviceDiscovery/DeviceManager.spec.ts
@@ -335,19 +335,19 @@ describe('DeviceManager', () => {
             expect(manager['timeSinceLastScan']).to.be.lessThan(100);
         });
 
-        it('calls checkDevicesHealth with force flag', () => {
+        it('calls healthCheckAllDevices with force flag', () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
-            const checkDevicesHealthSpy = sinon.stub(manager as any, 'checkDevicesHealth').resolves();
+            const healthCheckAllDevicesSpy = sinon.stub(manager as any, 'healthCheckAllDevices').resolves();
 
             manager.refresh(true);
-            expect(checkDevicesHealthSpy.calledWith(true)).to.be.true;
+            expect(healthCheckAllDevicesSpy.calledWith(true)).to.be.true;
 
             manager.refresh(false);
-            expect(checkDevicesHealthSpy.calledWith(false)).to.be.true;
+            expect(healthCheckAllDevicesSpy.calledWith(false)).to.be.true;
 
             manager.refresh(); // defaults to false
-            expect(checkDevicesHealthSpy.calledWith(false)).to.be.true;
+            expect(healthCheckAllDevicesSpy.calledWith(false)).to.be.true;
         });
     });
 
@@ -356,12 +356,12 @@ describe('DeviceManager', () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
             const discoverAllSpy = sinon.spy(manager as any, 'discoverAll');
-            const checkDevicesHealthSpy = sinon.spy(manager as any, 'checkDevicesHealth');
+            const healthCheckAllDevicesSpy = sinon.spy(manager as any, 'healthCheckAllDevices');
 
             manager.scan(true);
 
             expect(discoverAllSpy.calledOnce).to.be.true;
-            expect(checkDevicesHealthSpy.called).to.be.false;
+            expect(healthCheckAllDevicesSpy.called).to.be.false;
         });
 
         it('respects deviceDiscoveryEnabled when force=false', () => {
@@ -405,7 +405,7 @@ describe('DeviceManager', () => {
         });
     });
 
-    describe('checkDevicesHealth', () => {
+    describe('healthCheckAllDevices', () => {
         it('sets all devices to pending and checks all when force=true', async () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
@@ -416,7 +416,7 @@ describe('DeviceManager', () => {
 
             const resolveDeviceSpy = sinon.stub(manager as any, 'resolveDevice').returns(Promise.resolve(true) as any);
 
-            await (manager as any).checkDevicesHealth(true);
+            await (manager as any).healthCheckAllDevices(true);
 
             expect(resolveDeviceSpy.calledTwice).to.be.true;
         });
@@ -434,7 +434,7 @@ describe('DeviceManager', () => {
 
             const resolveDeviceSpy = sinon.stub(manager as any, 'resolveDevice').returns(Promise.resolve(true) as any);
 
-            await (manager as any).checkDevicesHealth(false);
+            await (manager as any).healthCheckAllDevices(false);
 
             // Only device2 should be checked (device1 is not stale)
             expect(resolveDeviceSpy.calledOnce).to.be.true;
@@ -454,7 +454,7 @@ describe('DeviceManager', () => {
                 return Promise.resolve(true);
             });
 
-            await (manager as any).checkDevicesHealth(false);
+            await (manager as any).healthCheckAllDevices(false);
 
             expect(stateWhenResolveCalled).to.equal('pending');
         });
@@ -470,13 +470,13 @@ describe('DeviceManager', () => {
 
             const resolveDeviceSpy = sinon.stub(manager as any, 'resolveDevice').returns(Promise.resolve(true));
 
-            await (manager as any).checkDevicesHealth(false);
+            await (manager as any).healthCheckAllDevices(false);
 
             expect(resolveDeviceSpy.called).to.be.false;
         });
     });
 
-    describe('checkDeviceHealth with force=false (cooldown)', () => {
+    describe('healthCheckDevice with force=false (cooldown)', () => {
         it('skips check if within cooldown period', async () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
@@ -484,11 +484,11 @@ describe('DeviceManager', () => {
             const resolveDeviceSpy = sinon.stub(manager as any, 'resolveDevice').returns(Promise.resolve(true));
 
             // First call - should check
-            await manager.checkDeviceHealth(device);
+            await manager.healthCheckDevice(device);
             expect(resolveDeviceSpy.calledOnce).to.be.true;
 
             // Second call immediately - should skip due to cooldown
-            await manager.checkDeviceHealth(device);
+            await manager.healthCheckDevice(device);
             expect(resolveDeviceSpy.calledOnce).to.be.true; // Still just one call
         });
 
@@ -501,14 +501,14 @@ describe('DeviceManager', () => {
                 const resolveDeviceSpy = sinon.stub(manager as any, 'resolveDevice').returns(Promise.resolve(true));
 
                 // First call
-                await manager.checkDeviceHealth(device);
+                await manager.healthCheckDevice(device);
                 expect(resolveDeviceSpy.calledOnce).to.be.true;
 
                 // Advance past cooldown (5 minutes)
                 clock.tick((5 * 60 * 1_000) + 1);
 
                 // Second call - should check again
-                await manager.checkDeviceHealth(device);
+                await manager.healthCheckDevice(device);
                 expect(resolveDeviceSpy.calledTwice).to.be.true;
             } finally {
                 clock.restore();
@@ -522,11 +522,11 @@ describe('DeviceManager', () => {
             const resolveDeviceSpy = sinon.stub(manager as any, 'resolveDevice').returns(Promise.resolve(true));
 
             // First call with force
-            await manager.checkDeviceHealth(device, true);
+            await manager.healthCheckDevice(device, true);
             expect(resolveDeviceSpy.calledOnce).to.be.true;
 
             // Second call immediately with force - should still check
-            await manager.checkDeviceHealth(device, true);
+            await manager.healthCheckDevice(device, true);
             expect(resolveDeviceSpy.calledTwice).to.be.true;
         });
     });
@@ -631,7 +631,7 @@ describe('DeviceManager', () => {
                 manager.on('devices-changed', devicesChangedSpy);
 
                 // setDiscoveredDevice + emitDevicesChanged is the pattern used in real code
-                manager['setDiscoveredDevice']('192.168.1.100', 'serial-123', 'online');
+                manager['setDiscoveredDevice']('192.168.1.100', 'serial-123');
                 manager['emitDevicesChanged']();
 
                 // First call after throttle window emits immediately
@@ -677,16 +677,16 @@ describe('DeviceManager', () => {
                 manager.on('devices-changed', devicesChangedSpy);
 
                 // First call emits immediately
-                manager['setDiscoveredDevice']('192.168.1.101', 'device-1', 'online');
+                manager['setDiscoveredDevice']('192.168.1.101', 'device-1');
                 manager['emitDevicesChanged']();
                 expect(devicesChangedSpy.calledOnce).to.be.true;
 
                 // Subsequent calls within throttle window are queued
                 clock.tick(10);
-                manager['setDiscoveredDevice']('192.168.1.102', 'device-2', 'online');
+                manager['setDiscoveredDevice']('192.168.1.102', 'device-2');
                 manager['emitDevicesChanged']();
                 clock.tick(10);
-                manager['setDiscoveredDevice']('192.168.1.103', 'device-3', 'online');
+                manager['setDiscoveredDevice']('192.168.1.103', 'device-3');
                 manager['emitDevicesChanged']();
 
                 // Still just one emit (subsequent calls queued)
@@ -701,7 +701,7 @@ describe('DeviceManager', () => {
         });
     });
 
-    describe('checkDeviceHealth', () => {
+    describe('healthCheckDevice', () => {
         it('sets device to pending during health check', async () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
             (vscode.window as any).state = { focused: true };
@@ -716,7 +716,7 @@ describe('DeviceManager', () => {
             });
             sinon.stub(rokuDeploy, 'getDeviceInfo').returns(healthPromise);
 
-            const checkPromise = manager.checkDeviceHealth(device, true);
+            const checkPromise = manager.healthCheckDevice(device, true);
 
             // Device should be pending during check
             expect(manager.getAllDevices()[0].deviceState).to.equal('pending');
@@ -742,7 +742,7 @@ describe('DeviceManager', () => {
 
             sinon.stub(rokuDeploy, 'getDeviceInfo').rejects(new Error('Device not responding'));
 
-            const result = await manager.checkDeviceHealth(device, true);
+            const result = await manager.healthCheckDevice(device, true);
 
             expect(result).to.be.false;
             expect(manager.getAllDevices().length).to.equal(0);
@@ -760,7 +760,7 @@ describe('DeviceManager', () => {
                 'default-device-name': 'Roku Express'
             });
 
-            const result = await manager.checkDeviceHealth(device, true);
+            const result = await manager.healthCheckDevice(device, true);
 
             expect(result).to.be.true;
         });
@@ -790,10 +790,10 @@ describe('DeviceManager', () => {
             getDeviceInfoStub.onSecondCall().returns(fastCheckPromise);
 
             // Start first (slow) health check - will return unhealthy
-            const slowResult = manager.checkDeviceHealth(device, true);
+            const slowResult = manager.healthCheckDevice(device, true);
 
             // Start second (fast) health check - will return healthy
-            const fastResult = manager.checkDeviceHealth(device, true);
+            const fastResult = manager.healthCheckDevice(device, true);
 
             // Fast check completes first with healthy result
             resolveFastCheck({
@@ -842,8 +842,8 @@ describe('DeviceManager', () => {
             getDeviceInfoStub.onSecondCall().returns(device2Promise);
 
             // Start health checks for both devices
-            const result1 = manager.checkDeviceHealth(device1, true);
-            const result2 = manager.checkDeviceHealth(device2, true);
+            const result1 = manager.healthCheckDevice(device1, true);
+            const result2 = manager.healthCheckDevice(device2, true);
 
             // Device 2 completes first (healthy)
             resolveDevice2({
@@ -1084,7 +1084,7 @@ describe('DeviceManager', () => {
     });
 
     describe('device filtering (shouldShowDevice)', () => {
-        it('filters devices without developer-enabled by default', () => {
+        it('filters devices without developer-enabled via getDevicesForUI', () => {
             // Default config has includeNonDeveloperDevices: true for tests,
             // so override to test filtering
             (vscode.workspace.getConfiguration as sinon.SinonStub).returns({
@@ -1106,11 +1106,13 @@ describe('DeviceManager', () => {
                 deviceState: 'online'
             });
 
-            // Device should be filtered out
-            expect(manager.getAllDevices().length).to.equal(0);
+            // Device should be filtered out from getDevicesForUI
+            expect(manager.getDevicesForUI().length).to.equal(0);
+            // But still available via getAllDevices (unfiltered)
+            expect(manager.getAllDevices().length).to.equal(1);
         });
 
-        it('shows devices with developer-enabled: true', () => {
+        it('shows devices with developer-enabled: true via getDevicesForUI', () => {
             (vscode.workspace.getConfiguration as sinon.SinonStub).returns({
                 get: () => undefined,
                 inspect: () => ({ workspaceValue: [], globalValue: [] }),
@@ -1131,7 +1133,7 @@ describe('DeviceManager', () => {
             });
             addDevice(device);
 
-            expect(manager.getAllDevices().length).to.equal(1);
+            expect(manager.getDevicesForUI().length).to.equal(1);
         });
 
         it('includes non-developer devices when setting enabled', () => {
@@ -1155,10 +1157,10 @@ describe('DeviceManager', () => {
             });
             addDevice(device);
 
-            expect(manager.getAllDevices().length).to.equal(1);
+            expect(manager.getDevicesForUI().length).to.equal(1);
         });
 
-        it('getDevice returns undefined for filtered devices', () => {
+        it('getDevice returns device regardless of filtering (unfiltered)', () => {
             (vscode.workspace.getConfiguration as sinon.SinonStub).returns({
                 get: () => undefined,
                 inspect: () => ({ workspaceValue: [], globalValue: [] }),
@@ -1178,7 +1180,8 @@ describe('DeviceManager', () => {
                 deviceState: 'online'
             });
 
-            expect(manager.getDevice({ ip: '192.168.1.100' })).to.be.undefined;
+            // getDevice now returns devices regardless of filtering
+            expect(manager.getDevice({ ip: '192.168.1.100' })).to.not.be.undefined;
         });
 
         it('emits devices-changed when includeNonDeveloperDevices setting changes', () => {
@@ -1209,8 +1212,10 @@ describe('DeviceManager', () => {
             });
             addDevice(device);
 
-            // Device should be filtered initially
-            expect(manager.getAllDevices().length).to.equal(0);
+            // Device should be filtered initially from getDevicesForUI
+            expect(manager.getDevicesForUI().length).to.equal(0);
+            // But available from getAllDevices (unfiltered)
+            expect(manager.getAllDevices().length).to.equal(1);
 
             // Listen for devices-changed event
             const devicesChangedSpy = sinon.spy();
@@ -1681,7 +1686,7 @@ describe('DeviceManager', () => {
             });
         });
 
-        describe('checkDeviceHealth with failed network calls', () => {
+        describe('healthCheckDevice with failed network calls', () => {
             it('marks configured device as offline when health check fails and cache exists', async () => {
                 manager = new DeviceManager(vscode.context, mockGlobalStateManager);
                 sinon.stub(manager as any, 'randomDelay').resolves();
@@ -1703,7 +1708,7 @@ describe('DeviceManager', () => {
                 // Stub to simulate network failure
                 sinon.stub(rokuDeploy, 'getDeviceInfo').rejects(new Error('Device not responding'));
 
-                const result = await manager.checkDeviceHealth(device, true);
+                const result = await manager.healthCheckDevice(device, true);
 
                 expect(result).to.be.false;
                 expect(manager.getAllDevices().length).to.equal(1);
@@ -1727,7 +1732,7 @@ describe('DeviceManager', () => {
                 // Stub to simulate network failure
                 sinon.stub(rokuDeploy, 'getDeviceInfo').rejects(new Error('Device not responding'));
 
-                const result = await manager.checkDeviceHealth(device, true);
+                const result = await manager.healthCheckDevice(device, true);
 
                 expect(result).to.be.false;
                 expect(manager.getAllDevices().length).to.equal(1);
@@ -1751,7 +1756,7 @@ describe('DeviceManager', () => {
                 // Stub to simulate network failure
                 sinon.stub(rokuDeploy, 'getDeviceInfo').rejects(new Error('Device not responding'));
 
-                const result = await manager.checkDeviceHealth(device, true);
+                const result = await manager.healthCheckDevice(device, true);
 
                 expect(result).to.be.false;
                 expect(manager.getAllDevices().length).to.equal(0);
@@ -1763,7 +1768,7 @@ describe('DeviceManager', () => {
                 manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
                 // Simulate SSDP discovery - just adds to discoveredDevices
-                manager['setDiscoveredDevice']('192.168.1.100', 'ABC123', 'pending');
+                manager['setDiscoveredDevice']('192.168.1.100', 'ABC123');
 
                 const device = manager.getAllDevices().find(d => d.ip === '192.168.1.100');
                 expect(device?.isDiscovered).to.be.true;
@@ -1784,7 +1789,7 @@ describe('DeviceManager', () => {
 
                 sinon.stub(rokuDeploy, 'getDeviceInfo').rejects(new Error('Offline'));
 
-                await manager.checkDeviceHealth(device, true);
+                await manager.healthCheckDevice(device, true);
 
                 // Device kept (configured) but not discovered
                 expect(manager.getAllDevices().length).to.equal(1);
@@ -1807,7 +1812,7 @@ describe('DeviceManager', () => {
 
                 sinon.stub(rokuDeploy, 'getDeviceInfo').rejects(new Error('Offline'));
 
-                await manager.checkDeviceHealth(device, true);
+                await manager.healthCheckDevice(device, true);
 
                 // Device removed (not configured, not discovered)
                 expect(manager.getAllDevices().length).to.equal(0);
@@ -2080,18 +2085,18 @@ describe('DeviceManager', () => {
                     const resolveDeviceSpy = sinon.stub(manager as any, 'resolveDevice').returns(Promise.resolve(true));
 
                     // Perform health check to populate cooldown
-                    await manager.checkDeviceHealth(device);
+                    await manager.healthCheckDevice(device);
                     expect(resolveDeviceSpy.calledOnce).to.be.true;
 
                     // Second call should be skipped due to cooldown
-                    await manager.checkDeviceHealth(device);
+                    await manager.healthCheckDevice(device);
                     expect(resolveDeviceSpy.calledOnce).to.be.true; // Still just one call
 
                     // Clear cache
                     manager.clearAllCache();
 
                     // Now health check should work immediately
-                    await manager.checkDeviceHealth(device);
+                    await manager.healthCheckDevice(device);
                     expect(resolveDeviceSpy.calledTwice).to.be.true; // Cooldown was cleared
                 });
 
@@ -2181,14 +2186,14 @@ describe('DeviceManager', () => {
                     const resolveDeviceSpy = sinon.stub(manager as any, 'resolveDevice').returns(Promise.resolve(true));
 
                     // First health check
-                    await manager.checkDeviceHealth(device);
+                    await manager.healthCheckDevice(device);
                     expect(resolveDeviceSpy.calledOnce).to.be.true;
 
                     // Clear cache (should clear cooldown)
                     manager.clearAllCache();
 
                     // Health check should run immediately (no cooldown)
-                    await manager.checkDeviceHealth(device);
+                    await manager.healthCheckDevice(device);
                     expect(resolveDeviceSpy.calledTwice).to.be.true;
                 });
 
@@ -2204,7 +2209,7 @@ describe('DeviceManager', () => {
                     });
                     sinon.stub(manager as any, 'resolveDevice').returns(healthCheckPromise);
 
-                    const healthCheckCall = manager.checkDeviceHealth(device);
+                    const healthCheckCall = manager.healthCheckDevice(device);
 
                     // Clear cache while health check is in flight
                     manager.clearAllCache();
@@ -2449,7 +2454,7 @@ describe('DeviceManager', () => {
 
                 // Simulate device resolution - update discovered entry with serial
                 // (this is what resolveDevice does when it successfully fetches deviceInfo)
-                manager['setDiscoveredDevice']('192.168.1.100', 'NEWSERIAL', 'online');
+                manager['setDiscoveredDevice']('192.168.1.100', 'NEWSERIAL');
 
                 // Device now has serial-based key
                 result = manager.getDevice({ serialNumber: 'NEWSERIAL' });
@@ -2474,7 +2479,7 @@ describe('DeviceManager', () => {
                 addDevice(oldDevice);
 
                 // SSDP discovers same serial at new IP
-                manager['setDiscoveredDevice']('192.168.1.200', 'ABC123', 'online');
+                manager['setDiscoveredDevice']('192.168.1.200', 'ABC123');
 
                 // Should have exactly one device at new IP
                 expect(manager.getAllDevices().length).to.equal(1);
@@ -2498,7 +2503,7 @@ describe('DeviceManager', () => {
                 addDevice(oldDevice);
 
                 // SSDP discovers same serial at new IP
-                manager['setDiscoveredDevice']('192.168.1.200', 'ABC123', 'online');
+                manager['setDiscoveredDevice']('192.168.1.200', 'ABC123');
 
                 // Should preserve configured properties (from configuredDevices array)
                 expect(manager.getAllDevices().length).to.equal(1);
@@ -2522,7 +2527,7 @@ describe('DeviceManager', () => {
                 manager.setLastUsedDeviceIp('192.168.1.100');
 
                 // SSDP discovers same serial at new IP
-                manager['setDiscoveredDevice']('192.168.1.200', 'ABC123', 'online');
+                manager['setDiscoveredDevice']('192.168.1.200', 'ABC123');
 
                 // lastUsedDeviceIp should transfer to new IP
                 expect(manager.getLastUsedDeviceIp()).to.equal('192.168.1.200');
@@ -2699,7 +2704,7 @@ describe('DeviceManager', () => {
                 addDevice(oldDevice);
 
                 // SSDP discovers same serial at new IP
-                manager['setDiscoveredDevice']('192.168.1.200', 'ABC123', 'online');
+                manager['setDiscoveredDevice']('192.168.1.200', 'ABC123');
 
                 // Should have one device with BOTH isDiscovered and isConfigured
                 expect(manager.getAllDevices().length).to.equal(1);
@@ -2725,7 +2730,7 @@ describe('DeviceManager', () => {
                 addDevice(oldDevice);
 
                 // Discover device at new IP, also without serial
-                manager['setDiscoveredDevice']('192.168.1.200', undefined, 'online');
+                manager['setDiscoveredDevice']('192.168.1.200', undefined);
 
                 // Should have two devices (no deduplication without serial)
                 expect(manager.getAllDevices().length).to.equal(2);
@@ -2734,21 +2739,23 @@ describe('DeviceManager', () => {
             it('does not remove device at same IP (not a duplicate)', () => {
                 manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
-                // Device exists
+                // Device exists with fresh cache (deviceInfo provided populates cache)
                 const device = createMockDevice({
                     serialNumber: 'ABC123',
                     ip: '192.168.1.100',
                     deviceState: 'pending',
-                    isDiscovered: true
+                    isDiscovered: true,
+                    deviceInfo: { 'developer-enabled': 'true' } // Populate cache for fresh state determination
                 });
                 addDevice(device);
 
                 // Re-discover at same IP (normal refresh scenario)
-                manager['setDiscoveredDevice']('192.168.1.100', 'ABC123', 'online');
+                manager['setDiscoveredDevice']('192.168.1.100', 'ABC123');
 
                 // Should still have exactly one device (merged, not duplicated)
                 expect(manager.getAllDevices().length).to.equal(1);
                 expect(manager.getAllDevices()[0].ip).to.equal('192.168.1.100');
+                // With fresh cache, device should be online
                 expect(manager.getAllDevices()[0].deviceState).to.equal('online');
             });
         });

--- a/src/deviceDiscovery/DeviceManager.spec.ts
+++ b/src/deviceDiscovery/DeviceManager.spec.ts
@@ -659,7 +659,8 @@ describe('DeviceManager', () => {
                 const devicesChangedSpy = sinon.spy();
                 manager.on('devices-changed', devicesChangedSpy);
 
-                manager['removeDevice'](device.ip);
+                manager['removeDiscoveredDevice'](device.ip);
+                manager['emitDevicesChanged']();
 
                 // First call after throttle window emits immediately
                 expect(devicesChangedSpy.calledOnce).to.be.true;
@@ -911,7 +912,7 @@ describe('DeviceManager', () => {
         });
     });
 
-    describe('removeDevice', () => {
+    describe('removeDiscoveredDevice', () => {
         it('clears lastUsedDeviceIp when removed device matches', () => {
             const clock = sinon.useFakeTimers();
             try {
@@ -924,7 +925,7 @@ describe('DeviceManager', () => {
 
                 expect(manager.getLastUsedDeviceIp()).to.equal(device.ip);
 
-                manager['removeDevice'](device.ip);
+                manager['removeDiscoveredDevice'](device.ip);
 
                 expect(manager.getLastUsedDeviceIp()).to.be.undefined;
             } finally {
@@ -944,7 +945,7 @@ describe('DeviceManager', () => {
                 addDevice(device2);
                 manager.setLastUsedDeviceIp(device1.ip);
 
-                manager['removeDevice'](device2.ip);
+                manager['removeDiscoveredDevice'](device2.ip);
 
                 expect(manager.getLastUsedDeviceIp()).to.equal(device1.ip);
             } finally {
@@ -961,34 +962,9 @@ describe('DeviceManager', () => {
                 const device = createMockDevice();
                 addDevice(device);
 
-                manager['removeDevice'](device.ip);
+                manager['removeDiscoveredDevice'](device.ip);
 
                 expect(mockGlobalStateManager.removeLastSeenDevice.calledWith('test-network-hash', device.serialNumber)).to.be.true;
-            } finally {
-                clock.restore();
-            }
-        });
-
-        it('emits devices-changed when device is removed', () => {
-            const clock = sinon.useFakeTimers();
-            try {
-                manager = new DeviceManager(vscode.context, mockGlobalStateManager);
-
-                manager['discoveredDevices'].push({
-                    ip: '192.168.1.100',
-                    serialNumber: 'device-123'
-                });
-                manager['setDeviceState']({ ip: '192.168.1.100', serialNumber: 'device-123' }, 'online');
-
-                const spy = sinon.spy();
-                manager.on('devices-changed', spy);
-
-                manager['removeDevice']('192.168.1.100');
-
-                // Advance past throttle
-                clock.tick(100);
-
-                expect(spy.called).to.be.true;
             } finally {
                 clock.restore();
             }
@@ -998,7 +974,7 @@ describe('DeviceManager', () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
             // Should not throw
-            expect(() => manager['removeDevice']('192.168.1.100')).to.not.throw();
+            expect(() => manager['removeDiscoveredDevice']('192.168.1.100')).to.not.throw();
         });
     });
 

--- a/src/deviceDiscovery/DeviceManager.spec.ts
+++ b/src/deviceDiscovery/DeviceManager.spec.ts
@@ -2764,6 +2764,136 @@ describe('DeviceManager', () => {
         });
     });
 
+    describe('serial mismatch detection', () => {
+        describe('checkForSerialMismatch', () => {
+            it('returns false when no new serial is provided', () => {
+                manager = new DeviceManager(vscode.context, mockGlobalStateManager);
+
+                const result = manager['checkForSerialMismatch']('192.168.1.100', undefined);
+                expect(result).to.be.false;
+            });
+
+            it('returns false when no stored serial exists for IP', () => {
+                manager = new DeviceManager(vscode.context, mockGlobalStateManager);
+                mockGlobalStateManager.getSerialNumberForIp.returns(undefined);
+
+                const result = manager['checkForSerialMismatch']('192.168.1.100', 'NEW-SERIAL');
+                expect(result).to.be.false;
+            });
+
+            it('returns false when stored serial matches new serial', () => {
+                manager = new DeviceManager(vscode.context, mockGlobalStateManager);
+                mockGlobalStateManager.getSerialNumberForIp.returns('ABC123');
+
+                const result = manager['checkForSerialMismatch']('192.168.1.100', 'ABC123');
+                expect(result).to.be.false;
+            });
+
+            it('returns true when stored serial differs from new serial', () => {
+                manager = new DeviceManager(vscode.context, mockGlobalStateManager);
+                mockGlobalStateManager.getSerialNumberForIp.returns('OLD-SERIAL');
+
+                const result = manager['checkForSerialMismatch']('192.168.1.100', 'NEW-SERIAL');
+                expect(result).to.be.true;
+            });
+
+            it('returns true when configured device has different serial', () => {
+                manager = new DeviceManager(vscode.context, mockGlobalStateManager);
+                mockGlobalStateManager.getSerialNumberForIp.returns(undefined);
+
+                // Add configured device with serial
+                manager['configuredDevices'].push({
+                    host: '192.168.1.100',
+                    resolvedIp: '192.168.1.100',
+                    serialNumber: 'CONFIGURED-SERIAL'
+                });
+
+                const result = manager['checkForSerialMismatch']('192.168.1.100', 'NEW-SERIAL');
+                expect(result).to.be.true;
+            });
+
+            it('returns true when discovered device has different serial', () => {
+                manager = new DeviceManager(vscode.context, mockGlobalStateManager);
+                mockGlobalStateManager.getSerialNumberForIp.returns(undefined);
+
+                // Add discovered device with serial
+                manager['discoveredDevices'].push({
+                    ip: '192.168.1.100',
+                    serialNumber: 'DISCOVERED-SERIAL'
+                });
+
+                const result = manager['checkForSerialMismatch']('192.168.1.100', 'NEW-SERIAL');
+                expect(result).to.be.true;
+            });
+        });
+
+        describe('config reload on mismatch', () => {
+            it('reloads configured devices when resolveDevice detects serial mismatch', async () => {
+                manager = new DeviceManager(vscode.context, mockGlobalStateManager);
+                sinon.stub(manager as any, 'randomDelay').resolves();
+
+                // Set up: stored serial for this IP
+                mockGlobalStateManager.getSerialNumberForIp.returns('OLD-SERIAL');
+
+                // Spy on loadConfiguredDevices
+                const loadConfigSpy = sinon.spy(manager as any, 'loadConfiguredDevices');
+
+                // Mock getDeviceInfo to return a different serial
+                sinon.stub(rokuDeploy, 'getDeviceInfo').resolves({
+                    'serial-number': 'NEW-SERIAL',
+                    'device-id': 'NEW-SERIAL',
+                    'default-device-name': 'Roku Express'
+                } as any);
+
+                // Resolve device
+                await manager['resolveDevice']({ ip: '192.168.1.100' });
+
+                // Should have called loadConfiguredDevices
+                expect(loadConfigSpy.calledOnce).to.be.true;
+            });
+
+            it('reloads configured devices when SSDP finds device with different serial at known IP', () => {
+                manager = new DeviceManager(vscode.context, mockGlobalStateManager);
+
+                // Set up: stored serial for this IP
+                mockGlobalStateManager.getSerialNumberForIp.returns('OLD-SERIAL');
+
+                // Spy on loadConfiguredDevices
+                const loadConfigSpy = sinon.spy(manager as any, 'loadConfiguredDevices');
+
+                // Simulate SSDP finding a different device at the same IP
+                manager['finder'].emit('found', '192.168.1.100', { serialNumber: 'NEW-SERIAL' });
+
+                // Should have called loadConfiguredDevices
+                expect(loadConfigSpy.calledOnce).to.be.true;
+            });
+
+            it('does not reload when serial matches', async () => {
+                manager = new DeviceManager(vscode.context, mockGlobalStateManager);
+                sinon.stub(manager as any, 'randomDelay').resolves();
+
+                // Set up: stored serial for this IP
+                mockGlobalStateManager.getSerialNumberForIp.returns('SAME-SERIAL');
+
+                // Spy on loadConfiguredDevices
+                const loadConfigSpy = sinon.spy(manager as any, 'loadConfiguredDevices');
+
+                // Mock getDeviceInfo to return the same serial
+                sinon.stub(rokuDeploy, 'getDeviceInfo').resolves({
+                    'serial-number': 'SAME-SERIAL',
+                    'device-id': 'SAME-SERIAL',
+                    'default-device-name': 'Roku Express'
+                } as any);
+
+                // Resolve device
+                await manager['resolveDevice']({ ip: '192.168.1.100' });
+
+                // Should NOT have called loadConfiguredDevices
+                expect(loadConfigSpy.called).to.be.false;
+            });
+        });
+    });
+
     describe('defaultPassword', () => {
         function stubConfig(defaultDevicePassword: string | undefined) {
             (vscode.workspace.getConfiguration as sinon.SinonStub).returns({

--- a/src/deviceDiscovery/DeviceManager.spec.ts
+++ b/src/deviceDiscovery/DeviceManager.spec.ts
@@ -12,7 +12,8 @@ describe('DeviceManager', () => {
     let mockGlobalStateManager: any;
 
     function createMockDevice(overrides: Partial<RokuDevice> & { deviceInfo?: any; serialNumber?: string | null } = {}): RokuDevice {
-        const serialNumber = overrides.serialNumber ?? 'device-123';
+        // Explicit null means no serial, undefined means use default
+        const serialNumber = overrides.serialNumber === null ? undefined : (overrides.serialNumber ?? 'device-123');
         const ip = overrides.ip ?? '192.168.1.100';
 
         // Remove serialNumber and deviceInfo from overrides since we handle them separately
@@ -62,9 +63,10 @@ describe('DeviceManager', () => {
     function addDiscoveredDevice(device: RokuDevice): void {
         manager['discoveredDevices'].push({
             ip: device.ip,
-            serialNumber: device.serialNumber,
-            deviceState: device.deviceState === 'offline' ? 'pending' : device.deviceState
+            serialNumber: device.serialNumber
         });
+        // Set the device state in the separate state map
+        manager['setDeviceState']({ ip: device.ip, serialNumber: device.serialNumber }, device.deviceState === 'offline' ? 'pending' : device.deviceState);
     }
 
     /**
@@ -77,9 +79,10 @@ describe('DeviceManager', () => {
             name: device.configuredName,
             password: device.configuredPassword,
             serialNumber: device.serialNumber,
-            deviceState: device.deviceState,
             configuredIn: device.configuredIn
         });
+        // Set the device state in the separate state map
+        manager['setDeviceState']({ ip: device.ip, serialNumber: device.serialNumber }, device.deviceState);
     }
 
     /**
@@ -933,9 +936,9 @@ describe('DeviceManager', () => {
 
                 manager['discoveredDevices'].push({
                     ip: '192.168.1.100',
-                    serialNumber: 'device-123',
-                    deviceState: 'online'
+                    serialNumber: 'device-123'
                 });
+                manager['setDeviceState']({ ip: '192.168.1.100', serialNumber: 'device-123' }, 'online');
 
                 const spy = sinon.spy();
                 manager.on('devices-changed', spy);
@@ -1012,7 +1015,7 @@ describe('DeviceManager', () => {
 
             manager['loadLastSeenDevices']();
 
-            expect(manager['discoveredDevices'][0].deviceState).to.equal('online');
+            expect(manager['getDeviceState']({ ip: '192.168.1.100', serialNumber: 'device-1' })).to.equal('online');
         });
 
         it('loads cached devices as pending when cache is stale (older than 5 minutes)', () => {
@@ -1102,9 +1105,9 @@ describe('DeviceManager', () => {
             // Add device without developer-enabled in deviceInfo
             manager['discoveredDevices'].push({
                 ip: '192.168.1.100',
-                serialNumber: 'ABC123',
-                deviceState: 'online'
+                serialNumber: 'ABC123'
             });
+            manager['setDeviceState']({ ip: '192.168.1.100', serialNumber: 'ABC123' }, 'online');
 
             // Device should be filtered out from getDevicesForUI
             expect(manager.getDevicesForUI().length).to.equal(0);
@@ -1176,9 +1179,9 @@ describe('DeviceManager', () => {
             // Add device without developer-enabled
             manager['discoveredDevices'].push({
                 ip: '192.168.1.100',
-                serialNumber: 'ABC123',
-                deviceState: 'online'
+                serialNumber: 'ABC123'
             });
+            manager['setDeviceState']({ ip: '192.168.1.100', serialNumber: 'ABC123' }, 'online');
 
             // getDevice now returns devices regardless of filtering
             expect(manager.getDevice({ ip: '192.168.1.100' })).to.not.be.undefined;
@@ -1501,9 +1504,9 @@ describe('DeviceManager', () => {
             // Add a discovered device to verify it gets cleared on network change
             manager['discoveredDevices'].push({
                 serialNumber: 'device-123',
-                ip: '192.168.1.100',
-                deviceState: 'online'
+                ip: '192.168.1.100'
             });
+            manager['setDeviceState']({ serialNumber: 'device-123', ip: '192.168.1.100' }, 'online');
             expect(manager['discoveredDevices'].length).to.equal(1);
 
             // Change the network hash
@@ -1555,14 +1558,14 @@ describe('DeviceManager', () => {
             // Add discovered devices
             manager['discoveredDevices'].push({
                 serialNumber: 'device-123',
-                ip: '192.168.1.100',
-                deviceState: 'online'
+                ip: '192.168.1.100'
             });
+            manager['setDeviceState']({ serialNumber: 'device-123', ip: '192.168.1.100' }, 'online');
             manager['discoveredDevices'].push({
                 serialNumber: 'device-456',
-                ip: '192.168.1.101',
-                deviceState: 'online'
+                ip: '192.168.1.101'
             });
+            manager['setDeviceState']({ serialNumber: 'device-456', ip: '192.168.1.101' }, 'online');
             expect(manager['discoveredDevices'].length).to.equal(2);
 
             // Change the network hash
@@ -1581,16 +1584,16 @@ describe('DeviceManager', () => {
             // Add a configured device
             manager['configuredDevices'].push({
                 host: '192.168.1.100',
-                name: 'My Roku',
-                deviceState: 'online'
+                name: 'My Roku'
             } as any);
+            manager['setDeviceState']({ ip: '192.168.1.100' }, 'online');
 
             // Add a discovered device
             manager['discoveredDevices'].push({
                 serialNumber: 'device-123',
-                ip: '192.168.1.101',
-                deviceState: 'online'
+                ip: '192.168.1.101'
             });
+            manager['setDeviceState']({ serialNumber: 'device-123', ip: '192.168.1.101' }, 'online');
 
             expect(manager['configuredDevices'].length).to.equal(1);
             expect(manager['discoveredDevices'].length).to.equal(1);
@@ -1642,9 +1645,9 @@ describe('DeviceManager', () => {
                     host: '192.168.1.100',
                     resolvedIp: '192.168.1.100',
                     name: 'My Roku',
-                    deviceState: 'pending',
                     serialNumber: undefined
-                });
+                } as any);
+                manager['setDeviceState']({ ip: '192.168.1.100' }, 'pending');
 
                 // Add discovered device at same IP with serial
                 addDiscoveredDevice(createMockDevice({
@@ -2290,9 +2293,9 @@ describe('DeviceManager', () => {
                 // Create device without serial - manually add to discovered array
                 manager['discoveredDevices'].push({
                     ip: '192.168.1.100',
-                    serialNumber: undefined,
-                    deviceState: 'online'
+                    serialNumber: undefined
                 });
+                manager['setDeviceState']({ ip: '192.168.1.100' }, 'online');
 
                 const result = manager.getDevice({ ip: '192.168.1.100' });
 
@@ -2444,9 +2447,9 @@ describe('DeviceManager', () => {
                 // Start with device that has no serial
                 manager['discoveredDevices'].push({
                     ip: '192.168.1.100',
-                    serialNumber: undefined,
-                    deviceState: 'online'
+                    serialNumber: undefined
                 });
+                manager['setDeviceState']({ ip: '192.168.1.100' }, 'online');
 
                 // Initially should have IP-based key
                 let result = manager.getDevice('i:192.168.1.100');
@@ -2674,10 +2677,10 @@ describe('DeviceManager', () => {
                     host: '192.168.1.200', // stale IP from config
                     resolvedIp: '192.168.1.200',
                     serialNumber: 'ABC123',
-                    deviceState: 'pending',
                     name: 'My Configured Roku',
                     password: 'secret'
                 });
+                manager['setDeviceState']({ ip: '192.168.1.200', serialNumber: 'ABC123' }, 'pending');
 
                 // Should have ONE device at the DISCOVERED IP (not the configured IP)
                 expect(manager.getAllDevices().length).to.equal(1);
@@ -2800,9 +2803,9 @@ describe('DeviceManager', () => {
 
                 manager['discoveredDevices'].push({
                     serialNumber: 'abc',
-                    ip: '10.0.0.5',
-                    deviceState: 'online'
+                    ip: '10.0.0.5'
                 });
+                manager['setDeviceState']({ serialNumber: 'abc', ip: '10.0.0.5' }, 'online');
 
                 const device = manager.getDevice({ ip: '10.0.0.5' });
                 expect(device?.configuredPassword).to.equal('hunter2');
@@ -2815,9 +2818,9 @@ describe('DeviceManager', () => {
                 // Add a configured device with a specific password
                 manager['configuredDevices'].push({
                     host: '10.0.0.5',
-                    password: 'specific',
-                    deviceState: 'online'
+                    password: 'specific'
                 } as any);
+                manager['setDeviceState']({ ip: '10.0.0.5' }, 'online');
 
                 const device = manager.getDevice({ ip: '10.0.0.5' });
                 expect(device?.configuredPassword).to.equal('specific');
@@ -2829,9 +2832,9 @@ describe('DeviceManager', () => {
 
                 manager['discoveredDevices'].push({
                     serialNumber: 'abc',
-                    ip: '10.0.0.5',
-                    deviceState: 'online'
+                    ip: '10.0.0.5'
                 });
+                manager['setDeviceState']({ serialNumber: 'abc', ip: '10.0.0.5' }, 'online');
 
                 const device = manager.getDevice({ ip: '10.0.0.5' });
                 expect(device?.configuredPassword).to.be.undefined;
@@ -2846,16 +2849,16 @@ describe('DeviceManager', () => {
                 // Discovered device without password
                 manager['discoveredDevices'].push({
                     serialNumber: 'no-pw',
-                    ip: '10.0.0.5',
-                    deviceState: 'online'
+                    ip: '10.0.0.5'
                 });
+                manager['setDeviceState']({ serialNumber: 'no-pw', ip: '10.0.0.5' }, 'online');
                 // Configured device with specific password
                 manager['configuredDevices'].push({
                     host: '10.0.0.6',
                     password: 'specific',
-                    serialNumber: 'has-pw',
-                    deviceState: 'online'
+                    serialNumber: 'has-pw'
                 } as any);
+                manager['setDeviceState']({ serialNumber: 'has-pw', ip: '10.0.0.6' }, 'online');
 
                 const devices = manager.getAllDevices();
                 const withoutPw = devices.find(d => d.serialNumber === 'no-pw');
@@ -2870,9 +2873,9 @@ describe('DeviceManager', () => {
 
                 manager['discoveredDevices'].push({
                     serialNumber: 'abc',
-                    ip: '10.0.0.5',
-                    deviceState: 'online'
+                    ip: '10.0.0.5'
                 });
+                manager['setDeviceState']({ serialNumber: 'abc', ip: '10.0.0.5' }, 'online');
 
                 manager.getAllDevices();
 

--- a/src/deviceDiscovery/DeviceManager.spec.ts
+++ b/src/deviceDiscovery/DeviceManager.spec.ts
@@ -139,6 +139,7 @@ describe('DeviceManager', () => {
         // Mock vscode configuration
         sinon.stub(vscode.workspace, 'getConfiguration').returns({
             get: () => undefined,
+            inspect: () => ({ workspaceValue: [], globalValue: [] }),
             deviceDiscovery: {
                 enabled: false, // Disabled to prevent auto-initialization
                 showInfoMessages: false
@@ -1971,11 +1972,11 @@ describe('DeviceManager', () => {
 
                 manager['loadLastSeenDevices']();
 
-                // Only configured device should remain
+                // Only configured device should remain (state unchanged - reset happens in network change handler)
                 expect(manager.getAllDevices().length).to.equal(1);
                 const serial = manager.getAllDevices()[0].serialNumber;
                 expect(serial).to.equal('configured-1');
-                expect(manager.getAllDevices()[0].deviceState).to.equal('pending');
+                expect(manager.getAllDevices()[0].deviceState).to.equal('online');
             });
         });
 

--- a/src/deviceDiscovery/DeviceManager.spec.ts
+++ b/src/deviceDiscovery/DeviceManager.spec.ts
@@ -1971,9 +1971,9 @@ describe('DeviceManager', () => {
                 expect(manager.getAllDevices().length).to.equal(0);
             });
 
-            it('merges config entries with same IP but different serials (last wins)', async () => {
+            it('shows separate entries when same IP has different serials in config', async () => {
                 // Two config entries pointing to same IP with different serials
-                // This is a misconfiguration, but we should handle it gracefully
+                // Since serial is primary key, these are treated as different devices
                 (vscode.workspace.getConfiguration as sinon.SinonStub).returns({
                     inspect: () => ({
                         workspaceValue: [],
@@ -1992,11 +1992,22 @@ describe('DeviceManager', () => {
 
                 await manager['loadConfiguredDevices']();
 
-                // Should have exactly one device (merged by IP, second entry wins)
-                expect(manager.getAllDevices().length).to.equal(1);
-                expect(manager.getAllDevices()[0].ip).to.equal('192.168.1.100');
-                expect(manager.getAllDevices()[0].configuredName).to.equal('Second Entry');
-                expect(manager.getAllDevices()[0].isConfigured).to.equal(true);
+                // Should have two devices (different serials = different devices, even at same IP)
+                const devices = manager.getAllDevices();
+                expect(devices.length).to.equal(2);
+
+                const firstDevice = devices.find(d => d.serialNumber === 'ABC');
+                const secondDevice = devices.find(d => d.serialNumber === 'XYZ');
+
+                expect(firstDevice).to.exist;
+                expect(firstDevice.ip).to.equal('192.168.1.100');
+                expect(firstDevice.configuredName).to.equal('First Entry');
+                expect(firstDevice.isConfigured).to.equal(true);
+
+                expect(secondDevice).to.exist;
+                expect(secondDevice.ip).to.equal('192.168.1.100');
+                expect(secondDevice.configuredName).to.equal('Second Entry');
+                expect(secondDevice.isConfigured).to.equal(true);
             });
 
             it('clears configuredName when name is removed from config', async () => {
@@ -2949,7 +2960,7 @@ describe('DeviceManager', () => {
                 });
             });
 
-            it('shows actual device serial when configured serial differs from device at IP', async () => {
+            it('shows two devices when configured serial differs from device at IP', async () => {
                 manager = new DeviceManager(vscode.context, mockGlobalStateManager);
                 sinon.stub(manager as any, 'randomDelay').resolves();
 
@@ -2975,13 +2986,24 @@ describe('DeviceManager', () => {
                 // Get the devices
                 const devices = manager.getAllDevices();
 
-                // Current behavior: shows ONE device with the actual serial (XYZ)
-                // but with the user's configured name
-                expect(devices).to.have.lengthOf(1);
-                expect(devices[0].serialNumber).to.equal('ACTUAL-XYZ');
-                expect(devices[0].configuredName).to.equal('My Living Room Roku');
-                expect(devices[0].isConfigured).to.be.true;
-                expect(devices[0].isDiscovered).to.be.true;
+                // Expected: TWO devices - configured device offline, discovered device online
+                expect(devices).to.have.lengthOf(2);
+
+                // Find the configured device (serial ABC) - offline because a different device is at its IP
+                const configuredDevice = devices.find(d => d.serialNumber === 'CONFIGURED-ABC');
+                expect(configuredDevice).to.exist;
+                expect(configuredDevice.configuredName).to.equal('My Living Room Roku');
+                expect(configuredDevice.isConfigured).to.be.true;
+                expect(configuredDevice.isDiscovered).to.be.false;
+                expect(configuredDevice.deviceState).to.equal('offline');
+
+                // Find the discovered device (serial XYZ)
+                const discoveredDevice = devices.find(d => d.serialNumber === 'ACTUAL-XYZ');
+                expect(discoveredDevice).to.exist;
+                expect(discoveredDevice.configuredName).to.be.undefined;
+                expect(discoveredDevice.isConfigured).to.be.false;
+                expect(discoveredDevice.isDiscovered).to.be.true;
+                expect(discoveredDevice.deviceState).to.equal('online');
             });
         });
     });

--- a/src/deviceDiscovery/DeviceManager.spec.ts
+++ b/src/deviceDiscovery/DeviceManager.spec.ts
@@ -142,7 +142,8 @@ describe('DeviceManager', () => {
             inspect: () => ({ workspaceValue: [], globalValue: [] }),
             deviceDiscovery: {
                 enabled: false, // Disabled to prevent auto-initialization
-                showInfoMessages: false
+                showInfoMessages: false,
+                includeNonDeveloperDevices: true // Include all devices in tests by default
             }
         } as any);
 
@@ -1082,68 +1083,61 @@ describe('DeviceManager', () => {
         });
     });
 
-    describe('processDiscoveredIp', () => {
-        const mockDeviceInfo = {
-            'device-id': 'test-device-123',
-            'serial-number': 'YN00AB123456',
-            'default-device-name': 'Roku Express',
-            'developer-enabled': 'true',
-            'is-stick': 'false',
-            'is-tv': 'false'
-        };
-
-        it('fetches device info and upserts device using serial number', async () => {
-            manager = new DeviceManager(vscode.context, mockGlobalStateManager);
-
-            sinon.stub(rokuDeploy, 'getDeviceInfo').resolves(mockDeviceInfo as any);
-
-            await manager['processDiscoveredIp']('192.168.1.100');
-
-            expect(manager.getAllDevices().length).to.equal(1);
-            expect(manager.getAllDevices()[0].ip).to.equal('192.168.1.100');
-            expect(manager.getAllDevices()[0].serialNumber).to.equal('YN00AB123456');
-            expect(manager.getAllDevices()[0].deviceState).to.equal('online');
-        });
-
-        it('uses serial from deviceInfo (not SSDP hint)', async () => {
-            manager = new DeviceManager(vscode.context, mockGlobalStateManager);
-
-            sinon.stub(rokuDeploy, 'getDeviceInfo').resolves(mockDeviceInfo as any);
-
-            // SSDP provides a hint, but deviceInfo is the source of truth
-            await manager['processDiscoveredIp']('192.168.1.100', 'SSDP-SERIAL-123');
-
-            expect(manager.getAllDevices().length).to.equal(1);
-            // Should use deviceInfo's serial, not SSDP hint
-            expect(manager.getAllDevices()[0].serialNumber).to.equal('YN00AB123456');
-        });
-
-        it('falls back to deviceInfo serial when SSDP serial not provided', async () => {
-            manager = new DeviceManager(vscode.context, mockGlobalStateManager);
-
-            sinon.stub(rokuDeploy, 'getDeviceInfo').resolves(mockDeviceInfo as any);
-
-            await manager['processDiscoveredIp']('192.168.1.100');
-
-            expect(manager.getAllDevices()[0].serialNumber).to.equal('YN00AB123456');
-        });
-
-        it('filters non-developer devices by default', async () => {
-            manager = new DeviceManager(vscode.context, mockGlobalStateManager);
-
-            sinon.stub(rokuDeploy, 'getDeviceInfo').resolves({
-                ...mockDeviceInfo,
-                'developer-enabled': 'false'
+    describe('device filtering (shouldShowDevice)', () => {
+        it('filters devices without developer-enabled by default', () => {
+            // Default config has includeNonDeveloperDevices: true for tests,
+            // so override to test filtering
+            (vscode.workspace.getConfiguration as sinon.SinonStub).returns({
+                get: () => undefined,
+                inspect: () => ({ workspaceValue: [], globalValue: [] }),
+                deviceDiscovery: {
+                    enabled: false,
+                    showInfoMessages: false,
+                    includeNonDeveloperDevices: false
+                }
             } as any);
 
-            await manager['processDiscoveredIp']('192.168.1.100');
+            manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
+            // Add device without developer-enabled in deviceInfo
+            manager['discoveredDevices'].push({
+                ip: '192.168.1.100',
+                serialNumber: 'ABC123',
+                deviceState: 'online'
+            });
+
+            // Device should be filtered out
             expect(manager.getAllDevices().length).to.equal(0);
         });
 
-        it('includes non-developer devices when setting enabled', async () => {
+        it('shows devices with developer-enabled: true', () => {
             (vscode.workspace.getConfiguration as sinon.SinonStub).returns({
                 get: () => undefined,
+                inspect: () => ({ workspaceValue: [], globalValue: [] }),
+                deviceDiscovery: {
+                    enabled: false,
+                    showInfoMessages: false,
+                    includeNonDeveloperDevices: false
+                }
+            } as any);
+
+            manager = new DeviceManager(vscode.context, mockGlobalStateManager);
+
+            // Add device with developer-enabled in cached deviceInfo
+            const device = createMockDevice({
+                serialNumber: 'ABC123',
+                ip: '192.168.1.100',
+                deviceInfo: { 'developer-enabled': 'true' }
+            });
+            addDevice(device);
+
+            expect(manager.getAllDevices().length).to.equal(1);
+        });
+
+        it('includes non-developer devices when setting enabled', () => {
+            (vscode.workspace.getConfiguration as sinon.SinonStub).returns({
+                get: () => undefined,
+                inspect: () => ({ workspaceValue: [], globalValue: [] }),
                 deviceDiscovery: {
                     enabled: false,
                     showInfoMessages: false,
@@ -1153,57 +1147,38 @@ describe('DeviceManager', () => {
 
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
-            sinon.stub(rokuDeploy, 'getDeviceInfo').resolves({
-                ...mockDeviceInfo,
-                'developer-enabled': 'false'
-            } as any);
-
-            await manager['processDiscoveredIp']('192.168.1.100');
-
-            expect(manager.getAllDevices().length).to.equal(1);
-        });
-
-        it('handles string "true" for developer-enabled', async () => {
-            manager = new DeviceManager(vscode.context, mockGlobalStateManager);
-
-            sinon.stub(rokuDeploy, 'getDeviceInfo').resolves({
-                ...mockDeviceInfo,
-                'developer-enabled': 'true'
-            } as any);
-
-            await manager['processDiscoveredIp']('192.168.1.100');
+            // Add device with developer-enabled: false
+            const device = createMockDevice({
+                serialNumber: 'ABC123',
+                ip: '192.168.1.100',
+                deviceInfo: { 'developer-enabled': 'false' }
+            });
+            addDevice(device);
 
             expect(manager.getAllDevices().length).to.equal(1);
         });
 
-        it('handles network errors gracefully', async () => {
-            manager = new DeviceManager(vscode.context, mockGlobalStateManager);
-
-            sinon.stub(rokuDeploy, 'getDeviceInfo').rejects(new Error('Network error'));
-
-            // Should not throw
-            await manager['processDiscoveredIp']('192.168.1.100');
-
-            expect(manager.getAllDevices().length).to.equal(0);
-        });
-
-        it('processDiscoveredIp does not show notifications', async () => {
+        it('getDevice returns undefined for filtered devices', () => {
             (vscode.workspace.getConfiguration as sinon.SinonStub).returns({
                 get: () => undefined,
+                inspect: () => ({ workspaceValue: [], globalValue: [] }),
                 deviceDiscovery: {
                     enabled: false,
-                    showInfoMessages: true
+                    showInfoMessages: false,
+                    includeNonDeveloperDevices: false
                 }
             } as any);
 
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
-            sinon.stub(rokuDeploy, 'getDeviceInfo').resolves(mockDeviceInfo as any);
-            const showTimedStub = sinon.stub(util, 'showTimedNotification').resolves();
+            // Add device without developer-enabled
+            manager['discoveredDevices'].push({
+                ip: '192.168.1.100',
+                serialNumber: 'ABC123',
+                deviceState: 'online'
+            });
 
-            await manager['processDiscoveredIp']('192.168.1.100');
-
-            expect(showTimedStub.called).to.be.false;
+            expect(manager.getDevice({ ip: '192.168.1.100' })).to.be.undefined;
         });
     });
 
@@ -1221,23 +1196,27 @@ describe('DeviceManager', () => {
             const clock = sinon.useFakeTimers();
             (vscode.workspace.getConfiguration as sinon.SinonStub).returns({
                 get: () => undefined,
+                inspect: () => ({ workspaceValue: [], globalValue: [] }),
                 deviceDiscovery: {
                     enabled: false,
-                    showInfoMessages: true
+                    showInfoMessages: true,
+                    includeNonDeveloperDevices: true
                 }
             } as any);
 
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
-            sinon.stub(manager as any, 'randomDelay').resolves();
-
-            sinon.stub(rokuDeploy, 'getDeviceInfo').resolves(mockDeviceInfo as any);
             const showTimedStub = sinon.stub(util, 'showTimedNotification').resolves();
 
-            // First, add device to cache
-            await manager['processDiscoveredIp']('192.168.1.100', 'ABC123');
+            // Add device with cached info
+            const device = createMockDevice({
+                serialNumber: 'YN00AB123456',
+                ip: '192.168.1.100',
+                deviceInfo: mockDeviceInfo
+            });
+            addDevice(device);
 
-            // Now trigger device-online
-            manager['handleDeviceOnline']('192.168.1.100', 'ABC123');
+            // Trigger device-online
+            manager['handleDeviceOnline']('192.168.1.100', 'YN00AB123456');
             clock.tick(1_000);
             await Promise.resolve();
 
@@ -1288,30 +1267,34 @@ describe('DeviceManager', () => {
             const clock = sinon.useFakeTimers();
             (vscode.workspace.getConfiguration as sinon.SinonStub).returns({
                 get: () => undefined,
+                inspect: () => ({ workspaceValue: [], globalValue: [] }),
                 deviceDiscovery: {
                     enabled: false,
-                    showInfoMessages: true
+                    showInfoMessages: true,
+                    includeNonDeveloperDevices: true
                 }
             } as any);
 
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
-            sinon.stub(manager as any, 'randomDelay').resolves();
-
-            sinon.stub(rokuDeploy, 'getDeviceInfo').resolves(mockDeviceInfo as any);
             const showTimedStub = sinon.stub(util, 'showTimedNotification').resolves();
 
-            // Add device to cache
-            await manager['processDiscoveredIp']('192.168.1.100', 'ABC123');
+            // Add device with cached info
+            const device = createMockDevice({
+                serialNumber: 'YN00AB123456',
+                ip: '192.168.1.100',
+                deviceInfo: mockDeviceInfo
+            });
+            addDevice(device);
 
             // First device-online
-            manager['handleDeviceOnline']('192.168.1.100', 'ABC123');
+            manager['handleDeviceOnline']('192.168.1.100', 'YN00AB123456');
             clock.tick(1_000);
             await Promise.resolve();
 
             expect(showTimedStub.calledOnce).to.be.true;
 
             // Second device-online from same device - should still show notification
-            manager['handleDeviceOnline']('192.168.1.100', 'ABC123');
+            manager['handleDeviceOnline']('192.168.1.100', 'YN00AB123456');
             clock.tick(1_000);
             await Promise.resolve();
 
@@ -1732,16 +1715,11 @@ describe('DeviceManager', () => {
         });
 
         describe('isDiscovered flag', () => {
-            it('sets isDiscovered true when device comes from discovery', async () => {
+            it('sets isDiscovered true when device comes from discovery', () => {
                 manager = new DeviceManager(vscode.context, mockGlobalStateManager);
-                sinon.stub(rokuDeploy, 'getDeviceInfo').resolves({
-                    'device-id': 'device-123',
-                    'serial-number': 'ABC123',
-                    'default-device-name': 'Roku Express',
-                    'developer-enabled': 'true'
-                } as any);
 
-                await manager['processDiscoveredIp']('192.168.1.100', 'ABC123');
+                // Simulate SSDP discovery - just adds to discoveredDevices
+                manager['setDiscoveredDevice']('192.168.1.100', 'ABC123', 'pending');
 
                 const device = manager.getAllDevices().find(d => d.ip === '192.168.1.100');
                 expect(device?.isDiscovered).to.be.true;
@@ -1833,7 +1811,11 @@ describe('DeviceManager', () => {
                     inspect: () => ({
                         workspaceValue: [],
                         globalValue: []
-                    })
+                    }),
+                    deviceDiscovery: {
+                        enabled: false,
+                        includeNonDeveloperDevices: true
+                    }
                 });
 
                 manager = new DeviceManager(vscode.context, mockGlobalStateManager);
@@ -1870,7 +1852,11 @@ describe('DeviceManager', () => {
                     inspect: () => ({
                         workspaceValue: [],
                         globalValue: []
-                    })
+                    }),
+                    deviceDiscovery: {
+                        enabled: false,
+                        includeNonDeveloperDevices: true
+                    }
                 });
 
                 manager = new DeviceManager(vscode.context, mockGlobalStateManager);
@@ -1903,7 +1889,11 @@ describe('DeviceManager', () => {
                             { host: '192.168.1.100', serialNumber: 'ABC', name: 'First Entry' },
                             { host: '192.168.1.100', serialNumber: 'XYZ', name: 'Second Entry' }
                         ]
-                    })
+                    }),
+                    deviceDiscovery: {
+                        enabled: false,
+                        includeNonDeveloperDevices: true
+                    }
                 });
 
                 manager = new DeviceManager(vscode.context, mockGlobalStateManager);
@@ -1926,7 +1916,11 @@ describe('DeviceManager', () => {
                         globalValue: [
                             { host: '192.168.1.100', name: 'My Roku' }
                         ]
-                    })
+                    }),
+                    deviceDiscovery: {
+                        enabled: false,
+                        includeNonDeveloperDevices: true
+                    }
                 });
 
                 manager = new DeviceManager(vscode.context, mockGlobalStateManager);
@@ -1942,7 +1936,11 @@ describe('DeviceManager', () => {
                         globalValue: [
                             { host: '192.168.1.100' } // no name
                         ]
-                    })
+                    }),
+                    deviceDiscovery: {
+                        enabled: false,
+                        includeNonDeveloperDevices: true
+                    }
                 });
 
                 await manager['loadConfiguredDevices']();
@@ -2418,8 +2416,8 @@ describe('DeviceManager', () => {
     });
 
     describe('serial-based deduplication (DHCP IP change)', () => {
-        describe('processDiscoveredIp', () => {
-            it('removes old entry when same serial discovered at new IP', async () => {
+        describe('setDiscoveredDevice', () => {
+            it('removes old entry when same serial discovered at new IP', () => {
                 manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
                 // Device exists at old IP
@@ -2432,14 +2430,7 @@ describe('DeviceManager', () => {
                 addDevice(oldDevice);
 
                 // SSDP discovers same serial at new IP
-                sinon.stub(rokuDeploy, 'getDeviceInfo').resolves({
-                    'serial-number': 'ABC123',
-                    'device-id': 'ABC123',
-                    'default-device-name': 'Roku Express',
-                    'developer-enabled': 'true'
-                } as any);
-
-                await manager['processDiscoveredIp']('192.168.1.200', 'ABC123');
+                manager['setDiscoveredDevice']('192.168.1.200', 'ABC123', 'online');
 
                 // Should have exactly one device at new IP
                 expect(manager.getAllDevices().length).to.equal(1);
@@ -2447,7 +2438,7 @@ describe('DeviceManager', () => {
                 expect(manager.getAllDevices()[0].serialNumber).to.equal('ABC123');
             });
 
-            it('preserves configured properties when device changes IP', async () => {
+            it('preserves configured properties when device changes IP', () => {
                 manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
                 // Configured device exists at old IP
@@ -2463,16 +2454,9 @@ describe('DeviceManager', () => {
                 addDevice(oldDevice);
 
                 // SSDP discovers same serial at new IP
-                sinon.stub(rokuDeploy, 'getDeviceInfo').resolves({
-                    'serial-number': 'ABC123',
-                    'device-id': 'ABC123',
-                    'default-device-name': 'Roku Express',
-                    'developer-enabled': 'true'
-                } as any);
+                manager['setDiscoveredDevice']('192.168.1.200', 'ABC123', 'online');
 
-                await manager['processDiscoveredIp']('192.168.1.200', 'ABC123');
-
-                // Should preserve configured properties on new entry
+                // Should preserve configured properties (from configuredDevices array)
                 expect(manager.getAllDevices().length).to.equal(1);
                 expect(manager.getAllDevices()[0].ip).to.equal('192.168.1.200');
                 expect(manager.getAllDevices()[0].isConfigured).to.equal(true);
@@ -2480,7 +2464,7 @@ describe('DeviceManager', () => {
                 expect(manager.getAllDevices()[0].configuredPassword).to.equal('secret123');
             });
 
-            it('transfers lastUsedDeviceIp when device changes IP', async () => {
+            it('transfers lastUsedDeviceIp when device changes IP', () => {
                 manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
                 // Device exists at old IP and is the last used device
@@ -2494,14 +2478,7 @@ describe('DeviceManager', () => {
                 manager.setLastUsedDeviceIp('192.168.1.100');
 
                 // SSDP discovers same serial at new IP
-                sinon.stub(rokuDeploy, 'getDeviceInfo').resolves({
-                    'serial-number': 'ABC123',
-                    'device-id': 'ABC123',
-                    'default-device-name': 'Roku Express',
-                    'developer-enabled': 'true'
-                } as any);
-
-                await manager['processDiscoveredIp']('192.168.1.200', 'ABC123');
+                manager['setDiscoveredDevice']('192.168.1.200', 'ABC123', 'online');
 
                 // lastUsedDeviceIp should transfer to new IP
                 expect(manager.getLastUsedDeviceIp()).to.equal('192.168.1.200');
@@ -2662,7 +2639,7 @@ describe('DeviceManager', () => {
                 expect(manager.getAllDevices()[0].configuredPassword).to.equal('secret');
             });
 
-            it('preserves isConfigured when configured device gets discovered at new IP', async () => {
+            it('preserves isConfigured when configured device gets discovered at new IP', () => {
                 manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
                 // Configured-only device at old IP (not yet discovered on network)
@@ -2678,14 +2655,7 @@ describe('DeviceManager', () => {
                 addDevice(oldDevice);
 
                 // SSDP discovers same serial at new IP
-                sinon.stub(rokuDeploy, 'getDeviceInfo').resolves({
-                    'serial-number': 'ABC123',
-                    'device-id': 'ABC123',
-                    'default-device-name': 'Roku Express',
-                    'developer-enabled': 'true'
-                } as any);
-
-                await manager['processDiscoveredIp']('192.168.1.200', 'ABC123');
+                manager['setDiscoveredDevice']('192.168.1.200', 'ABC123', 'online');
 
                 // Should have one device with BOTH isDiscovered and isConfigured
                 expect(manager.getAllDevices().length).to.equal(1);
@@ -2698,7 +2668,7 @@ describe('DeviceManager', () => {
         });
 
         describe('edge cases', () => {
-            it('does not dedupe when serial is undefined', async () => {
+            it('does not dedupe when serial is undefined', () => {
                 manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
                 // Device without serial at old IP
@@ -2710,21 +2680,14 @@ describe('DeviceManager', () => {
                 });
                 addDevice(oldDevice);
 
-                // Discover device at new IP, also without serial in response
-                sinon.stub(rokuDeploy, 'getDeviceInfo').resolves({
-                    'device-id': 'some-id',
-                    'default-device-name': 'Roku Express',
-                    'developer-enabled': 'true'
-                    // No serial-number field
-                } as any);
-
-                await manager['processDiscoveredIp']('192.168.1.200');
+                // Discover device at new IP, also without serial
+                manager['setDiscoveredDevice']('192.168.1.200', undefined, 'online');
 
                 // Should have two devices (no deduplication without serial)
                 expect(manager.getAllDevices().length).to.equal(2);
             });
 
-            it('does not remove device at same IP (not a duplicate)', async () => {
+            it('does not remove device at same IP (not a duplicate)', () => {
                 manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
                 // Device exists
@@ -2732,19 +2695,12 @@ describe('DeviceManager', () => {
                     serialNumber: 'ABC123',
                     ip: '192.168.1.100',
                     deviceState: 'pending',
-                    isDiscovered: false
+                    isDiscovered: true
                 });
                 addDevice(device);
 
                 // Re-discover at same IP (normal refresh scenario)
-                sinon.stub(rokuDeploy, 'getDeviceInfo').resolves({
-                    'serial-number': 'ABC123',
-                    'device-id': 'ABC123',
-                    'default-device-name': 'Roku Express',
-                    'developer-enabled': 'true'
-                } as any);
-
-                await manager['processDiscoveredIp']('192.168.1.100', 'ABC123');
+                manager['setDiscoveredDevice']('192.168.1.100', 'ABC123', 'online');
 
                 // Should still have exactly one device (merged, not duplicated)
                 expect(manager.getAllDevices().length).to.equal(1);
@@ -2761,7 +2717,8 @@ describe('DeviceManager', () => {
                 inspect: () => ({ workspaceValue: [], globalValue: [] }),
                 deviceDiscovery: {
                     enabled: false,
-                    showInfoMessages: false
+                    showInfoMessages: false,
+                    includeNonDeveloperDevices: true
                 },
                 defaultDevicePassword: defaultDevicePassword
             } as any);

--- a/src/deviceDiscovery/DeviceManager.spec.ts
+++ b/src/deviceDiscovery/DeviceManager.spec.ts
@@ -2337,6 +2337,76 @@ describe('DeviceManager', () => {
             });
         });
 
+        describe('cross-state preservation', () => {
+            it('keeps discovered IP when config has stale IP for same serial', () => {
+                manager = new DeviceManager(vscode.context, mockGlobalStateManager);
+
+                // Device discovered at IP1 (real network location)
+                const discoveredDevice = createMockDevice({
+                    serialNumber: 'ABC123',
+                    ip: '192.168.1.100',
+                    deviceState: 'online',
+                    isDiscovered: true,
+                    isConfigured: false
+                });
+                manager['devices'].push(discoveredDevice);
+
+                // Config loads with same serial at different IP (stale config)
+                // This simulates loadConfiguredDevices calling setDevice
+                manager['setDevice']({
+                    ip: '192.168.1.200', // stale IP from config
+                    serialNumber: 'ABC123',
+                    deviceState: 'pending',
+                    isConfigured: true,
+                    isDiscovered: false, // config op, not discovery
+                    configuredName: 'My Configured Roku',
+                    configuredPassword: 'secret'
+                });
+
+                // Should have ONE device at the DISCOVERED IP (not the configured IP)
+                expect(manager['devices'].length).to.equal(1);
+                expect(manager['devices'][0].ip).to.equal('192.168.1.100'); // discovered IP preserved
+                expect(manager['devices'][0].isDiscovered).to.equal(true);
+                expect(manager['devices'][0].isConfigured).to.equal(true);
+                expect(manager['devices'][0].configuredName).to.equal('My Configured Roku');
+                expect(manager['devices'][0].configuredPassword).to.equal('secret');
+            });
+
+            it('preserves isConfigured when configured device gets discovered at new IP', async () => {
+                manager = new DeviceManager(vscode.context, mockGlobalStateManager);
+
+                // Configured-only device at old IP (not yet discovered on network)
+                const oldDevice = createMockDevice({
+                    serialNumber: 'ABC123',
+                    ip: '192.168.1.100',
+                    deviceState: 'offline',
+                    isDiscovered: false,
+                    isConfigured: true,
+                    configuredName: 'Living Room Roku',
+                    configuredPassword: 'secret'
+                });
+                manager['devices'].push(oldDevice);
+
+                // SSDP discovers same serial at new IP
+                sinon.stub(rokuDeploy, 'getDeviceInfo').resolves({
+                    'serial-number': 'ABC123',
+                    'device-id': 'ABC123',
+                    'default-device-name': 'Roku Express',
+                    'developer-enabled': 'true'
+                } as any);
+
+                await manager['processDiscoveredIp']('192.168.1.200', 'ABC123');
+
+                // Should have one device with BOTH isDiscovered and isConfigured
+                expect(manager['devices'].length).to.equal(1);
+                expect(manager['devices'][0].ip).to.equal('192.168.1.200');
+                expect(manager['devices'][0].isDiscovered).to.equal(true);
+                expect(manager['devices'][0].isConfigured).to.equal(true);
+                expect(manager['devices'][0].configuredName).to.equal('Living Room Roku');
+                expect(manager['devices'][0].configuredPassword).to.equal('secret');
+            });
+        });
+
         describe('edge cases', () => {
             it('does not dedupe when serial is undefined', async () => {
                 manager = new DeviceManager(vscode.context, mockGlobalStateManager);

--- a/src/deviceDiscovery/DeviceManager.spec.ts
+++ b/src/deviceDiscovery/DeviceManager.spec.ts
@@ -49,10 +49,49 @@ describe('DeviceManager', () => {
             serialNumber: serialNumber ?? undefined,
             key: key,
             deviceState: 'online',
+            deviceInfo: {},
             isConfigured: false, // Default to discovered-only
             isDiscovered: true, // Default to discovered
             ...deviceOverrides
         } as RokuDevice;
+    }
+
+    /**
+     * Add a discovered device to the manager's discoveredDevices array
+     */
+    function addDiscoveredDevice(device: RokuDevice): void {
+        manager['discoveredDevices'].push({
+            ip: device.ip,
+            serialNumber: device.serialNumber,
+            deviceState: device.deviceState === 'offline' ? 'pending' : (device.deviceState as 'pending' | 'online')
+        });
+    }
+
+    /**
+     * Add a configured device to the manager's configuredDevices array
+     */
+    function addConfiguredDevice(device: RokuDevice): void {
+        manager['configuredDevices'].push({
+            host: device.ip,
+            resolvedIp: device.ip,
+            name: device.configuredName,
+            password: device.configuredPassword,
+            serialNumber: device.serialNumber,
+            deviceState: device.deviceState,
+            configuredIn: device.configuredIn
+        });
+    }
+
+    /**
+     * Add a device to the appropriate array(s) based on its isConfigured/isDiscovered flags
+     */
+    function addDevice(device: RokuDevice): void {
+        if (device.isConfigured) {
+            addConfiguredDevice(device);
+        }
+        if (device.isDiscovered) {
+            addDiscoveredDevice(device);
+        }
     }
 
     beforeEach(() => {
@@ -221,9 +260,9 @@ describe('DeviceManager', () => {
             });
 
             // Add devices in wrong order
-            manager['devices'].push(tv);
-            manager['devices'].push(box);
-            manager['devices'].push(stick);
+            addDevice(tv);
+            addDevice(box);
+            addDevice(stick);
 
             const devices = manager.getAllDevices();
 
@@ -251,9 +290,9 @@ describe('DeviceManager', () => {
                 deviceInfo: { 'default-device-name': 'Roku C', 'is-tv': 'false', 'is-stick': 'false' }
             });
 
-            manager['devices'].push(boxB);
-            manager['devices'].push(boxC);
-            manager['devices'].push(boxA);
+            addDevice(boxB);
+            addDevice(boxC);
+            addDevice(boxA);
 
             const devices = manager.getAllDevices();
 
@@ -316,7 +355,8 @@ describe('DeviceManager', () => {
 
             const device1 = createMockDevice({ serialNumber: 'device-1', ip: '192.168.1.101' });
             const device2 = createMockDevice({ serialNumber: 'device-2', ip: '192.168.1.102' });
-            (manager as any).devices = [device1, device2];
+            addDevice(device1);
+            addDevice(device2);
 
             const resolveDeviceSpy = sinon.stub(manager as any, 'resolveDevice').returns(Promise.resolve(true) as any);
 
@@ -330,7 +370,8 @@ describe('DeviceManager', () => {
 
             const device1 = createMockDevice({ serialNumber: 'device-1', ip: '192.168.1.101' });
             const device2 = createMockDevice({ serialNumber: 'device-2', ip: '192.168.1.102' });
-            (manager as any).devices = [device1, device2];
+            addDevice(device1);
+            addDevice(device2);
 
             // Mark device1 as recently checked (not stale)
             (manager as any).lastHealthCheckTime.set('192.168.1.101', Date.now());
@@ -348,11 +389,12 @@ describe('DeviceManager', () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
             const device = createMockDevice();
-            (manager as any).devices = [device];
+            addDevice(device);
 
             let stateWhenResolveCalled: string;
-            sinon.stub(manager as any, 'resolveDevice').callsFake((d: RokuDevice) => {
-                stateWhenResolveCalled = d.deviceState;
+            sinon.stub(manager as any, 'resolveDevice').callsFake(() => {
+                // Check the state from getAllDevices() during the health check
+                stateWhenResolveCalled = manager.getAllDevices()[0].deviceState;
                 return Promise.resolve(true);
             });
 
@@ -365,7 +407,7 @@ describe('DeviceManager', () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
             const device = createMockDevice();
-            (manager as any).devices = [device];
+            addDevice(device);
 
             // Mark device as recently checked
             (manager as any).lastHealthCheckTime.set(device.ip, Date.now());
@@ -532,7 +574,9 @@ describe('DeviceManager', () => {
                 const devicesChangedSpy = sinon.spy();
                 manager.on('devices-changed', devicesChangedSpy);
 
-                manager['setDevice'](createMockDevice());
+                // setDiscoveredDevice + emitDevicesChanged is the pattern used in real code
+                manager['setDiscoveredDevice']('192.168.1.100', 'serial-123', 'online');
+                manager['emitDevicesChanged']();
 
                 // First call after throttle window emits immediately
                 expect(devicesChangedSpy.calledOnce).to.be.true;
@@ -548,7 +592,7 @@ describe('DeviceManager', () => {
 
                 // Add a device first
                 const device = createMockDevice();
-                manager['devices'].push(device);
+                addDevice(device);
 
                 // Wait for initial throttle window from constructor's loadLastSeenDevices
                 clock.tick(400);
@@ -577,14 +621,17 @@ describe('DeviceManager', () => {
                 manager.on('devices-changed', devicesChangedSpy);
 
                 // First call emits immediately
-                manager['setDevice'](createMockDevice({ serialNumber: 'device-1' }));
+                manager['setDiscoveredDevice']('192.168.1.101', 'device-1', 'online');
+                manager['emitDevicesChanged']();
                 expect(devicesChangedSpy.calledOnce).to.be.true;
 
                 // Subsequent calls within throttle window are queued
                 clock.tick(10);
-                manager['setDevice'](createMockDevice({ serialNumber: 'device-2' }));
+                manager['setDiscoveredDevice']('192.168.1.102', 'device-2', 'online');
+                manager['emitDevicesChanged']();
                 clock.tick(10);
-                manager['setDevice'](createMockDevice({ serialNumber: 'device-3' }));
+                manager['setDiscoveredDevice']('192.168.1.103', 'device-3', 'online');
+                manager['emitDevicesChanged']();
 
                 // Still just one emit (subsequent calls queued)
                 expect(devicesChangedSpy.calledOnce).to.be.true;
@@ -604,7 +651,7 @@ describe('DeviceManager', () => {
             (vscode.window as any).state = { focused: true };
 
             const device = createMockDevice();
-            manager['devices'].push(device);
+            addDevice(device);
 
             // Stub rokuDeploy.getDeviceInfo to delay so we can check pending state
             let resolveHealth: (value: any) => void;
@@ -616,7 +663,7 @@ describe('DeviceManager', () => {
             const checkPromise = manager.checkDeviceHealth(device, true);
 
             // Device should be pending during check
-            expect(manager['devices'][0].deviceState).to.equal('pending');
+            expect(manager.getAllDevices()[0].deviceState).to.equal('pending');
 
             // Resolve with mock deviceInfo
             resolveHealth({
@@ -627,7 +674,7 @@ describe('DeviceManager', () => {
             await checkPromise;
 
             // Device should be online after successful check
-            expect(manager['devices'][0].deviceState).to.equal('online');
+            expect(manager.getAllDevices()[0].deviceState).to.equal('online');
         });
 
         it('removes device when health check fails', async () => {
@@ -635,21 +682,21 @@ describe('DeviceManager', () => {
             (vscode.window as any).state = { focused: true };
 
             const device = createMockDevice();
-            manager['devices'].push(device);
+            addDevice(device);
 
             sinon.stub(rokuDeploy, 'getDeviceInfo').rejects(new Error('Device not responding'));
 
             const result = await manager.checkDeviceHealth(device, true);
 
             expect(result).to.be.false;
-            expect(manager['devices'].length).to.equal(0);
+            expect(manager.getAllDevices().length).to.equal(0);
         });
 
         it('returns true when device is healthy', async () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
             const device = createMockDevice({ serialNumber: 'device-123' });
-            manager['devices'].push(device);
+            addDevice(device);
 
             sinon.stub(rokuDeploy, 'getDeviceInfo').resolves({
                 'device-id': 'device-123',
@@ -667,7 +714,7 @@ describe('DeviceManager', () => {
             (vscode.window as any).state = { focused: true };
 
             const device = createMockDevice({ serialNumber: 'device-123' });
-            manager['devices'].push(device);
+            addDevice(device);
 
             // Stub refresh to prevent cascade of health checks
             sinon.stub(manager, 'refresh');
@@ -701,16 +748,16 @@ describe('DeviceManager', () => {
             await fastResult;
 
             // Device should be online (fast check succeeded)
-            expect(manager['devices'].length).to.equal(1);
-            expect(manager['devices'][0].deviceState).to.equal('online');
+            expect(manager.getAllDevices().length).to.equal(1);
+            expect(manager.getAllDevices()[0].deviceState).to.equal('online');
 
             // Slow check completes later with unhealthy result
             rejectSlowCheck(new Error('Device not responding'));
             await slowResult;
 
             // Device should STILL be online - slow check result was ignored (stale)
-            expect(manager['devices'].length).to.equal(1);
-            expect(manager['devices'][0].deviceState).to.equal('online');
+            expect(manager.getAllDevices().length).to.equal(1);
+            expect(manager.getAllDevices()[0].deviceState).to.equal('online');
         });
 
         it('tracks sequence numbers independently per device', async () => {
@@ -719,7 +766,8 @@ describe('DeviceManager', () => {
 
             const device1 = createMockDevice({ serialNumber: 'device-1', ip: '192.168.1.101' });
             const device2 = createMockDevice({ serialNumber: 'device-2', ip: '192.168.1.102' });
-            manager['devices'].push(device1, device2);
+            addDevice(device1);
+            addDevice(device2);
 
             // Stub refresh to prevent cascade of health checks
             sinon.stub(manager, 'refresh');
@@ -758,9 +806,9 @@ describe('DeviceManager', () => {
             await result1;
 
             // Both devices should be online - sequence numbers are independent
-            expect(manager['devices'].length).to.equal(2);
-            expect(manager['devices'].find(d => d.ip === device1.ip)?.deviceState).to.equal('online');
-            expect(manager['devices'].find(d => d.ip === device2.ip)?.deviceState).to.equal('online');
+            expect(manager.getAllDevices().length).to.equal(2);
+            expect(manager.getAllDevices().find(d => d.ip === device1.ip)?.deviceState).to.equal('online');
+            expect(manager.getAllDevices().find(d => d.ip === device2.ip)?.deviceState).to.equal('online');
         });
     });
 
@@ -772,7 +820,7 @@ describe('DeviceManager', () => {
                 (vscode.window as any).state = { focused: true };
 
                 const device = createMockDevice();
-                manager['devices'].push(device);
+                addDevice(device);
                 manager.setLastUsedDeviceIp(device.ip);
 
                 expect(manager.getLastUsedDeviceIp()).to.equal(device.ip);
@@ -793,7 +841,8 @@ describe('DeviceManager', () => {
 
                 const device1 = createMockDevice({ serialNumber: 'device-1', ip: '192.168.1.101' });
                 const device2 = createMockDevice({ serialNumber: 'device-2', ip: '192.168.1.102' });
-                manager['devices'].push(device1, device2);
+                addDevice(device1);
+            addDevice(device2);
                 manager.setLastUsedDeviceIp(device1.ip);
 
                 manager['removeDevice'](device2.ip);
@@ -811,7 +860,7 @@ describe('DeviceManager', () => {
                 (vscode.window as any).state = { focused: true };
 
                 const device = createMockDevice();
-                manager['devices'].push(device);
+                addDevice(device);
 
                 manager['removeDevice'](device.ip);
 
@@ -828,7 +877,7 @@ describe('DeviceManager', () => {
 
             // Add a configured device (configured devices are preserved)
             const existingDevice = createMockDevice({ serialNumber: 'existing', ip: '192.168.1.150', isConfigured: true });
-            manager['devices'].push(existingDevice);
+            addDevice(existingDevice);
 
             // Setup cache to return a different device
             mockGlobalStateManager.getLastSeenDevices.returns(['cached-device']);
@@ -853,9 +902,9 @@ describe('DeviceManager', () => {
             manager['loadLastSeenDevices']();
 
             // Should have both devices (merges instead of clearing)
-            expect(manager['devices'].length).to.equal(2);
-            expect(manager['devices'].some(d => d.serialNumber === 'existing')).to.be.true;
-            expect(manager['devices'].some(d => d.serialNumber === 'cached-device')).to.be.true;
+            expect(manager.getAllDevices().length).to.equal(2);
+            expect(manager.getAllDevices().some(d => d.serialNumber === 'existing')).to.be.true;
+            expect(manager.getAllDevices().some(d => d.serialNumber === 'cached-device')).to.be.true;
         });
 
         it('loads cached devices as pending state', () => {
@@ -875,7 +924,7 @@ describe('DeviceManager', () => {
 
             manager['loadLastSeenDevices']();
 
-            expect(manager['devices'][0].deviceState).to.equal('pending');
+            expect(manager.getAllDevices()[0].deviceState).to.equal('pending');
         });
 
         it('removes stale entries when cache returns undefined', () => {
@@ -886,7 +935,7 @@ describe('DeviceManager', () => {
 
             manager['loadLastSeenDevices']();
 
-            expect(manager['devices'].length).to.equal(0);
+            expect(manager.getAllDevices().length).to.equal(0);
             expect(mockGlobalStateManager.removeLastSeenDevice.calledWith('test-network-hash', 'stale-device')).to.be.true;
         });
     });
@@ -896,7 +945,7 @@ describe('DeviceManager', () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
             const device = createMockDevice({ serialNumber: 'target-device' });
-            manager['devices'].push(device);
+            addDevice(device);
 
             // Mock the cache to return deviceInfo
             mockGlobalStateManager.getCachedDevice.withArgs('target-device').returns({
@@ -943,10 +992,10 @@ describe('DeviceManager', () => {
 
             await manager['processDiscoveredIp']('192.168.1.100');
 
-            expect(manager['devices'].length).to.equal(1);
-            expect(manager['devices'][0].ip).to.equal('192.168.1.100');
-            expect(manager['devices'][0].serialNumber).to.equal('YN00AB123456');
-            expect(manager['devices'][0].deviceState).to.equal('online');
+            expect(manager.getAllDevices().length).to.equal(1);
+            expect(manager.getAllDevices()[0].ip).to.equal('192.168.1.100');
+            expect(manager.getAllDevices()[0].serialNumber).to.equal('YN00AB123456');
+            expect(manager.getAllDevices()[0].deviceState).to.equal('online');
         });
 
         it('uses serial from deviceInfo (not SSDP hint)', async () => {
@@ -957,9 +1006,9 @@ describe('DeviceManager', () => {
             // SSDP provides a hint, but deviceInfo is the source of truth
             await manager['processDiscoveredIp']('192.168.1.100', 'SSDP-SERIAL-123');
 
-            expect(manager['devices'].length).to.equal(1);
+            expect(manager.getAllDevices().length).to.equal(1);
             // Should use deviceInfo's serial, not SSDP hint
-            expect(manager['devices'][0].serialNumber).to.equal('YN00AB123456');
+            expect(manager.getAllDevices()[0].serialNumber).to.equal('YN00AB123456');
         });
 
         it('falls back to deviceInfo serial when SSDP serial not provided', async () => {
@@ -969,7 +1018,7 @@ describe('DeviceManager', () => {
 
             await manager['processDiscoveredIp']('192.168.1.100');
 
-            expect(manager['devices'][0].serialNumber).to.equal('YN00AB123456');
+            expect(manager.getAllDevices()[0].serialNumber).to.equal('YN00AB123456');
         });
 
         it('filters non-developer devices by default', async () => {
@@ -982,7 +1031,7 @@ describe('DeviceManager', () => {
 
             await manager['processDiscoveredIp']('192.168.1.100');
 
-            expect(manager['devices'].length).to.equal(0);
+            expect(manager.getAllDevices().length).to.equal(0);
         });
 
         it('includes non-developer devices when setting enabled', async () => {
@@ -1004,7 +1053,7 @@ describe('DeviceManager', () => {
 
             await manager['processDiscoveredIp']('192.168.1.100');
 
-            expect(manager['devices'].length).to.equal(1);
+            expect(manager.getAllDevices().length).to.equal(1);
         });
 
         it('handles string "true" for developer-enabled', async () => {
@@ -1017,7 +1066,7 @@ describe('DeviceManager', () => {
 
             await manager['processDiscoveredIp']('192.168.1.100');
 
-            expect(manager['devices'].length).to.equal(1);
+            expect(manager.getAllDevices().length).to.equal(1);
         });
 
         it('handles network errors gracefully', async () => {
@@ -1028,7 +1077,7 @@ describe('DeviceManager', () => {
             // Should not throw
             await manager['processDiscoveredIp']('192.168.1.100');
 
-            expect(manager['devices'].length).to.equal(0);
+            expect(manager.getAllDevices().length).to.equal(0);
         });
 
         it('processDiscoveredIp does not show notifications', async () => {
@@ -1287,65 +1336,81 @@ describe('DeviceManager', () => {
     });
 
     describe('configured devices', () => {
-        describe('setDevice', () => {
-            it('preserves isConfigured when merging by serialNumber', () => {
+        describe('merging configured and discovered', () => {
+            it('merges configured and discovered entries by serialNumber', () => {
                 manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
                 // Add configured device
-                const configuredDevice = createMockDevice({
+                addConfiguredDevice(createMockDevice({
                     serialNumber: 'device-123',
                     ip: '192.168.1.100',
                     isConfigured: true,
                     configuredName: 'My Roku'
-                });
-                manager['devices'].push(configuredDevice);
+                }));
 
-                // Update same device without isConfigured (simulating discovery - property omitted, not undefined)
-                const { isConfigured, configuredName, configuredPassword, configuredIn, ...discoveryUpdate } = createMockDevice({ serialNumber: 'device-123', ip: '192.168.1.100' });
-                manager['setDevice'](discoveryUpdate);
+                // Add discovered device with same serial (simulating discovery)
+                addDiscoveredDevice(createMockDevice({
+                    serialNumber: 'device-123',
+                    ip: '192.168.1.100',
+                    deviceState: 'online'
+                }));
 
-                expect(manager['devices'].length).to.equal(1);
-                expect(manager['devices'][0].isConfigured).to.equal(true);
-                expect(manager['devices'][0].configuredName).to.equal('My Roku');
+                // Should merge into one device with both flags
+                expect(manager.getAllDevices().length).to.equal(1);
+                expect(manager.getAllDevices()[0].isConfigured).to.equal(true);
+                expect(manager.getAllDevices()[0].isDiscovered).to.equal(true);
+                expect(manager.getAllDevices()[0].configuredName).to.equal('My Roku');
             });
 
-            it('preserves isConfigured when merging by IP', () => {
+            it('merges configured and discovered entries by IP when no serial match', () => {
                 manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
-                // Add configured device with host as serialNumber (before resolution)
-                const configuredDevice = createMockDevice({
-                    serialNumber: '192.168.1.100', // Using IP as serialNumber before resolution
-                    ip: '192.168.1.100',
-                    isConfigured: true,
-                    configuredName: 'My Roku'
+                // Add configured device (no serial yet - not resolved)
+                manager['configuredDevices'].push({
+                    host: '192.168.1.100',
+                    resolvedIp: '192.168.1.100',
+                    name: 'My Roku',
+                    deviceState: 'pending',
+                    serialNumber: undefined
                 });
-                manager['devices'].push(configuredDevice);
 
-                // Update with real serialNumber (simulating resolution - property omitted, not undefined)
-                const { isConfigured, configuredName, configuredPassword, configuredIn, ...resolutionUpdate } = createMockDevice({ serialNumber: 'real-serial-number', ip: '192.168.1.100' });
-                manager['setDevice'](resolutionUpdate);
+                // Add discovered device at same IP with serial
+                addDiscoveredDevice(createMockDevice({
+                    serialNumber: 'real-serial-number',
+                    ip: '192.168.1.100',
+                    deviceState: 'online'
+                }));
 
-                expect(manager['devices'].length).to.equal(1);
-                expect(manager['devices'][0].serialNumber).to.equal('real-serial-number');
-                expect(manager['devices'][0].isConfigured).to.equal(true);
-                expect(manager['devices'][0].configuredName).to.equal('My Roku');
+                // Should merge into one device
+                expect(manager.getAllDevices().length).to.equal(1);
+                expect(manager.getAllDevices()[0].serialNumber).to.equal('real-serial-number');
+                expect(manager.getAllDevices()[0].isConfigured).to.equal(true);
+                expect(manager.getAllDevices()[0].isDiscovered).to.equal(true);
+                expect(manager.getAllDevices()[0].configuredName).to.equal('My Roku');
             });
 
             it('preserves configuredName separately from deviceInfo', () => {
                 manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
-                manager['setDevice'](createMockDevice({
+                // Set up cache with deviceInfo
+                mockGlobalStateManager.getCachedDevice.withArgs('device-123').returns({
                     serialNumber: 'device-123',
+                    deviceInfo: { 'user-device-name': 'Discovered Name' },
+                    createdAt: Date.now()
+                });
+
+                // Add configured device with configuredName
+                addConfiguredDevice(createMockDevice({
+                    serialNumber: 'device-123',
+                    ip: '192.168.1.100',
                     isConfigured: true,
-                    configuredName: 'My Custom Name',
-                    deviceInfo: { 'user-device-name': 'Discovered Name' }
+                    configuredName: 'My Custom Name'
                 }));
 
-                // deviceInfo should be cached - UI layer handles the fallback to configuredName
-                const serial = manager['devices'][0].serialNumber;
-                const cachedDevice = mockGlobalStateManager.getCachedDevice(serial);
-                expect(cachedDevice.deviceInfo['user-device-name']).to.equal('Discovered Name');
-                expect(manager['devices'][0].configuredName).to.equal('My Custom Name');
+                // configuredName should be separate from cached deviceInfo
+                const device = manager.getAllDevices()[0];
+                expect(device.deviceInfo['user-device-name']).to.equal('Discovered Name');
+                expect(device.configuredName).to.equal('My Custom Name');
             });
         });
 
@@ -1359,7 +1424,7 @@ describe('DeviceManager', () => {
                     serialNumber: 'device-123',
                     isConfigured: true
                 });
-                manager['devices'].push(device);
+                addDevice(device);
 
                 // Simulate cache exists
                 mockGlobalStateManager.getCachedDevice.returns({
@@ -1374,8 +1439,8 @@ describe('DeviceManager', () => {
                 const result = await manager.checkDeviceHealth(device, true);
 
                 expect(result).to.be.false;
-                expect(manager['devices'].length).to.equal(1);
-                expect(manager['devices'][0].deviceState).to.equal('offline');
+                expect(manager.getAllDevices().length).to.equal(1);
+                expect(manager.getAllDevices()[0].deviceState).to.equal('offline');
             });
 
             it('marks configured device as offline when health check fails and no cache exists', async () => {
@@ -1387,7 +1452,7 @@ describe('DeviceManager', () => {
                     serialNumber: 'device-123',
                     isConfigured: true
                 });
-                manager['devices'].push(device);
+                addDevice(device);
 
                 // Simulate no cache - view layer uses hasDeviceCache() to show warning icon
                 mockGlobalStateManager.getCachedDevice.returns(undefined);
@@ -1398,9 +1463,9 @@ describe('DeviceManager', () => {
                 const result = await manager.checkDeviceHealth(device, true);
 
                 expect(result).to.be.false;
-                expect(manager['devices'].length).to.equal(1);
+                expect(manager.getAllDevices().length).to.equal(1);
                 // State is always 'offline' - icon logic uses cache check to distinguish
-                expect(manager['devices'][0].deviceState).to.equal('offline');
+                expect(manager.getAllDevices()[0].deviceState).to.equal('offline');
                 // hasDeviceCache() would return false, triggering warning icon in view
                 expect(manager.hasDeviceCache('device-123')).to.equal(false);
             });
@@ -1414,7 +1479,7 @@ describe('DeviceManager', () => {
                     serialNumber: 'device-123',
                     isConfigured: false
                 });
-                manager['devices'].push(device);
+                addDevice(device);
 
                 // Stub to simulate network failure
                 sinon.stub(rokuDeploy, 'getDeviceInfo').rejects(new Error('Device not responding'));
@@ -1422,7 +1487,7 @@ describe('DeviceManager', () => {
                 const result = await manager.checkDeviceHealth(device, true);
 
                 expect(result).to.be.false;
-                expect(manager['devices'].length).to.equal(0);
+                expect(manager.getAllDevices().length).to.equal(0);
             });
         });
 
@@ -1438,7 +1503,7 @@ describe('DeviceManager', () => {
 
                 await manager['processDiscoveredIp']('192.168.1.100', 'ABC123');
 
-                const device = manager['devices'].find(d => d.ip === '192.168.1.100');
+                const device = manager.getAllDevices().find(d => d.ip === '192.168.1.100');
                 expect(device?.isDiscovered).to.be.true;
             });
 
@@ -1453,16 +1518,16 @@ describe('DeviceManager', () => {
                     isConfigured: true,
                     isDiscovered: true
                 });
-                manager['devices'].push(device);
+                addDevice(device);
 
                 sinon.stub(rokuDeploy, 'getDeviceInfo').rejects(new Error('Offline'));
 
                 await manager.checkDeviceHealth(device, true);
 
                 // Device kept (configured) but not discovered
-                expect(manager['devices'].length).to.equal(1);
-                expect(manager['devices'][0].isDiscovered).to.be.false;
-                expect(manager['devices'][0].deviceState).to.equal('offline');
+                expect(manager.getAllDevices().length).to.equal(1);
+                expect(manager.getAllDevices()[0].isDiscovered).to.be.false;
+                expect(manager.getAllDevices()[0].deviceState).to.equal('offline');
             });
 
             it('removes discovered-only device when health check fails', async () => {
@@ -1476,14 +1541,14 @@ describe('DeviceManager', () => {
                     isConfigured: false, // Not configured
                     isDiscovered: true // Only discovered
                 });
-                manager['devices'].push(device);
+                addDevice(device);
 
                 sinon.stub(rokuDeploy, 'getDeviceInfo').rejects(new Error('Offline'));
 
                 await manager.checkDeviceHealth(device, true);
 
                 // Device removed (not configured, not discovered)
-                expect(manager['devices'].length).to.equal(0);
+                expect(manager.getAllDevices().length).to.equal(0);
             });
         });
 
@@ -1492,7 +1557,7 @@ describe('DeviceManager', () => {
                 manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
                 // Add TV (priority 2) with Z name
-                manager['devices'].push(createMockDevice({
+                addDiscoveredDevice(createMockDevice({
                     serialNumber: 'tv-1',
                     ip: '192.168.1.101',
                     deviceInfo: {
@@ -1503,7 +1568,7 @@ describe('DeviceManager', () => {
                 }));
 
                 // Add stick (priority 0) with A name
-                manager['devices'].push(createMockDevice({
+                addDiscoveredDevice(createMockDevice({
                     serialNumber: 'stick-1',
                     ip: '192.168.1.102',
                     deviceInfo: {
@@ -1534,7 +1599,7 @@ describe('DeviceManager', () => {
                 manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
                 // Add configured device with real device info (was resolved from network)
-                manager['devices'].push(createMockDevice({
+                addDevice(createMockDevice({
                     serialNumber: 'real-serial-123',
                     ip: '192.168.1.100',
                     isConfigured: true,
@@ -1550,13 +1615,13 @@ describe('DeviceManager', () => {
                 await manager['loadConfiguredDevices']();
 
                 // Device should be kept as discovered-only
-                expect(manager['devices'].length).to.equal(1);
-                const serial = manager['devices'][0].serialNumber;
+                expect(manager.getAllDevices().length).to.equal(1);
+                const serial = manager.getAllDevices()[0].serialNumber;
                 expect(serial).to.equal('real-serial-123');
-                expect(manager['devices'][0].isConfigured).to.be.false;
-                expect(manager['devices'][0].isDiscovered).to.be.true; // NEW
-                expect(manager['devices'][0].configuredName).to.be.undefined;
-                expect(manager['devices'][0].configuredPassword).to.be.undefined;
+                expect(manager.getAllDevices()[0].isConfigured).to.be.false;
+                expect(manager.getAllDevices()[0].isDiscovered).to.be.true; // NEW
+                expect(manager.getAllDevices()[0].configuredName).to.be.undefined;
+                expect(manager.getAllDevices()[0].configuredPassword).to.be.undefined;
             });
 
             it('removes unresolved configured device when removed from config', async () => {
@@ -1571,7 +1636,7 @@ describe('DeviceManager', () => {
                 manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
                 // Add configured device that was never resolved (no serial)
-                manager['devices'].push(createMockDevice({
+                addConfiguredDevice(createMockDevice({
                     serialNumber: null, // CHANGED: null instead of IP
                     ip: '192.168.1.100',
                     isConfigured: true,
@@ -1585,7 +1650,7 @@ describe('DeviceManager', () => {
                 await manager['loadConfiguredDevices']();
 
                 // Device should be completely removed
-                expect(manager['devices'].length).to.equal(0);
+                expect(manager.getAllDevices().length).to.equal(0);
             });
 
             it('merges config entries with same IP but different serials (last wins)', async () => {
@@ -1606,10 +1671,10 @@ describe('DeviceManager', () => {
                 await manager['loadConfiguredDevices']();
 
                 // Should have exactly one device (merged by IP, second entry wins)
-                expect(manager['devices'].length).to.equal(1);
-                expect(manager['devices'][0].ip).to.equal('192.168.1.100');
-                expect(manager['devices'][0].configuredName).to.equal('Second Entry');
-                expect(manager['devices'][0].isConfigured).to.equal(true);
+                expect(manager.getAllDevices().length).to.equal(1);
+                expect(manager.getAllDevices()[0].ip).to.equal('192.168.1.100');
+                expect(manager.getAllDevices()[0].configuredName).to.equal('Second Entry');
+                expect(manager.getAllDevices()[0].isConfigured).to.equal(true);
             });
 
             it('clears configuredName when name is removed from config', async () => {
@@ -1627,8 +1692,8 @@ describe('DeviceManager', () => {
                 manager = new DeviceManager(vscode.context, mockGlobalStateManager);
                 await manager['loadConfiguredDevices']();
 
-                expect(manager['devices'].length).to.equal(1);
-                expect(manager['devices'][0].configuredName).to.equal('My Roku');
+                expect(manager.getAllDevices().length).to.equal(1);
+                expect(manager.getAllDevices()[0].configuredName).to.equal('My Roku');
 
                 // Simulate config change: name is removed
                 configStub.returns({
@@ -1643,8 +1708,8 @@ describe('DeviceManager', () => {
                 await manager['loadConfiguredDevices']();
 
                 // Name should be cleared
-                expect(manager['devices'].length).to.equal(1);
-                expect(manager['devices'][0].configuredName).to.equal(undefined);
+                expect(manager.getAllDevices().length).to.equal(1);
+                expect(manager.getAllDevices()[0].configuredName).to.equal(undefined);
             });
         });
 
@@ -1653,14 +1718,14 @@ describe('DeviceManager', () => {
                 manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
                 // Add configured device
-                manager['devices'].push(createMockDevice({
+                addConfiguredDevice(createMockDevice({
                     serialNumber: 'configured-1',
                     ip: '192.168.1.101',
                     isConfigured: true
                 }));
 
                 // Add discovered device
-                manager['devices'].push(createMockDevice({
+                addDiscoveredDevice(createMockDevice({
                     serialNumber: 'discovered-1',
                     ip: '192.168.1.102'
                 }));
@@ -1668,10 +1733,10 @@ describe('DeviceManager', () => {
                 manager['loadLastSeenDevices']();
 
                 // Only configured device should remain
-                expect(manager['devices'].length).to.equal(1);
-                const serial = manager['devices'][0].serialNumber;
+                expect(manager.getAllDevices().length).to.equal(1);
+                const serial = manager.getAllDevices()[0].serialNumber;
                 expect(serial).to.equal('configured-1');
-                expect(manager['devices'][0].deviceState).to.equal('pending');
+                expect(manager.getAllDevices()[0].deviceState).to.equal('pending');
             });
         });
 
@@ -1686,7 +1751,7 @@ describe('DeviceManager', () => {
                     configuredName: 'My Roku',
                     deviceState: 'pending'
                 });
-                manager['devices'].push(device);
+                addDevice(device);
 
                 sinon.stub(rokuDeploy, 'getDeviceInfo').resolves({
                     'device-id': 'device-123',
@@ -1695,9 +1760,9 @@ describe('DeviceManager', () => {
 
                 await manager['resolveDevice'](device);
 
-                expect(manager['devices'][0].deviceState).to.equal('online');
-                expect(manager['devices'][0].isConfigured).to.equal(true);
-                expect(manager['devices'][0].configuredName).to.equal('My Roku');
+                expect(manager.getAllDevices()[0].deviceState).to.equal('online');
+                expect(manager.getAllDevices()[0].isConfigured).to.equal(true);
+                expect(manager.getAllDevices()[0].configuredName).to.equal('My Roku');
             });
         });
         describe('clearAllCache', () => {
@@ -1925,7 +1990,7 @@ describe('DeviceManager', () => {
                     ip: '192.168.1.100',
                     deviceInfo: { 'serial-number': 'ABC123' }
                 });
-                manager['devices'].push(device);
+                addDevice(device);
 
                 const result = manager.getDevice({ ip: '192.168.1.100' });
 
@@ -1935,13 +2000,11 @@ describe('DeviceManager', () => {
             it('uses IP-based key (i:...) when no serial exists', () => {
                 manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
-                // Create device without serial - manually add with IP-based key
-                manager['devices'].push({
+                // Create device without serial - manually add to discovered array
+                manager['discoveredDevices'].push({
                     ip: '192.168.1.100',
-                    key: 'i:192.168.1.100',
-                    deviceState: 'online',
-                    isConfigured: false,
-                    isDiscovered: true
+                    serialNumber: undefined,
+                    deviceState: 'online'
                 });
 
                 const result = manager.getDevice({ ip: '192.168.1.100' });
@@ -1957,7 +2020,7 @@ describe('DeviceManager', () => {
                     ip: '192.168.1.101',
                     deviceInfo: { 'serial-number': 'DEF456' }
                 });
-                manager['devices'].push(device);
+                addDevice(device);
 
                 const devices = manager.getAllDevices();
 
@@ -1974,7 +2037,7 @@ describe('DeviceManager', () => {
                     ip: '192.168.1.100',
                     deviceInfo: { 'serial-number': 'ABC123' }
                 });
-                manager['devices'].push(device);
+                addDevice(device);
 
                 const result = manager.getDevice('s:ABC123');
 
@@ -1991,7 +2054,7 @@ describe('DeviceManager', () => {
                     ip: '192.168.1.100',
                     deviceInfo: { 'serial-number': 'XYZ789' }
                 });
-                manager['devices'].push(device);
+                addDevice(device);
 
                 const result = manager.getDevice('i:192.168.1.100');
 
@@ -2009,7 +2072,7 @@ describe('DeviceManager', () => {
                     ip: '192.168.1.100',
                     deviceInfo: { 'serial-number': 'NEWSERIAL' }
                 });
-                manager['devices'].push(device);
+                addDevice(device);
 
                 // Old UI component might still have "i:192.168.1.100" key
                 const result = manager.getDevice('i:192.168.1.100');
@@ -2029,7 +2092,7 @@ describe('DeviceManager', () => {
                     serialNumber: 'ABC123',
                     ip: '192.168.1.100'
                 });
-                manager['devices'].push(device);
+                addDevice(device);
 
                 // Unprefixed strings should be rejected
                 const result = manager.getDevice('192.168.1.100');
@@ -2044,7 +2107,7 @@ describe('DeviceManager', () => {
                     serialNumber: 'ABC123',
                     ip: '192.168.1.100'
                 });
-                manager['devices'].push(device);
+                addDevice(device);
 
                 expect(manager.getDevice('s:')).to.be.undefined;
                 expect(manager.getDevice('i:')).to.be.undefined;
@@ -2065,7 +2128,7 @@ describe('DeviceManager', () => {
                     serialNumber: 'ABC123',
                     ip: '192.168.1.100'
                 });
-                manager['devices'].push(device);
+                addDevice(device);
 
                 const result = manager.getDevice('s:UNKNOWN');
 
@@ -2079,7 +2142,7 @@ describe('DeviceManager', () => {
                     serialNumber: 'ABC123',
                     ip: '192.168.1.100'
                 });
-                manager['devices'].push(device);
+                addDevice(device);
 
                 const result = manager.getDevice('i:192.168.1.999');
 
@@ -2092,30 +2155,22 @@ describe('DeviceManager', () => {
                 manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
                 // Start with device that has no serial
-                manager['devices'].push({
+                manager['discoveredDevices'].push({
                     ip: '192.168.1.100',
-                    key: 'i:192.168.1.100',
-                    deviceState: 'online',
-                    isConfigured: false,
-                    isDiscovered: true
+                    serialNumber: undefined,
+                    deviceState: 'online'
                 });
 
                 // Initially should have IP-based key
                 let result = manager.getDevice('i:192.168.1.100');
                 expect(result?.key).to.equal('i:192.168.1.100');
 
-                // Simulate device resolution - setDevice is called with serial
+                // Simulate device resolution - update discovered entry with serial
                 // (this is what resolveDevice does when it successfully fetches deviceInfo)
-                manager['setDevice']({
-                    ip: '192.168.1.100',
-                    serialNumber: 'NEWSERIAL',
-                    deviceState: 'online',
-                    isConfigured: false,
-                    isDiscovered: true
-                });
+                manager['setDiscoveredDevice']('192.168.1.100', 'NEWSERIAL', 'online');
 
                 // Device now has serial-based key
-                result = manager.getDevice('i:192.168.1.100');
+                result = manager.getDevice({ serialNumber: 'NEWSERIAL' });
                 expect(result?.key).to.equal('s:NEWSERIAL');
                 expect(result?.serialNumber).to.equal('NEWSERIAL');
             });
@@ -2134,7 +2189,7 @@ describe('DeviceManager', () => {
                     deviceState: 'online',
                     isDiscovered: true
                 });
-                manager['devices'].push(oldDevice);
+                addDevice(oldDevice);
 
                 // SSDP discovers same serial at new IP
                 sinon.stub(rokuDeploy, 'getDeviceInfo').resolves({
@@ -2147,9 +2202,9 @@ describe('DeviceManager', () => {
                 await manager['processDiscoveredIp']('192.168.1.200', 'ABC123');
 
                 // Should have exactly one device at new IP
-                expect(manager['devices'].length).to.equal(1);
-                expect(manager['devices'][0].ip).to.equal('192.168.1.200');
-                expect(manager['devices'][0].serialNumber).to.equal('ABC123');
+                expect(manager.getAllDevices().length).to.equal(1);
+                expect(manager.getAllDevices()[0].ip).to.equal('192.168.1.200');
+                expect(manager.getAllDevices()[0].serialNumber).to.equal('ABC123');
             });
 
             it('preserves configured properties when device changes IP', async () => {
@@ -2165,7 +2220,7 @@ describe('DeviceManager', () => {
                     configuredName: 'Living Room Roku',
                     configuredPassword: 'secret123'
                 });
-                manager['devices'].push(oldDevice);
+                addDevice(oldDevice);
 
                 // SSDP discovers same serial at new IP
                 sinon.stub(rokuDeploy, 'getDeviceInfo').resolves({
@@ -2178,11 +2233,11 @@ describe('DeviceManager', () => {
                 await manager['processDiscoveredIp']('192.168.1.200', 'ABC123');
 
                 // Should preserve configured properties on new entry
-                expect(manager['devices'].length).to.equal(1);
-                expect(manager['devices'][0].ip).to.equal('192.168.1.200');
-                expect(manager['devices'][0].isConfigured).to.equal(true);
-                expect(manager['devices'][0].configuredName).to.equal('Living Room Roku');
-                expect(manager['devices'][0].configuredPassword).to.equal('secret123');
+                expect(manager.getAllDevices().length).to.equal(1);
+                expect(manager.getAllDevices()[0].ip).to.equal('192.168.1.200');
+                expect(manager.getAllDevices()[0].isConfigured).to.equal(true);
+                expect(manager.getAllDevices()[0].configuredName).to.equal('Living Room Roku');
+                expect(manager.getAllDevices()[0].configuredPassword).to.equal('secret123');
             });
 
             it('transfers lastUsedDeviceIp when device changes IP', async () => {
@@ -2195,7 +2250,7 @@ describe('DeviceManager', () => {
                     deviceState: 'online',
                     isDiscovered: true
                 });
-                manager['devices'].push(oldDevice);
+                addDevice(oldDevice);
                 manager.setLastUsedDeviceIp('192.168.1.100');
 
                 // SSDP discovers same serial at new IP
@@ -2225,7 +2280,7 @@ describe('DeviceManager', () => {
                     deviceState: 'online',
                     isDiscovered: true
                 });
-                manager['devices'].push(oldDevice);
+                addDevice(oldDevice);
 
                 // New device at different IP (e.g., from config or cache)
                 const newDevice = createMockDevice({
@@ -2234,7 +2289,7 @@ describe('DeviceManager', () => {
                     deviceState: 'pending',
                     isDiscovered: false
                 });
-                manager['devices'].push(newDevice);
+                addDevice(newDevice);
 
                 // Resolve returns same serial as old device
                 sinon.stub(rokuDeploy, 'getDeviceInfo').resolves({
@@ -2247,9 +2302,9 @@ describe('DeviceManager', () => {
                 await manager['resolveDevice'](newDevice);
 
                 // Should have exactly one device at new IP
-                expect(manager['devices'].length).to.equal(1);
-                expect(manager['devices'][0].ip).to.equal('192.168.1.200');
-                expect(manager['devices'][0].serialNumber).to.equal('ABC123');
+                expect(manager.getAllDevices().length).to.equal(1);
+                expect(manager.getAllDevices()[0].ip).to.equal('192.168.1.200');
+                expect(manager.getAllDevices()[0].serialNumber).to.equal('ABC123');
             });
 
             it('preserves configured properties when resolving at new IP', async () => {
@@ -2266,7 +2321,7 @@ describe('DeviceManager', () => {
                     configuredName: 'My Roku',
                     configuredPassword: 'pass123'
                 });
-                manager['devices'].push(oldDevice);
+                addDevice(oldDevice);
 
                 // New device at different IP being resolved
                 const newDevice = createMockDevice({
@@ -2275,7 +2330,7 @@ describe('DeviceManager', () => {
                     deviceState: 'pending',
                     isDiscovered: false
                 });
-                manager['devices'].push(newDevice);
+                addDevice(newDevice);
 
                 // Resolve returns same serial as configured device
                 sinon.stub(rokuDeploy, 'getDeviceInfo').resolves({
@@ -2288,11 +2343,11 @@ describe('DeviceManager', () => {
                 await manager['resolveDevice'](newDevice);
 
                 // Should preserve configured properties
-                expect(manager['devices'].length).to.equal(1);
-                expect(manager['devices'][0].ip).to.equal('192.168.1.200');
-                expect(manager['devices'][0].isConfigured).to.equal(true);
-                expect(manager['devices'][0].configuredName).to.equal('My Roku');
-                expect(manager['devices'][0].configuredPassword).to.equal('pass123');
+                expect(manager.getAllDevices().length).to.equal(1);
+                expect(manager.getAllDevices()[0].ip).to.equal('192.168.1.200');
+                expect(manager.getAllDevices()[0].isConfigured).to.equal(true);
+                expect(manager.getAllDevices()[0].configuredName).to.equal('My Roku');
+                expect(manager.getAllDevices()[0].configuredPassword).to.equal('pass123');
             });
         });
 
@@ -2317,8 +2372,8 @@ describe('DeviceManager', () => {
                     isConfigured: true,
                     configuredName: 'New Location'
                 });
-                manager['devices'].push(device1);
-                manager['devices'].push(device2);
+                addDevice(device1);
+                addDevice(device2);
 
                 // Resolve the second device (at new IP)
                 sinon.stub(rokuDeploy, 'getDeviceInfo').resolves({
@@ -2331,9 +2386,9 @@ describe('DeviceManager', () => {
                 await manager['resolveDevice'](device2);
 
                 // Should have exactly one device - the one that was just resolved
-                expect(manager['devices'].length).to.equal(1);
-                expect(manager['devices'][0].ip).to.equal('192.168.1.200');
-                expect(manager['devices'][0].serialNumber).to.equal('ABC123');
+                expect(manager.getAllDevices().length).to.equal(1);
+                expect(manager.getAllDevices()[0].ip).to.equal('192.168.1.200');
+                expect(manager.getAllDevices()[0].serialNumber).to.equal('ABC123');
             });
         });
 
@@ -2342,34 +2397,29 @@ describe('DeviceManager', () => {
                 manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
                 // Device discovered at IP1 (real network location)
-                const discoveredDevice = createMockDevice({
+                addDiscoveredDevice(createMockDevice({
                     serialNumber: 'ABC123',
                     ip: '192.168.1.100',
-                    deviceState: 'online',
-                    isDiscovered: true,
-                    isConfigured: false
-                });
-                manager['devices'].push(discoveredDevice);
+                    deviceState: 'online'
+                }));
 
-                // Config loads with same serial at different IP (stale config)
-                // This simulates loadConfiguredDevices calling setDevice
-                manager['setDevice']({
-                    ip: '192.168.1.200', // stale IP from config
+                // Config has same serial at different IP (stale config)
+                manager['configuredDevices'].push({
+                    host: '192.168.1.200', // stale IP from config
+                    resolvedIp: '192.168.1.200',
                     serialNumber: 'ABC123',
                     deviceState: 'pending',
-                    isConfigured: true,
-                    isDiscovered: false, // config op, not discovery
-                    configuredName: 'My Configured Roku',
-                    configuredPassword: 'secret'
+                    name: 'My Configured Roku',
+                    password: 'secret'
                 });
 
                 // Should have ONE device at the DISCOVERED IP (not the configured IP)
-                expect(manager['devices'].length).to.equal(1);
-                expect(manager['devices'][0].ip).to.equal('192.168.1.100'); // discovered IP preserved
-                expect(manager['devices'][0].isDiscovered).to.equal(true);
-                expect(manager['devices'][0].isConfigured).to.equal(true);
-                expect(manager['devices'][0].configuredName).to.equal('My Configured Roku');
-                expect(manager['devices'][0].configuredPassword).to.equal('secret');
+                expect(manager.getAllDevices().length).to.equal(1);
+                expect(manager.getAllDevices()[0].ip).to.equal('192.168.1.100'); // discovered IP preserved
+                expect(manager.getAllDevices()[0].isDiscovered).to.equal(true);
+                expect(manager.getAllDevices()[0].isConfigured).to.equal(true);
+                expect(manager.getAllDevices()[0].configuredName).to.equal('My Configured Roku');
+                expect(manager.getAllDevices()[0].configuredPassword).to.equal('secret');
             });
 
             it('preserves isConfigured when configured device gets discovered at new IP', async () => {
@@ -2385,7 +2435,7 @@ describe('DeviceManager', () => {
                     configuredName: 'Living Room Roku',
                     configuredPassword: 'secret'
                 });
-                manager['devices'].push(oldDevice);
+                addDevice(oldDevice);
 
                 // SSDP discovers same serial at new IP
                 sinon.stub(rokuDeploy, 'getDeviceInfo').resolves({
@@ -2398,12 +2448,12 @@ describe('DeviceManager', () => {
                 await manager['processDiscoveredIp']('192.168.1.200', 'ABC123');
 
                 // Should have one device with BOTH isDiscovered and isConfigured
-                expect(manager['devices'].length).to.equal(1);
-                expect(manager['devices'][0].ip).to.equal('192.168.1.200');
-                expect(manager['devices'][0].isDiscovered).to.equal(true);
-                expect(manager['devices'][0].isConfigured).to.equal(true);
-                expect(manager['devices'][0].configuredName).to.equal('Living Room Roku');
-                expect(manager['devices'][0].configuredPassword).to.equal('secret');
+                expect(manager.getAllDevices().length).to.equal(1);
+                expect(manager.getAllDevices()[0].ip).to.equal('192.168.1.200');
+                expect(manager.getAllDevices()[0].isDiscovered).to.equal(true);
+                expect(manager.getAllDevices()[0].isConfigured).to.equal(true);
+                expect(manager.getAllDevices()[0].configuredName).to.equal('Living Room Roku');
+                expect(manager.getAllDevices()[0].configuredPassword).to.equal('secret');
             });
         });
 
@@ -2418,7 +2468,7 @@ describe('DeviceManager', () => {
                     deviceState: 'online',
                     isDiscovered: true
                 });
-                manager['devices'].push(oldDevice);
+                addDevice(oldDevice);
 
                 // Discover device at new IP, also without serial in response
                 sinon.stub(rokuDeploy, 'getDeviceInfo').resolves({
@@ -2431,7 +2481,7 @@ describe('DeviceManager', () => {
                 await manager['processDiscoveredIp']('192.168.1.200');
 
                 // Should have two devices (no deduplication without serial)
-                expect(manager['devices'].length).to.equal(2);
+                expect(manager.getAllDevices().length).to.equal(2);
             });
 
             it('does not remove device at same IP (not a duplicate)', async () => {
@@ -2444,7 +2494,7 @@ describe('DeviceManager', () => {
                     deviceState: 'pending',
                     isDiscovered: false
                 });
-                manager['devices'].push(device);
+                addDevice(device);
 
                 // Re-discover at same IP (normal refresh scenario)
                 sinon.stub(rokuDeploy, 'getDeviceInfo').resolves({
@@ -2457,9 +2507,9 @@ describe('DeviceManager', () => {
                 await manager['processDiscoveredIp']('192.168.1.100', 'ABC123');
 
                 // Should still have exactly one device (merged, not duplicated)
-                expect(manager['devices'].length).to.equal(1);
-                expect(manager['devices'][0].ip).to.equal('192.168.1.100');
-                expect(manager['devices'][0].deviceState).to.equal('online');
+                expect(manager.getAllDevices().length).to.equal(1);
+                expect(manager.getAllDevices()[0].ip).to.equal('192.168.1.100');
+                expect(manager.getAllDevices()[0].deviceState).to.equal('online');
             });
         });
     });

--- a/src/deviceDiscovery/DeviceManager.spec.ts
+++ b/src/deviceDiscovery/DeviceManager.spec.ts
@@ -63,7 +63,7 @@ describe('DeviceManager', () => {
         manager['discoveredDevices'].push({
             ip: device.ip,
             serialNumber: device.serialNumber,
-            deviceState: device.deviceState === 'offline' ? 'pending' : (device.deviceState as 'pending' | 'online')
+            deviceState: device.deviceState === 'offline' ? 'pending' : device.deviceState
         });
     }
 

--- a/src/deviceDiscovery/DeviceManager.spec.ts
+++ b/src/deviceDiscovery/DeviceManager.spec.ts
@@ -896,7 +896,7 @@ describe('DeviceManager', () => {
                 const device1 = createMockDevice({ serialNumber: 'device-1', ip: '192.168.1.101' });
                 const device2 = createMockDevice({ serialNumber: 'device-2', ip: '192.168.1.102' });
                 addDevice(device1);
-            addDevice(device2);
+                addDevice(device2);
                 manager.setLastUsedDeviceIp(device1.ip);
 
                 manager['removeDevice'](device2.ip);
@@ -922,6 +922,38 @@ describe('DeviceManager', () => {
             } finally {
                 clock.restore();
             }
+        });
+
+        it('emits devices-changed when device is removed', () => {
+            const clock = sinon.useFakeTimers();
+            try {
+                manager = new DeviceManager(vscode.context, mockGlobalStateManager);
+
+                manager['discoveredDevices'].push({
+                    ip: '192.168.1.100',
+                    serialNumber: 'device-123',
+                    deviceState: 'online'
+                });
+
+                const spy = sinon.spy();
+                manager.on('devices-changed', spy);
+
+                manager['removeDevice']('192.168.1.100');
+
+                // Advance past throttle
+                clock.tick(100);
+
+                expect(spy.called).to.be.true;
+            } finally {
+                clock.restore();
+            }
+        });
+
+        it('does not throw when removing non-existent device', () => {
+            manager = new DeviceManager(vscode.context, mockGlobalStateManager);
+
+            // Should not throw
+            expect(() => manager['removeDevice']('192.168.1.100')).to.not.throw();
         });
     });
 
@@ -978,7 +1010,7 @@ describe('DeviceManager', () => {
 
             manager['loadLastSeenDevices']();
 
-            expect(manager['devices'][0].deviceState).to.equal('online');
+            expect(manager['discoveredDevices'][0].deviceState).to.equal('online');
         });
 
         it('loads cached devices as pending when cache is stale (older than 5 minutes)', () => {
@@ -1434,12 +1466,12 @@ describe('DeviceManager', () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
             // Add a discovered device to verify it gets cleared on network change
-            manager['devices'].push(createMockDevice({
+            manager['discoveredDevices'].push({
                 serialNumber: 'device-123',
                 ip: '192.168.1.100',
-                isDiscovered: true
-            }));
-            expect(manager['devices'].length).to.equal(1);
+                deviceState: 'online'
+            });
+            expect(manager['discoveredDevices'].length).to.equal(1);
 
             // Change the network hash
             (NetworkChangeMonitorModule.getNetworkHash as sinon.SinonStub).returns('new-network-hash');
@@ -1447,8 +1479,8 @@ describe('DeviceManager', () => {
             // Trigger the network change callback directly
             manager['networkChangeMonitor']['onNetworkChanged']();
 
-            // Discovered device should be removed (loadLastSeenDevices clears non-configured)
-            expect(manager['devices'].length).to.equal(0);
+            // Discovered device should be removed (loadLastSeenDevices clears discoveredDevices)
+            expect(manager['discoveredDevices'].length).to.equal(0);
         });
 
         it('clears fetchDeviceThrottleData when network changes', () => {
@@ -1484,21 +1516,21 @@ describe('DeviceManager', () => {
             expect(setScanNeededSpy.calledOnce).to.be.true;
         });
 
-        it('clears devices array when network changes', () => {
+        it('clears discovered devices when network changes', () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
-            // Add multiple devices
-            manager['devices'].push(createMockDevice({
+            // Add discovered devices
+            manager['discoveredDevices'].push({
                 serialNumber: 'device-123',
                 ip: '192.168.1.100',
-                isDiscovered: true
-            }));
-            manager['devices'].push(createMockDevice({
+                deviceState: 'online'
+            });
+            manager['discoveredDevices'].push({
                 serialNumber: 'device-456',
                 ip: '192.168.1.101',
-                isConfigured: true
-            }));
-            expect(manager['devices'].length).to.equal(2);
+                deviceState: 'online'
+            });
+            expect(manager['discoveredDevices'].length).to.equal(2);
 
             // Change the network hash
             (NetworkChangeMonitorModule.getNetworkHash as sinon.SinonStub).returns('new-network-hash');
@@ -1506,8 +1538,39 @@ describe('DeviceManager', () => {
             // Trigger the network change callback directly
             manager['networkChangeMonitor']['onNetworkChanged']();
 
-            // Devices array should be cleared (both discovered and configured)
-            expect(manager['devices'].length).to.equal(0);
+            // Discovered devices should be cleared
+            expect(manager['discoveredDevices'].length).to.equal(0);
+        });
+
+        it('preserves configured devices when network changes', () => {
+            manager = new DeviceManager(vscode.context, mockGlobalStateManager);
+
+            // Add a configured device
+            manager['configuredDevices'].push({
+                host: '192.168.1.100',
+                name: 'My Roku',
+                deviceState: 'online'
+            } as any);
+
+            // Add a discovered device
+            manager['discoveredDevices'].push({
+                serialNumber: 'device-123',
+                ip: '192.168.1.101',
+                deviceState: 'online'
+            });
+
+            expect(manager['configuredDevices'].length).to.equal(1);
+            expect(manager['discoveredDevices'].length).to.equal(1);
+
+            // Change the network hash
+            (NetworkChangeMonitorModule.getNetworkHash as sinon.SinonStub).returns('new-network-hash');
+
+            // Trigger the network change callback directly
+            manager['networkChangeMonitor']['onNetworkChanged']();
+
+            // Configured device should persist, discovered should be cleared
+            expect(manager['configuredDevices'].length).to.equal(1);
+            expect(manager['discoveredDevices'].length).to.equal(0);
         });
     });
 

--- a/src/deviceDiscovery/DeviceManager.spec.ts
+++ b/src/deviceDiscovery/DeviceManager.spec.ts
@@ -2797,11 +2797,13 @@ describe('DeviceManager', () => {
                 expect(result).to.be.true;
             });
 
-            it('returns true when configured device has different serial', () => {
+            it('returns false when configured device has different serial (avoids reload loop)', () => {
                 manager = new DeviceManager(vscode.context, mockGlobalStateManager);
                 mockGlobalStateManager.getSerialNumberForIp.returns(undefined);
 
-                // Add configured device with serial
+                // Add configured device with serial - this is a user misconfiguration
+                // We intentionally don't trigger mismatch here because reloading
+                // won't fix the config and would cause an infinite loop
                 manager['configuredDevices'].push({
                     host: '192.168.1.100',
                     resolvedIp: '192.168.1.100',
@@ -2809,7 +2811,7 @@ describe('DeviceManager', () => {
                 });
 
                 const result = manager['checkForSerialMismatch']('192.168.1.100', 'NEW-SERIAL');
-                expect(result).to.be.true;
+                expect(result).to.be.false;
             });
 
             it('returns true when discovered device has different serial', () => {
@@ -2890,6 +2892,56 @@ describe('DeviceManager', () => {
 
                 // Should NOT have called loadConfiguredDevices
                 expect(loadConfigSpy.called).to.be.false;
+            });
+        });
+
+        describe('configured device with mismatched serial at IP', () => {
+            let ipToSerialMap: Map<string, string>;
+
+            beforeEach(() => {
+                // Reset the IP→serial tracking map and restore callsFake behavior
+                ipToSerialMap = new Map();
+                mockGlobalStateManager.getSerialNumberForIp.callsFake((ip: string, networkId: string) => {
+                    return ipToSerialMap.get(`${networkId}:${ip}`);
+                });
+                mockGlobalStateManager.setSerialNumberForIp.callsFake((networkId: string, ip: string, serial: string) => {
+                    ipToSerialMap.set(`${networkId}:${ip}`, serial);
+                });
+            });
+
+            it('shows actual device serial when configured serial differs from device at IP', async () => {
+                manager = new DeviceManager(vscode.context, mockGlobalStateManager);
+                sinon.stub(manager as any, 'randomDelay').resolves();
+
+                // User configured device with serial ABC at this IP
+                manager['configuredDevices'].push({
+                    host: '192.168.1.100',
+                    serialNumber: 'CONFIGURED-ABC',
+                    name: 'My Living Room Roku'
+                });
+
+                // But device XYZ is actually at that IP
+                // Note: rokuDeploy.getDeviceInfo returns both serialNumber (camelCase) and 'serial-number' (kebab)
+                sinon.stub(rokuDeploy, 'getDeviceInfo').resolves({
+                    'serial-number': 'ACTUAL-XYZ',
+                    'serialNumber': 'ACTUAL-XYZ',
+                    'device-id': 'ACTUAL-XYZ',
+                    'default-device-name': 'Roku Express'
+                } as any);
+
+                // Resolve the device
+                await manager['resolveDevice']({ ip: '192.168.1.100' });
+
+                // Get the devices
+                const devices = manager.getAllDevices();
+
+                // Current behavior: shows ONE device with the actual serial (XYZ)
+                // but with the user's configured name
+                expect(devices).to.have.lengthOf(1);
+                expect(devices[0].serialNumber).to.equal('ACTUAL-XYZ');
+                expect(devices[0].configuredName).to.equal('My Living Room Roku');
+                expect(devices[0].isConfigured).to.be.true;
+                expect(devices[0].isDiscovered).to.be.true;
             });
         });
     });

--- a/src/deviceDiscovery/DeviceManager.spec.ts
+++ b/src/deviceDiscovery/DeviceManager.spec.ts
@@ -134,8 +134,12 @@ describe('DeviceManager', () => {
                 return undefined;
             }),
             clearLastSeenDevices: sinon.stub(),
-            clearDeviceCache: sinon.stub(),
-            clearSerialNumberByIpForNetwork: sinon.stub(),
+            clearDeviceCache: sinon.stub().callsFake(() => {
+                deviceCache.clear();
+            }),
+            clearSerialNumberByIpForNetwork: sinon.stub().callsFake(() => {
+                ipToSerialMap.clear();
+            }),
             clearExpiredEntriesSerialNumberByIpForNetwork: sinon.stub()
         };
 
@@ -424,7 +428,7 @@ describe('DeviceManager', () => {
             expect(resolveDeviceSpy.calledTwice).to.be.true;
         });
 
-        it('only checks stale devices when force=false', async () => {
+        it('calls resolveDevice for all devices (caching happens in resolveDevice)', async () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
             const device1 = createMockDevice({ serialNumber: 'device-1', ip: '192.168.1.101' });
@@ -432,16 +436,12 @@ describe('DeviceManager', () => {
             addDevice(device1);
             addDevice(device2);
 
-            // Mark device1 as recently checked (not stale)
-            (manager as any).lastHealthCheckTime.set('192.168.1.101', Date.now());
-
             const resolveDeviceSpy = sinon.stub(manager as any, 'resolveDevice').returns(Promise.resolve(true) as any);
 
             await (manager as any).healthCheckAllDevices(false);
 
-            // Only device2 should be checked (device1 is not stale)
-            expect(resolveDeviceSpy.calledOnce).to.be.true;
-            expect(resolveDeviceSpy.firstCall.args[0].serialNumber).to.equal('device-2');
+            // Both devices should have resolveDevice called (caching is internal to resolveDevice)
+            expect(resolveDeviceSpy.calledTwice).to.be.true;
         });
 
         it('sets devices to pending before checking when force=false', async () => {
@@ -462,75 +462,112 @@ describe('DeviceManager', () => {
             expect(stateWhenResolveCalled).to.equal('pending');
         });
 
-        it('skips check when no devices are stale', async () => {
+        it('resolveDevice uses cached data when recently fetched', async () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
             const device = createMockDevice();
             addDevice(device);
 
-            // Mark device as recently checked
-            (manager as any).lastHealthCheckTime.set(device.ip, Date.now());
+            const getDeviceInfoStub = sinon.stub(rokuDeploy, 'getDeviceInfo').resolves({
+                'device-id': 'device-123',
+                'serial-number': 'device-123',
+                'default-device-name': 'Roku Express'
+            } as any);
 
-            const resolveDeviceSpy = sinon.stub(manager as any, 'resolveDevice').returns(Promise.resolve(true));
+            // Stub random delay to be instant
+            sinon.stub(manager as any, 'randomDelay').resolves();
 
+            // Pre-populate the cache by calling resolveDevice once
+            await manager['resolveDevice'](device, false);
+            expect(getDeviceInfoStub.calledOnce).to.be.true;
+
+            // Now call healthCheckAllDevices - should use cached data
             await (manager as any).healthCheckAllDevices(false);
 
-            expect(resolveDeviceSpy.called).to.be.false;
+            // Still only one network call (second used cache)
+            expect(getDeviceInfoStub.calledOnce).to.be.true;
         });
     });
 
     describe('healthCheckDevice with force=false (cooldown)', () => {
-        it('skips check if within cooldown period', async () => {
+        it('skips network fetch if within cooldown period (uses cached data)', async () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
             const device = createMockDevice();
-            const resolveDeviceSpy = sinon.stub(manager as any, 'resolveDevice').returns(Promise.resolve(true));
+            addDevice(device);
 
-            // First call - should check
-            await manager.healthCheckDevice(device);
-            expect(resolveDeviceSpy.calledOnce).to.be.true;
+            const getDeviceInfoStub = sinon.stub(rokuDeploy, 'getDeviceInfo').resolves({
+                'device-id': 'device-123',
+                'serial-number': 'device-123',
+                'default-device-name': 'Roku Express'
+            } as any);
 
-            // Second call immediately - should skip due to cooldown
+            // Stub random delay to be instant
+            sinon.stub(manager as any, 'randomDelay').resolves();
+
+            // First call - should fetch from network
             await manager.healthCheckDevice(device);
-            expect(resolveDeviceSpy.calledOnce).to.be.true; // Still just one call
+            expect(getDeviceInfoStub.calledOnce).to.be.true;
+
+            // Second call immediately - should use cache, no new network call
+            await manager.healthCheckDevice(device);
+            expect(getDeviceInfoStub.calledOnce).to.be.true; // Still just one call
         });
 
-        it('checks again after cooldown expires', async () => {
+        it('fetches again after cooldown expires', async () => {
             const clock = sinon.useFakeTimers(Date.now());
             try {
                 manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
                 const device = createMockDevice();
-                const resolveDeviceSpy = sinon.stub(manager as any, 'resolveDevice').returns(Promise.resolve(true));
+                addDevice(device);
+
+                const getDeviceInfoStub = sinon.stub(rokuDeploy, 'getDeviceInfo').resolves({
+                    'device-id': 'device-123',
+                    'serial-number': 'device-123',
+                    'default-device-name': 'Roku Express'
+                } as any);
+
+                // Stub random delay to be instant
+                sinon.stub(manager as any, 'randomDelay').resolves();
 
                 // First call
                 await manager.healthCheckDevice(device);
-                expect(resolveDeviceSpy.calledOnce).to.be.true;
+                expect(getDeviceInfoStub.calledOnce).to.be.true;
 
                 // Advance past cooldown (5 minutes)
                 clock.tick((5 * 60 * 1_000) + 1);
 
-                // Second call - should check again
+                // Second call - cache expired, should fetch again
                 await manager.healthCheckDevice(device);
-                expect(resolveDeviceSpy.calledTwice).to.be.true;
+                expect(getDeviceInfoStub.calledTwice).to.be.true;
             } finally {
                 clock.restore();
             }
         });
 
-        it('always checks when force=true regardless of cooldown', async () => {
+        it('always fetches when force=true regardless of cooldown', async () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
             const device = createMockDevice();
-            const resolveDeviceSpy = sinon.stub(manager as any, 'resolveDevice').returns(Promise.resolve(true));
+            addDevice(device);
+
+            const getDeviceInfoStub = sinon.stub(rokuDeploy, 'getDeviceInfo').resolves({
+                'device-id': 'device-123',
+                'serial-number': 'device-123',
+                'default-device-name': 'Roku Express'
+            } as any);
+
+            // Stub random delay to be instant
+            sinon.stub(manager as any, 'randomDelay').resolves();
 
             // First call with force
             await manager.healthCheckDevice(device, true);
-            expect(resolveDeviceSpy.calledOnce).to.be.true;
+            expect(getDeviceInfoStub.calledOnce).to.be.true;
 
-            // Second call immediately with force - should still check
+            // Second call immediately with force - should still fetch
             await manager.healthCheckDevice(device, true);
-            expect(resolveDeviceSpy.calledTwice).to.be.true;
+            expect(getDeviceInfoStub.calledTwice).to.be.true;
         });
     });
 
@@ -1371,7 +1408,7 @@ describe('DeviceManager', () => {
     });
 
     describe('fetchDeviceInfo', () => {
-        it('only makes one network call for rapid successive requests', async () => {
+        it('always makes network call (no caching in fetchDeviceInfo)', async () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
             const getDeviceInfoStub = sinon.stub(rokuDeploy, 'getDeviceInfo').resolves({
@@ -1380,41 +1417,121 @@ describe('DeviceManager', () => {
                 'default-device-name': 'Roku Express'
             } as any);
 
-            // Call twice in rapid succession
+            // Call twice in rapid succession - both should hit network
             await manager['fetchDeviceInfo']('192.168.1.100', 8060);
             await manager['fetchDeviceInfo']('192.168.1.100', 8060);
 
-            // Should only have made one actual network call
+            // fetchDeviceInfo always makes network calls (caching is in resolveDevice)
+            expect(getDeviceInfoStub.callCount).to.equal(2);
+        });
+    });
+
+    describe('resolveDevice caching', () => {
+        it('only makes one network call for rapid successive requests', async () => {
+            manager = new DeviceManager(vscode.context, mockGlobalStateManager);
+
+            const device = createMockDevice();
+            addDevice(device);
+
+            const getDeviceInfoStub = sinon.stub(rokuDeploy, 'getDeviceInfo').resolves({
+                'device-id': 'device-123',
+                'serial-number': 'device-123',
+                'default-device-name': 'Roku Express'
+            } as any);
+
+            // Stub random delay to be instant
+            sinon.stub(manager as any, 'randomDelay').resolves();
+
+            // Call twice in rapid succession via resolveDevice
+            await manager['resolveDevice'](device, false);
+            await manager['resolveDevice'](device, false);
+
+            // Should only have made one actual network call (second uses cache)
             expect(getDeviceInfoStub.callCount).to.equal(1);
         });
 
         it('makes a new network call after cache TTL expires', async () => {
-            const clock = sinon.useFakeTimers();
+            const clock = sinon.useFakeTimers(Date.now());
             try {
                 manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
+                const device = createMockDevice();
+                addDevice(device);
+
                 const getDeviceInfoStub = sinon.stub(rokuDeploy, 'getDeviceInfo').resolves({
                     'device-id': 'device-123',
+                    'serial-number': 'device-123',
                     'default-device-name': 'Roku Express'
                 } as any);
+
+                // Stub random delay to be instant
+                sinon.stub(manager as any, 'randomDelay').resolves();
 
                 // First call - should hit network
-                await manager['fetchDeviceInfo']('192.168.1.100', 8060);
+                await manager['resolveDevice'](device, false);
                 expect(getDeviceInfoStub.callCount).to.equal(1);
 
-                // Advance past TTL (5 seconds)
-                clock.tick(6_000);
+                // Advance past TTL (5 minutes)
+                clock.tick((5 * 60 * 1_000) + 1);
 
                 // Second call - cache expired, should hit network again
-                await manager['fetchDeviceInfo']('192.168.1.100', 8060);
+                await manager['resolveDevice'](device, false);
                 expect(getDeviceInfoStub.callCount).to.equal(2);
             } finally {
                 clock.restore();
             }
         });
 
-        it('caches different IPs separately', async () => {
+        it('caches different serial numbers separately', async () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
+
+            const device1 = createMockDevice({ ip: '192.168.1.100', serialNumber: 'device-100' });
+            const device2 = createMockDevice({ ip: '192.168.1.101', serialNumber: 'device-101' });
+            addDevice(device1);
+            addDevice(device2);
+
+            // Return different serials for different devices
+            const getDeviceInfoStub = sinon.stub(rokuDeploy, 'getDeviceInfo');
+            getDeviceInfoStub.onCall(0).resolves({
+                'device-id': 'device-100',
+                'serial-number': 'device-100',
+                'default-device-name': 'Roku Express 1'
+            } as any);
+            getDeviceInfoStub.onCall(1).resolves({
+                'device-id': 'device-101',
+                'serial-number': 'device-101',
+                'default-device-name': 'Roku Express 2'
+            } as any);
+            // Subsequent calls return same data for cache hits
+            getDeviceInfoStub.resolves({
+                'device-id': 'device-100',
+                'serial-number': 'device-100',
+                'default-device-name': 'Roku Express 1'
+            } as any);
+
+            // Stub random delay to be instant
+            sinon.stub(manager as any, 'randomDelay').resolves();
+
+            // Call for two different devices
+            await manager['resolveDevice'](device1, false);
+            await manager['resolveDevice'](device2, false);
+
+            // Should make two network calls (different serials)
+            expect(getDeviceInfoStub.callCount).to.equal(2);
+
+            // Calling same devices again should use cache (keyed by serial)
+            await manager['resolveDevice'](device1, false);
+            await manager['resolveDevice'](device2, false);
+
+            // Still only two calls (cache hit)
+            expect(getDeviceInfoStub.callCount).to.equal(2);
+        });
+
+        it('refetches on network change when serial unknown (IP→serial mapping is network-specific)', async () => {
+            manager = new DeviceManager(vscode.context, mockGlobalStateManager);
+
+            // Device with unknown serial (only IP known) - like a newly discovered device
+            const deviceIpOnly = { ip: '192.168.1.100' };
 
             const getDeviceInfoStub = sinon.stub(rokuDeploy, 'getDeviceInfo').resolves({
                 'device-id': 'device-123',
@@ -1422,53 +1539,34 @@ describe('DeviceManager', () => {
                 'default-device-name': 'Roku Express'
             } as any);
 
-            // Call for two different IPs
-            await manager['fetchDeviceInfo']('192.168.1.100', 8060);
-            await manager['fetchDeviceInfo']('192.168.1.101', 8060);
+            // Stub random delay to be instant
+            sinon.stub(manager as any, 'randomDelay').resolves();
 
-            // Should make two network calls (different IPs)
-            expect(getDeviceInfoStub.callCount).to.equal(2);
+            // First call - fetches from network (no cache, no IP→serial mapping)
+            await manager['resolveDevice'](deviceIpOnly, false);
+            expect(getDeviceInfoStub.callCount).to.equal(1);
 
-            // But calling same IPs again should use cache
-            await manager['fetchDeviceInfo']('192.168.1.100', 8060);
-            await manager['fetchDeviceInfo']('192.168.1.101', 8060);
+            // Now we have IP→serial mapping. Second call should use cache.
+            await manager['resolveDevice'](deviceIpOnly, false);
+            expect(getDeviceInfoStub.callCount).to.equal(1);
 
-            // Still only two calls
+            // Simulate network change
+            (NetworkChangeMonitorModule.getNetworkHash as sinon.SinonStub).returns('new-network-hash');
+            manager['networkChangeMonitor']['onNetworkChanged']();
+            await util.sleep(10);
+
+            // On new network, IP→serial mapping is cleared.
+            // Resolving by IP alone should refetch since we can't look up the serial.
+            await manager['resolveDevice'](deviceIpOnly, false);
             expect(getDeviceInfoStub.callCount).to.equal(2);
         });
 
-        it('clears cache after inactivity timeout', async () => {
-            const clock = sinon.useFakeTimers();
-            try {
-                manager = new DeviceManager(vscode.context, mockGlobalStateManager);
-
-                const getDeviceInfoStub = sinon.stub(rokuDeploy, 'getDeviceInfo').resolves({
-                    'device-id': 'device-123',
-                    'default-device-name': 'Roku Express'
-                } as any);
-
-                // First call - populates cache
-                await manager['fetchDeviceInfo']('192.168.1.100', 8060);
-                expect(getDeviceInfoStub.callCount).to.equal(1);
-
-                // Call again within TTL - should use cache
-                clock.tick(2_000);
-                await manager['fetchDeviceInfo']('192.168.1.100', 8060);
-                expect(getDeviceInfoStub.callCount).to.equal(1);
-
-                // Advance past cleanup delay (10 seconds of inactivity)
-                clock.tick(11_000);
-
-                // Cache should be cleared, next call hits network
-                await manager['fetchDeviceInfo']('192.168.1.100', 8060);
-                expect(getDeviceInfoStub.callCount).to.equal(2);
-            } finally {
-                clock.restore();
-            }
-        });
-
-        it('clears cache on network change', async () => {
+        it('uses cached data on network change when serial is known', async () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
+
+            // Device with known serial (from config or previous discovery)
+            const device = createMockDevice();
+            addDevice(device);
 
             const getDeviceInfoStub = sinon.stub(rokuDeploy, 'getDeviceInfo').resolves({
                 'device-id': 'device-123',
@@ -1476,27 +1574,29 @@ describe('DeviceManager', () => {
                 'default-device-name': 'Roku Express'
             } as any);
 
-            // Populate cache
-            await manager['fetchDeviceInfo']('192.168.1.100', 8060);
+            // Stub random delay to be instant
+            sinon.stub(manager as any, 'randomDelay').resolves();
+
+            // First call - fetches from network
+            await manager['resolveDevice'](device, false);
             expect(getDeviceInfoStub.callCount).to.equal(1);
 
             // Verify cache is working
-            await manager['fetchDeviceInfo']('192.168.1.100', 8060);
+            await manager['resolveDevice'](device, false);
             expect(getDeviceInfoStub.callCount).to.equal(1);
 
-            // Simulate network change by changing the stub's return value to a different hash
+            // Simulate network change
             (NetworkChangeMonitorModule.getNetworkHash as sinon.SinonStub).returns('new-network-hash');
-
-            // Simulate network change by calling the networkChangeMonitor callback
-            // (now handlePotentialNetworkChange will see the different hash)
             manager['networkChangeMonitor']['onNetworkChanged']();
-
-            // Wait for the async handlePotentialNetworkChange to complete
             await util.sleep(10);
 
-            // Cache should be cleared, next call hits network
-            await manager['fetchDeviceInfo']('192.168.1.100', 8060);
-            expect(getDeviceInfoStub.callCount).to.equal(2);
+            // Re-add device (network change clears discovered devices)
+            addDevice(device);
+
+            // Device info cache is keyed by serial, not network.
+            // Since we know the serial, we can use cached data even on new network.
+            await manager['resolveDevice'](device, false);
+            expect(getDeviceInfoStub.callCount).to.equal(1); // Still uses cache
         });
     });
 
@@ -1533,25 +1633,6 @@ describe('DeviceManager', () => {
 
             // Discovered device should be removed (loadLastSeenDevices clears discoveredDevices)
             expect(manager['discoveredDevices'].length).to.equal(0);
-        });
-
-        it('clears fetchDeviceThrottleData when network changes', () => {
-            manager = new DeviceManager(vscode.context, mockGlobalStateManager);
-
-            // Populate the cache
-            manager['fetchDeviceThrottleData'].set('192.168.1.100', {
-                info: { 'serial-number': 'device-123' } as any,
-                timestamp: Date.now()
-            });
-            expect(manager['fetchDeviceThrottleData'].size).to.equal(1);
-
-            // Change the network hash
-            (NetworkChangeMonitorModule.getNetworkHash as sinon.SinonStub).returns('new-network-hash');
-
-            // Trigger the network change callback directly
-            manager['networkChangeMonitor']['onNetworkChanged']();
-
-            expect(manager['fetchDeviceThrottleData'].size).to.equal(0);
         });
 
         it('calls setScanNeeded when network changes', () => {
@@ -2153,26 +2234,38 @@ describe('DeviceManager', () => {
                     expect(manager['timeSinceLastScan']).to.equal(Infinity);
                 });
 
-                it('clears lastHealthCheckTime map', async () => {
+                it('clears globalStateManager device cache (enables fresh fetch)', async () => {
                     manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
                     const device = createMockDevice();
-                    const resolveDeviceSpy = sinon.stub(manager as any, 'resolveDevice').returns(Promise.resolve(true));
+                    addDevice(device);
 
-                    // Perform health check to populate cooldown
+                    const getDeviceInfoStub = sinon.stub(rokuDeploy, 'getDeviceInfo').resolves({
+                        'device-id': 'device-123',
+                        'serial-number': 'device-123',
+                        'default-device-name': 'Roku Express'
+                    } as any);
+
+                    // Stub random delay to be instant
+                    sinon.stub(manager as any, 'randomDelay').resolves();
+
+                    // Perform health check to populate cache
                     await manager.healthCheckDevice(device);
-                    expect(resolveDeviceSpy.calledOnce).to.be.true;
+                    expect(getDeviceInfoStub.calledOnce).to.be.true;
 
-                    // Second call should be skipped due to cooldown
+                    // Second call should use cache (no new network call)
                     await manager.healthCheckDevice(device);
-                    expect(resolveDeviceSpy.calledOnce).to.be.true; // Still just one call
+                    expect(getDeviceInfoStub.calledOnce).to.be.true; // Still just one call
 
-                    // Clear cache
+                    // Clear cache (clears globalStateManager.deviceCache and IP→serial mappings)
                     manager.clearAllCache();
 
-                    // Now health check should work immediately
+                    // Re-add the device (clearAllCache removes discovered devices)
+                    addDevice(device);
+
+                    // Now health check should hit network again (cache was cleared)
                     await manager.healthCheckDevice(device);
-                    expect(resolveDeviceSpy.calledTwice).to.be.true; // Cooldown was cleared
+                    expect(getDeviceInfoStub.calledTwice).to.be.true;
                 });
 
                 it('clears resolveDeviceSequence map', () => {
@@ -2187,33 +2280,6 @@ describe('DeviceManager', () => {
                     manager.clearAllCache();
 
                     expect(manager['resolveDeviceSequence'].has(device.ip)).to.be.false;
-                });
-            });
-
-            describe('timer clearing', () => {
-                it('clears fetchDeviceInfoThrottleTimer', () => {
-                    const clock = sinon.useFakeTimers();
-                    try {
-                        manager = new DeviceManager(vscode.context, mockGlobalStateManager);
-
-                        // Trigger cache cleanup timer by resetting it
-                        manager['resetCacheCleanupTimer']();
-                        expect(manager['fetchDeviceInfoThrottleTimer']).to.not.be.null;
-
-                        manager.clearAllCache();
-
-                        expect(manager['fetchDeviceInfoThrottleTimer']).to.be.null;
-                    } finally {
-                        clock.restore();
-                    }
-                });
-
-                it('does not throw if fetchDeviceInfoThrottleTimer is already null', () => {
-                    manager = new DeviceManager(vscode.context, mockGlobalStateManager);
-
-                    manager['fetchDeviceInfoThrottleTimer'] = null;
-
-                    expect(() => manager.clearAllCache()).to.not.throw();
                 });
             });
 

--- a/src/deviceDiscovery/DeviceManager.spec.ts
+++ b/src/deviceDiscovery/DeviceManager.spec.ts
@@ -1140,7 +1140,7 @@ describe('DeviceManager', () => {
     });
 
     describe('device filtering (shouldShowDevice)', () => {
-        it('filters devices without developer-enabled via getDevicesForUI', () => {
+        it('filters devices with developer-enabled: false via getDevicesForUI', () => {
             // Default config has includeNonDeveloperDevices: true for tests,
             // so override to test filtering
             (vscode.workspace.getConfiguration as sinon.SinonStub).returns({
@@ -1155,17 +1155,43 @@ describe('DeviceManager', () => {
 
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
-            // Add device without developer-enabled in deviceInfo
+            // Add device with developer-enabled: false in cached deviceInfo
+            const device = createMockDevice({
+                serialNumber: 'ABC123',
+                ip: '192.168.1.100',
+                deviceInfo: { 'developer-enabled': 'false' }
+            });
+            addDevice(device);
+
+            // Device should be filtered out from getDevicesForUI
+            expect(manager.getDevicesForUI().length).to.equal(0);
+            // But still available via getAllDevices (unfiltered)
+            expect(manager.getAllDevices().length).to.equal(1);
+        });
+
+        it('shows devices with unknown developer-enabled status via getDevicesForUI', () => {
+            // When developer-enabled is not set, device should still be shown
+            (vscode.workspace.getConfiguration as sinon.SinonStub).returns({
+                get: () => undefined,
+                inspect: () => ({ workspaceValue: [], globalValue: [] }),
+                deviceDiscovery: {
+                    enabled: false,
+                    showInfoMessages: false,
+                    includeNonDeveloperDevices: false
+                }
+            } as any);
+
+            manager = new DeviceManager(vscode.context, mockGlobalStateManager);
+
+            // Add device without developer-enabled in deviceInfo (unknown status)
             manager['discoveredDevices'].push({
                 ip: '192.168.1.100',
                 serialNumber: 'ABC123'
             });
             manager['setDeviceState']({ ip: '192.168.1.100', serialNumber: 'ABC123' }, 'online');
 
-            // Device should be filtered out from getDevicesForUI
-            expect(manager.getDevicesForUI().length).to.equal(0);
-            // But still available via getAllDevices (unfiltered)
-            expect(manager.getAllDevices().length).to.equal(1);
+            // Device with unknown status should still be shown (only 'false' is filtered)
+            expect(manager.getDevicesForUI().length).to.equal(1);
         });
 
         it('shows devices with developer-enabled: true via getDevicesForUI', () => {
@@ -1241,49 +1267,57 @@ describe('DeviceManager', () => {
         });
 
         it('emits devices-changed when includeNonDeveloperDevices setting changes', () => {
-            // Capture the onDidChangeConfiguration callback
-            let configChangeCallback: (event: any) => void;
-            (vscode.workspace.onDidChangeConfiguration as any) = (callback: any) => {
-                configChangeCallback = callback;
-                return { dispose: () => { } };
-            };
+            const clock = sinon.useFakeTimers();
+            try {
+                // Capture the onDidChangeConfiguration callback
+                let configChangeCallback: (event: any) => void;
+                (vscode.workspace.onDidChangeConfiguration as any) = (callback: any) => {
+                    configChangeCallback = callback;
+                    return { dispose: () => { } };
+                };
 
-            (vscode.workspace.getConfiguration as sinon.SinonStub).returns({
-                get: () => undefined,
-                inspect: () => ({ workspaceValue: [], globalValue: [] }),
-                deviceDiscovery: {
-                    enabled: false,
-                    showInfoMessages: false,
-                    includeNonDeveloperDevices: false
-                }
-            } as any);
+                (vscode.workspace.getConfiguration as sinon.SinonStub).returns({
+                    get: () => undefined,
+                    inspect: () => ({ workspaceValue: [], globalValue: [] }),
+                    deviceDiscovery: {
+                        enabled: false,
+                        showInfoMessages: false,
+                        includeNonDeveloperDevices: false
+                    }
+                } as any);
 
-            manager = new DeviceManager(vscode.context, mockGlobalStateManager);
+                manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
-            // Add a non-developer device
-            const device = createMockDevice({
-                serialNumber: 'ABC123',
-                ip: '192.168.1.100',
-                deviceInfo: { 'developer-enabled': 'false' }
-            });
-            addDevice(device);
+                // Add a non-developer device
+                const device = createMockDevice({
+                    serialNumber: 'ABC123',
+                    ip: '192.168.1.100',
+                    deviceInfo: { 'developer-enabled': 'false' }
+                });
+                addDevice(device);
 
-            // Device should be filtered initially from getDevicesForUI
-            expect(manager.getDevicesForUI().length).to.equal(0);
-            // But available from getAllDevices (unfiltered)
-            expect(manager.getAllDevices().length).to.equal(1);
+                // Device should be filtered initially from getDevicesForUI
+                expect(manager.getDevicesForUI().length).to.equal(0);
+                // But available from getAllDevices (unfiltered)
+                expect(manager.getAllDevices().length).to.equal(1);
 
-            // Listen for devices-changed event
-            const devicesChangedSpy = sinon.spy();
-            manager.on('devices-changed', devicesChangedSpy);
+                // Listen for devices-changed event
+                const devicesChangedSpy = sinon.spy();
+                manager.on('devices-changed', devicesChangedSpy);
 
-            // Simulate config change
-            configChangeCallback({
-                affectsConfiguration: (key: string) => key === 'brightscript.deviceDiscovery.includeNonDeveloperDevices'
-            });
+                // Simulate config change
+                configChangeCallback({
+                    affectsConfiguration: (key: string) => key === 'brightscript.deviceDiscovery.includeNonDeveloperDevices'
+                });
 
-            // Should have emitted devices-changed
-            expect(devicesChangedSpy.called).to.be.true;
+                // Advance past debounce period (50ms)
+                clock.tick(100);
+
+                // Should have emitted devices-changed
+                expect(devicesChangedSpy.called).to.be.true;
+            } finally {
+                clock.restore();
+            }
         });
     });
 
@@ -2694,6 +2728,7 @@ describe('DeviceManager', () => {
                     serialNumber: null, // Not yet resolved
                     ip: '192.168.1.200',
                     deviceState: 'pending',
+                    isConfigured: true,
                     isDiscovered: false
                 });
                 addDevice(newDevice);
@@ -2730,12 +2765,12 @@ describe('DeviceManager', () => {
                 });
                 addDevice(oldDevice);
 
-                // New device at different IP being resolved
+                // New device at different IP discovered via SSDP (no serial yet)
                 const newDevice = createMockDevice({
                     serialNumber: null,
                     ip: '192.168.1.200',
                     deviceState: 'pending',
-                    isDiscovered: false
+                    isDiscovered: true
                 });
                 addDevice(newDevice);
 
@@ -2985,8 +3020,16 @@ describe('DeviceManager', () => {
                     'default-device-name': 'Roku Express'
                 } as any);
 
+                // Add discovered device at IP (mismatch detection happens in setDiscoveredDevice
+                // which is only called when isDiscovered is true)
+                const device = createMockDevice({
+                    ip: '192.168.1.100',
+                    isDiscovered: true
+                });
+                addDiscoveredDevice(device);
+
                 // Resolve device
-                await manager['resolveDevice']({ ip: '192.168.1.100' });
+                await manager['resolveDevice'](device);
 
                 // Should have called loadConfiguredDevices
                 expect(loadConfigSpy.calledOnce).to.be.true;
@@ -3067,8 +3110,18 @@ describe('DeviceManager', () => {
                     'default-device-name': 'Roku Express'
                 } as any);
 
-                // Resolve the device
-                await manager['resolveDevice']({ ip: '192.168.1.100' });
+                // Simulate SSDP discovering a device at the configured IP (no serial known yet)
+                // setDiscoveredDevice is only called when isDiscovered is true, which creates
+                // the discovered device entry after resolution
+                const device = createMockDevice({
+                    ip: '192.168.1.100',
+                    serialNumber: null, // No serial known yet from SSDP
+                    isDiscovered: true
+                });
+                addDiscoveredDevice(device);
+
+                // Resolve the discovered device - this will find XYZ serial
+                await manager['resolveDevice'](device);
 
                 // Get the devices
                 const devices = manager.getAllDevices();

--- a/src/deviceDiscovery/DeviceManager.spec.ts
+++ b/src/deviceDiscovery/DeviceManager.spec.ts
@@ -1180,6 +1180,50 @@ describe('DeviceManager', () => {
 
             expect(manager.getDevice({ ip: '192.168.1.100' })).to.be.undefined;
         });
+
+        it('emits devices-changed when includeNonDeveloperDevices setting changes', () => {
+            // Capture the onDidChangeConfiguration callback
+            let configChangeCallback: (event: any) => void;
+            (vscode.workspace.onDidChangeConfiguration as any) = (callback: any) => {
+                configChangeCallback = callback;
+                return { dispose: () => { } };
+            };
+
+            (vscode.workspace.getConfiguration as sinon.SinonStub).returns({
+                get: () => undefined,
+                inspect: () => ({ workspaceValue: [], globalValue: [] }),
+                deviceDiscovery: {
+                    enabled: false,
+                    showInfoMessages: false,
+                    includeNonDeveloperDevices: false
+                }
+            } as any);
+
+            manager = new DeviceManager(vscode.context, mockGlobalStateManager);
+
+            // Add a non-developer device
+            const device = createMockDevice({
+                serialNumber: 'ABC123',
+                ip: '192.168.1.100',
+                deviceInfo: { 'developer-enabled': 'false' }
+            });
+            addDevice(device);
+
+            // Device should be filtered initially
+            expect(manager.getAllDevices().length).to.equal(0);
+
+            // Listen for devices-changed event
+            const devicesChangedSpy = sinon.spy();
+            manager.on('devices-changed', devicesChangedSpy);
+
+            // Simulate config change
+            configChangeCallback({
+                affectsConfiguration: (key: string) => key === 'brightscript.deviceDiscovery.includeNonDeveloperDevices'
+            });
+
+            // Should have emitted devices-changed
+            expect(devicesChangedSpy.called).to.be.true;
+        });
     });
 
     describe('handleDeviceOnline', () => {

--- a/src/deviceDiscovery/DeviceManager.spec.ts
+++ b/src/deviceDiscovery/DeviceManager.spec.ts
@@ -789,6 +789,29 @@ describe('DeviceManager', () => {
             expect(manager.getAllDevices().length).to.equal(0);
         });
 
+        it('preserves cache data when device goes offline (for offline display)', async () => {
+            manager = new DeviceManager(vscode.context, mockGlobalStateManager);
+            (vscode.window as any).state = { focused: true };
+
+            const device = createMockDevice({
+                serialNumber: 'device-123',
+                deviceInfo: { 'default-device-name': 'My Roku' }
+            });
+            addDevice(device);
+
+            // First health check fails (device offline)
+            sinon.stub(rokuDeploy, 'getDeviceInfo').rejects(new Error('Device not responding'));
+            await manager.healthCheckDevice(device, true);
+
+            // Cache should still exist with device info preserved for offline display
+            const cached = mockGlobalStateManager.getCachedDevice('device-123');
+            expect(cached).to.exist;
+            expect(cached.deviceInfo['default-device-name']).to.equal('My Roku');
+
+            // Device should be offline
+            expect(manager.getDeviceState({ serialNumber: 'device-123' }).state).to.equal('offline');
+        });
+
         it('returns true when device is healthy', async () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
@@ -1068,7 +1091,7 @@ describe('DeviceManager', () => {
 
             manager['loadLastSeenDevices']();
 
-            expect(manager['getDeviceState']({ ip: '192.168.1.100', serialNumber: 'device-1' })).to.equal('online');
+            expect(manager['getDeviceState']({ ip: '192.168.1.100', serialNumber: 'device-1' }).state).to.equal('online');
         });
 
         it('loads cached devices as pending when cache is stale (older than 5 minutes)', () => {
@@ -3116,7 +3139,8 @@ describe('DeviceManager', () => {
                 const device = createMockDevice({
                     ip: '192.168.1.100',
                     serialNumber: null, // No serial known yet from SSDP
-                    isDiscovered: true
+                    isDiscovered: true,
+                    deviceState: 'pending' // Unresolved device starts as pending
                 });
                 addDiscoveredDevice(device);
 

--- a/src/deviceDiscovery/DeviceManager.spec.ts
+++ b/src/deviceDiscovery/DeviceManager.spec.ts
@@ -2010,6 +2010,51 @@ describe('DeviceManager', () => {
                 expect(secondDevice.isConfigured).to.equal(true);
             });
 
+            it('marks other configured device offline when health check finds different serial at same IP', async () => {
+                // Two config entries pointing to same IP with different serials
+                (vscode.workspace.getConfiguration as sinon.SinonStub).returns({
+                    inspect: () => ({
+                        workspaceValue: [],
+                        globalValue: [
+                            { host: '192.168.1.100', serialNumber: 'ABC', name: 'First Entry' },
+                            { host: '192.168.1.100', serialNumber: 'XYZ', name: 'Second Entry' }
+                        ]
+                    }),
+                    deviceDiscovery: {
+                        enabled: false,
+                        includeNonDeveloperDevices: true
+                    }
+                });
+
+                manager = new DeviceManager(vscode.context, mockGlobalStateManager);
+                sinon.stub(manager as any, 'randomDelay').resolves();
+
+                await manager['loadConfiguredDevices']();
+
+                // Health check finds ABC at the IP
+                sinon.stub(rokuDeploy, 'getDeviceInfo').resolves({
+                    'serial-number': 'ABC',
+                    'serialNumber': 'ABC',
+                    'device-id': 'ABC',
+                    'default-device-name': 'Roku Express'
+                } as any);
+
+                await manager['resolveDevice']({ ip: '192.168.1.100' });
+
+                const devices = manager.getAllDevices();
+                expect(devices.length).to.equal(2);
+
+                // ABC should be online (it's the device at the IP)
+                const abcDevice = devices.find(d => d.serialNumber === 'ABC');
+                expect(abcDevice).to.exist;
+                expect(abcDevice.deviceState).to.equal('online');
+
+                // XYZ should be offline (different device is at its configured IP)
+                const xyzDevice = devices.find(d => d.serialNumber === 'XYZ');
+                expect(xyzDevice).to.exist;
+                expect(xyzDevice.deviceState).to.equal('offline');
+            });
+
             it('clears configuredName when name is removed from config', async () => {
                 // Initial config with a name
                 const configStub = vscode.workspace.getConfiguration as sinon.SinonStub;

--- a/src/deviceDiscovery/DeviceManager.spec.ts
+++ b/src/deviceDiscovery/DeviceManager.spec.ts
@@ -1300,11 +1300,9 @@ describe('DeviceManager', () => {
                 });
                 manager['devices'].push(configuredDevice);
 
-                // Update same device without isConfigured (simulating discovery)
-                manager['setDevice']({
-                    ...createMockDevice({ serialNumber: 'device-123', ip: '192.168.1.100' }),
-                    isConfigured: undefined
-                });
+                // Update same device without isConfigured (simulating discovery - property omitted, not undefined)
+                const { isConfigured, configuredName, configuredPassword, configuredIn, ...discoveryUpdate } = createMockDevice({ serialNumber: 'device-123', ip: '192.168.1.100' });
+                manager['setDevice'](discoveryUpdate);
 
                 expect(manager['devices'].length).to.equal(1);
                 expect(manager['devices'][0].isConfigured).to.equal(true);
@@ -1323,11 +1321,9 @@ describe('DeviceManager', () => {
                 });
                 manager['devices'].push(configuredDevice);
 
-                // Update with real serialNumber (simulating resolution)
-                manager['setDevice']({
-                    ...createMockDevice({ serialNumber: 'real-serial-number', ip: '192.168.1.100' }),
-                    isConfigured: undefined
-                });
+                // Update with real serialNumber (simulating resolution - property omitted, not undefined)
+                const { isConfigured, configuredName, configuredPassword, configuredIn, ...resolutionUpdate } = createMockDevice({ serialNumber: 'real-serial-number', ip: '192.168.1.100' });
+                manager['setDevice'](resolutionUpdate);
 
                 expect(manager['devices'].length).to.equal(1);
                 expect(manager['devices'][0].serialNumber).to.equal('real-serial-number');
@@ -1614,6 +1610,41 @@ describe('DeviceManager', () => {
                 expect(manager['devices'][0].ip).to.equal('192.168.1.100');
                 expect(manager['devices'][0].configuredName).to.equal('Second Entry');
                 expect(manager['devices'][0].isConfigured).to.equal(true);
+            });
+
+            it('clears configuredName when name is removed from config', async () => {
+                // Initial config with a name
+                const configStub = vscode.workspace.getConfiguration as sinon.SinonStub;
+                configStub.returns({
+                    inspect: () => ({
+                        workspaceValue: [],
+                        globalValue: [
+                            { host: '192.168.1.100', name: 'My Roku' }
+                        ]
+                    })
+                });
+
+                manager = new DeviceManager(vscode.context, mockGlobalStateManager);
+                await manager['loadConfiguredDevices']();
+
+                expect(manager['devices'].length).to.equal(1);
+                expect(manager['devices'][0].configuredName).to.equal('My Roku');
+
+                // Simulate config change: name is removed
+                configStub.returns({
+                    inspect: () => ({
+                        workspaceValue: [],
+                        globalValue: [
+                            { host: '192.168.1.100' } // no name
+                        ]
+                    })
+                });
+
+                await manager['loadConfiguredDevices']();
+
+                // Name should be cleared
+                expect(manager['devices'].length).to.equal(1);
+                expect(manager['devices'][0].configuredName).to.equal(undefined);
             });
         });
 

--- a/src/deviceDiscovery/DeviceManager.ts
+++ b/src/deviceDiscovery/DeviceManager.ts
@@ -258,13 +258,16 @@ export class DeviceManager {
             let discovered: DiscoveredDeviceEntry | undefined;
 
             if (configured.serialNumber) {
+                // Config has serial - ONLY match by serial (serial is primary key)
                 discoveredIdx = this.discoveredDevices.findIndex(d => d.serialNumber === configured.serialNumber);
-            }
-            if (discoveredIdx < 0 && configured.resolvedIp) {
-                discoveredIdx = this.discoveredDevices.findIndex(d => d.ip === configured.resolvedIp);
-            }
-            if (discoveredIdx < 0) {
-                discoveredIdx = this.discoveredDevices.findIndex(d => d.ip === configured.host);
+            } else {
+                // Config has no serial - match by IP
+                if (configured.resolvedIp) {
+                    discoveredIdx = this.discoveredDevices.findIndex(d => d.ip === configured.resolvedIp);
+                }
+                if (discoveredIdx < 0) {
+                    discoveredIdx = this.discoveredDevices.findIndex(d => d.ip === configured.host);
+                }
             }
 
             if (discoveredIdx >= 0) {
@@ -287,12 +290,14 @@ export class DeviceManager {
             const discovered = this.discoveredDevices[i];
             const device = this.buildMergedDevice(undefined, discovered);
             if (device) {
-                // Check for duplicate by key or IP
+                // Check for duplicate by key
                 if (mergedDevices.has(device.key)) {
                     continue;
                 }
+                // Only skip by IP if neither device has a serial (serial is primary key)
+                // Different serials at same IP = different devices
                 const existingByIp = Array.from(mergedDevices.values()).find(d => d.ip === device.ip);
-                if (existingByIp) {
+                if (existingByIp && !device.serialNumber && !existingByIp.serialNumber) {
                     continue;
                 }
                 mergedDevices.set(device.key, device);
@@ -852,19 +857,30 @@ export class DeviceManager {
 
     /**
      * Update resolvedIp for a configured device by IP or serial number.
+     * Also marks configured devices as offline when a different device is found at their IP.
      */
     private updateConfiguredDeviceResolvedIp(ip: string, serialNumber: string | undefined): void {
-        // Try to find by serial first (more reliable), then by IP
-        let entry: ConfiguredDeviceEntry | undefined;
+        // Try to find by serial first (more reliable)
         if (serialNumber) {
-            entry = this.getConfiguredDevice({ serialNumber: serialNumber });
-        }
-        if (!entry) {
-            entry = this.getConfiguredDevice({ ip: ip });
+            const entryBySerial = this.getConfiguredDevice({ serialNumber: serialNumber });
+            if (entryBySerial) {
+                // Found configured device with matching serial - update its resolved IP
+                entryBySerial.resolvedIp = ip;
+                return;
+            }
         }
 
-        if (entry) {
-            entry.resolvedIp = ip;
+        // No configured device with this serial - check if there's one configured at this IP
+        const entryByIp = this.getConfiguredDevice({ ip: ip });
+        if (entryByIp) {
+            if (entryByIp.serialNumber && serialNumber && entryByIp.serialNumber !== serialNumber) {
+                // Configured device has a different serial than what's actually at this IP
+                // Mark the configured device as offline (it's not where it should be)
+                this.setDeviceState({ serialNumber: entryByIp.serialNumber }, 'offline');
+            } else if (!entryByIp.serialNumber) {
+                // Configured device has no serial - update its resolvedIp via IP matching
+                entryByIp.resolvedIp = ip;
+            }
         }
     }
 
@@ -1169,9 +1185,10 @@ export class DeviceManager {
             ip = configuredEntry.host;
         }
 
-        // Determine serial: cache > configured > discovered
-        const serialNumber = this.globalStateManager.getSerialNumberForIp(ip, this.networkId) ??
-            configuredEntry?.serialNumber ??
+        // Determine serial: configured entry has highest priority (user's explicit config),
+        // then cache (for lookup-by-IP scenarios), then discovered
+        const serialNumber = configuredEntry?.serialNumber ??
+            this.globalStateManager.getSerialNumberForIp(ip, this.networkId) ??
             discovered?.serialNumber;
 
         // Get merged state from state map

--- a/src/deviceDiscovery/DeviceManager.ts
+++ b/src/deviceDiscovery/DeviceManager.ts
@@ -912,6 +912,17 @@ export class DeviceManager {
     private async healthCheckStaleDevices() {
         const now = Date.now();
         const staleDevices = this.getAllDevices().filter(device => {
+            // Skip devices that are already offline - no point health checking them
+            if (device.deviceState === 'offline') {
+                return false;
+            }
+
+            // Skip devices that are currently being health checked
+            const lastCheck = this.lastHealthCheckTime.get(device.ip) ?? 0;
+            if (now - lastCheck < this.STALE_DEVICE_AFTER_SCAN_MS) {
+                return false;
+            }
+
             if (!device.serialNumber) {
                 // No serial = no cache, consider stale
                 return true;
@@ -969,7 +980,7 @@ export class DeviceManager {
                     deviceInfo: info,
                     createdAt: Date.now()
                 });
-                this.globalStateManager.setSerialNumberForIp(this.networkId, ip, info.serialNumber);
+                this.globalStateManager.setSerialNumberForIp(this.networkId, ip, info['serial-number']);
             }
 
             this.fetchDeviceThrottleData.set(ip, { info: info, timestamp: Date.now() });

--- a/src/deviceDiscovery/DeviceManager.ts
+++ b/src/deviceDiscovery/DeviceManager.ts
@@ -185,20 +185,35 @@ export class DeviceManager {
     /**
      * Get device by encoded key string.
      * Key format: "s:{serialNumber}" or "i:{ip}"
+     * Respects includeNonDeveloperDevices setting.
      *
      * @param key - Encoded device key
-     * @returns Device with deviceInfo or undefined if not found
+     * @returns Device with deviceInfo or undefined if not found/filtered
      */
     public getDevice(key: string): RokuDevice | undefined;
     /**
      * Get device by IP or serial number.
      * Returns device with deviceInfo hydrated from cache.
+     * Respects includeNonDeveloperDevices setting.
      *
      * @param lookup - Object with optional ip and/or serialNumber
-     * @returns Device with deviceInfo or undefined if not found
+     * @returns Device with deviceInfo or undefined if not found/filtered
      */
     public getDevice(lookup: { ip?: string; serialNumber?: string }): RokuDevice | undefined;
     public getDevice(keyOrLookup: string | { ip?: string; serialNumber?: string }): RokuDevice | undefined {
+        const device = this.getDeviceUnfiltered(keyOrLookup as any);
+        if (device && !this.shouldShowDevice(device)) {
+            return undefined;
+        }
+        return device;
+    }
+
+    /**
+     * Get device without filtering. Used internally.
+     */
+    private getDeviceUnfiltered(key: string): RokuDevice | undefined;
+    private getDeviceUnfiltered(lookup: { ip?: string; serialNumber?: string }): RokuDevice | undefined;
+    private getDeviceUnfiltered(keyOrLookup: string | { ip?: string; serialNumber?: string }): RokuDevice | undefined {
         const device = this.buildMergedDevice(keyOrLookup as any);
 
         // If lookup object with both ip and serialNumber, verify exact match
@@ -212,12 +227,19 @@ export class DeviceManager {
     }
 
     /**
-     * Get a list of all roku devices known by this extension (by scanning, hardcoded lists, etc)
-     * Returns full devices with deviceInfo hydrated from cache.
+     * Get a list of all visible roku devices.
+     * Respects includeNonDeveloperDevices setting.
+     */
+    public getAllDevices(): RokuDevice[] {
+        return this.getAllDevicesUnfiltered().filter(d => this.shouldShowDevice(d));
+    }
+
+    /**
+     * Get all devices without filtering. Used internally.
      * Builds merged view on-demand from configuredDevices and discoveredDevices arrays.
      * Deduplication by serial number (preferred) or IP (fallback).
      */
-    public getAllDevices(): RokuDevice[] {
+    private getAllDevicesUnfiltered(): RokuDevice[] {
         const mergedDevices = new Map<string, RokuDevice>();
         const processedDiscoveredIndices = new Set<number>();
 
@@ -407,7 +429,7 @@ export class DeviceManager {
         // If already a device object with deviceState, use it directly; otherwise look it up
         const device = 'deviceState' in deviceOrLookup
             ? deviceOrLookup
-            : this.getDevice(deviceOrLookup);
+            : this.getDeviceUnfiltered(deviceOrLookup);
 
         if (!device) {
             return false;
@@ -464,6 +486,25 @@ export class DeviceManager {
      */
     private get showInfoMessages() {
         return util.getConfiguration('brightscript')?.deviceDiscovery?.showInfoMessages ?? true;
+    }
+
+    /**
+     * Should non-developer devices be included in device lists?
+     */
+    private get includeNonDeveloperDevices() {
+        return util.getConfiguration('brightscript')?.deviceDiscovery?.includeNonDeveloperDevices === true;
+    }
+
+    /**
+     * Should this device be shown via public API?
+     * Filters based on includeNonDeveloperDevices setting.
+     */
+    private shouldShowDevice(device: RokuDevice): boolean {
+        if (this.includeNonDeveloperDevices) {
+            return true;
+        }
+        // Must have device info AND be developer-enabled to show
+        return device.deviceInfo?.['developer-enabled'] === 'true';
     }
 
     /**
@@ -709,8 +750,8 @@ export class DeviceManager {
     }
 
     private async checkDevicesHealth(force = false, doSyntheticDelay = true): Promise<void> {
-        // Get all devices from merged view
-        const devices = this.getAllDevices();
+        // Get all devices (unfiltered - health check all devices)
+        const devices = this.getAllDevicesUnfiltered();
 
         // Filter to devices that need checking
         const devicesToCheck = force ? devices : devices.filter(d => {
@@ -757,7 +798,7 @@ export class DeviceManager {
      */
     private healthCheckStaleDevices(): void {
         const now = Date.now();
-        const staleDevices = this.getAllDevices().filter(device => {
+        const staleDevices = this.getAllDevicesUnfiltered().filter(device => {
             if (!device.serialNumber) {
                 // No serial = no cache, consider stale
                 return true;
@@ -844,42 +885,6 @@ export class DeviceManager {
         return false;
     }
 
-    /**
-     * Process a discovered IP address from SSDP.
-     * Fetches device info, applies filtering, and sets if valid.
-     * @param serialNumber - Serial number from SSDP USN header, if available
-     */
-    private async processDiscoveredIp(ip: string, serialNumber?: string): Promise<void> {
-        try {
-            const deviceInfo = await this.fetchDeviceInfo(ip, 8060);
-
-            const config: any = util.getConfiguration('brightscript') || {};
-            const includeNonDeveloperDevices = config?.deviceDiscovery?.includeNonDeveloperDevices === true;
-            const developerEnabled = deviceInfo['developer-enabled'] === 'true';
-
-            if (!includeNonDeveloperDevices && !developerEnabled) {
-                return;
-            }
-
-            // Extract serial and cache the deviceInfo
-            const serial = deviceInfo['serial-number']?.toString?.();
-
-            if (serial) {
-                this.globalStateManager.addLastSeenDevice(this.networkId, serial);
-            }
-
-            // Update discoveredDevices array
-            this.setDiscoveredDevice(ip, serial, 'online');
-
-            // Update configured device state if present
-            this.updateConfiguredDeviceState(ip, serial, 'online');
-
-            this.emitDevicesChanged();
-        } catch {
-            // Device unreachable - remove from discoveredDevices if present
-            this.removeDiscoveredDevice(ip);
-        }
-    }
 
     /**
      * Add or update a device in the discoveredDevices array.
@@ -1131,7 +1136,8 @@ export class DeviceManager {
     private setupFinderListeners() {
         this.finder.removeAllListeners();
         this.finder.on('found', (ip: string, options?: { serialNumber?: string }) => {
-            void this.processDiscoveredIp(ip, options?.serialNumber);
+            this.setDiscoveredDevice(ip, options?.serialNumber, 'pending');
+            this.emitDevicesChanged();
         });
 
         this.finder.on('device-online', (ip: string, serialNumber?: string) => {

--- a/src/deviceDiscovery/DeviceManager.ts
+++ b/src/deviceDiscovery/DeviceManager.ts
@@ -202,28 +202,7 @@ export class DeviceManager {
      * @returns Device with deviceInfo or undefined if not found
      */
     public getDevice(lookup: { ip?: string; serialNumber?: string }): RokuDevice | undefined;
-    /**
-     * Get device by IP or serial number, optionally probing the network first.
-     * When `fetch: true`, probes the IP before returning.
-     *
-     * @param lookup - Object with optional ip and/or serialNumber
-     * @param options - Options object with `fetch` flag
-     * @returns Promise resolving to device with deviceInfo or undefined if not found/unreachable
-     */
-    public getDevice(
-        lookup: { ip?: string; serialNumber?: string },
-        options: { fetch: true }
-    ): Promise<RokuDevice | undefined>;
-    public getDevice(
-        keyOrLookup: string | { ip?: string; serialNumber?: string },
-        options?: { fetch?: boolean }
-    ): RokuDevice | undefined | Promise<RokuDevice | undefined> {
-        // If fetch requested, probe first then return
-        if (options?.fetch && typeof keyOrLookup !== 'string' && keyOrLookup.ip) {
-            return this.resolveDevice({ ip: keyOrLookup.ip, serialNumber: keyOrLookup.serialNumber }, false)
-                .then(() => this.getDevice(keyOrLookup));
-        }
-
+    public getDevice(keyOrLookup: string | { ip?: string; serialNumber?: string }): RokuDevice | undefined {
         const device = this.buildMergedDevice(keyOrLookup as any);
 
         // If lookup object with both ip and serialNumber, verify exact match
@@ -234,6 +213,18 @@ export class DeviceManager {
         }
 
         return device;
+    }
+
+    /**
+     * Probe an IP address, add it to the discovered devices list if reachable, and return the device.
+     * Used when user manually enters an IP or before resolving a debug config.
+     *
+     * @param ip - The IP address to probe
+     * @returns The device if reachable, undefined otherwise
+     */
+    public async validateAndAddDevice(ip: string): Promise<RokuDevice | undefined> {
+        await this.resolveDevice({ ip: ip }, false);
+        return this.getDevice({ ip: ip });
     }
 
     /**

--- a/src/deviceDiscovery/DeviceManager.ts
+++ b/src/deviceDiscovery/DeviceManager.ts
@@ -688,44 +688,11 @@ export class DeviceManager {
 
         const configuredDevices = Array.from(deviceMap.values());
 
-        for (let i = this.devices.length - 1; i >= 0; i--) {
-            const device = this.devices[i];
+        // Track resolved IPs so removal loop can compare against them (not hostnames)
+        const configuredIps = new Set<string>();
 
-            // Skip non-configured devices
-            if (!device.isConfigured) {
-                continue;
-            }
-
-            // Check if still in config (by IP or serial)
-            const serial = this.getSerial(device);
-            const stillConfigured = configuredDevices.some(c => c.host === device.ip ||
-                (serial && c.serialNumber === serial)
-            );
-
-            if (stillConfigured) {
-                continue; // Still configured, keep it
-            }
-
-            // Device removed from config
-            if (device.isDiscovered) {
-                // Keep as discovered-only device
-                device.isConfigured = false;
-                device.configuredIn = [];
-                device.configuredName = undefined;
-                device.configuredPassword = undefined;
-            } else {
-                // Not discovered either, remove completely
-                this.devices.splice(i, 1);
-            }
-        }
-
+        // First: add/update configured devices (with DNS resolution)
         for (const configured of configuredDevices) {
-            // Determine serial number
-            let serialNumber = configured.serialNumber;
-            if (!serialNumber) {
-                serialNumber = this.globalStateManager.getSerialNumberForIp(configured.host, this.networkId);
-            }
-
             // Resolve hostname to IP address (handles both hostnames and IPs)
             let ip = configured.host;
             try {
@@ -733,6 +700,15 @@ export class DeviceManager {
             } catch {
                 // DNS lookup failed - keep original host value as fallback
                 // This allows IP addresses to work even if DNS resolution fails
+            }
+
+            // Track resolved IP for removal loop
+            configuredIps.add(ip);
+
+            // Determine serial number (must be after DNS resolution so IP lookup works)
+            let serialNumber = configured.serialNumber;
+            if (!serialNumber) {
+                serialNumber = this.globalStateManager.getSerialNumberForIp(ip, this.networkId);
             }
 
             // Check if device already exists by IP (primary key)
@@ -766,6 +742,37 @@ export class DeviceManager {
                 configuredName: configured.name,
                 configuredPassword: configured.password
             });
+        }
+
+        // Then: remove devices no longer in config (using resolved IPs, not hostnames)
+        for (let i = this.devices.length - 1; i >= 0; i--) {
+            const device = this.devices[i];
+
+            // Skip non-configured devices
+            if (!device.isConfigured) {
+                continue;
+            }
+
+            // Check if still in config (by resolved IP or serial)
+            const serial = this.getSerial(device);
+            const stillConfigured = configuredIps.has(device.ip) ||
+                configuredDevices.some(c => serial && c.serialNumber === serial);
+
+            if (stillConfigured) {
+                continue;
+            }
+
+            // Device removed from config
+            if (device.isDiscovered) {
+                // Keep as discovered-only device
+                device.isConfigured = false;
+                device.configuredIn = [];
+                device.configuredName = undefined;
+                device.configuredPassword = undefined;
+            } else {
+                // Not discovered either, remove completely
+                this.devices.splice(i, 1);
+            }
         }
     }
 

--- a/src/deviceDiscovery/DeviceManager.ts
+++ b/src/deviceDiscovery/DeviceManager.ts
@@ -84,10 +84,9 @@ export class DeviceManager {
             this.networkId = getNetworkHash();
             this.fetchDeviceThrottleData.clear();
 
-            //clear and reload all devices anytime this network changes
-            this.devices = [];
+            //clear and reload discovered devices anytime this network changes
+            this.discoveredDevices = [];
             this.loadLastSeenDevices();
-            this.loadConfiguredDevices().catch(e => console.error(e));
 
             this.restartRokuFinder();
 
@@ -474,88 +473,6 @@ export class DeviceManager {
     }
 
     /**
-     * Remove a device from the discoveredDevices array and update lastSeenDevices.
-     */
-    private setDevice(input: Omit<DeviceEntry, 'key'>): void {
-        const index = this.devices.findIndex(d => d.ip === input.ip);
-        const isNewDevice = index < 0;
-
-        // Compute key: serial-based when available, IP-based as fallback
-        const key = input.serialNumber ? `s:${input.serialNumber}` : `i:${input.ip}`;
-        let device: DeviceEntry = { ...input, key: key };
-
-        if (isNewDevice) {
-            this.devices.push(device);
-        } else {
-            // Merge: incoming wins for most fields, but preserve configured properties
-            const existing = this.devices[index];
-            device = this.devices[index] = {
-                ...existing,
-                ...device,
-                // Preserve configured status from either side
-                isDiscovered: device.isDiscovered ?? existing.isDiscovered,
-                isConfigured: device.isConfigured ?? existing.isConfigured,
-                configuredIn: device.configuredIn ?? existing.configuredIn,
-                configuredName: device.configuredName ?? existing.configuredName,
-                configuredPassword: device.configuredPassword ?? existing.configuredPassword
-            };
-        }
-
-        this.emitDevicesChanged();
-    }
-
-    /**
-     * Deduplicate devices by serial number when a device changes IP (e.g., DHCP reassignment).
-     * If an existing device with the same serial exists at a DIFFERENT IP, removes it and
-     * returns its configured properties to be preserved on the new entry.
-     *
-     * @param newIp - The IP address where the device was just discovered/resolved
-     * @param serial - The serial number from the device
-     * @returns Configured properties to preserve, or undefined if no deduplication needed
-     */
-    private dedupeBySerial(newIp: string, serial: string): Pick<DeviceEntry, 'isConfigured' | 'configuredIn' | 'configuredName' | 'configuredPassword'> | undefined {
-        // Find existing device with same serial at a DIFFERENT IP
-        const existingDevice = this.devices.find(d => d.ip !== newIp && this.getSerial(d) === serial);
-
-        if (!existingDevice) {
-            return undefined;
-        }
-
-        // Capture configured properties to preserve
-        const preserved = {
-            isConfigured: existingDevice.isConfigured,
-            configuredIn: existingDevice.configuredIn,
-            configuredName: existingDevice.configuredName,
-            configuredPassword: existingDevice.configuredPassword
-        };
-
-        // Transfer lastUsedDeviceIp to new IP if it was pointing to old device
-        // (User's "active device" should follow the physical device, not the stale IP)
-        if (this.lastUsedDeviceIp === existingDevice.ip) {
-            this.lastUsedDeviceIp = newIp;
-        }
-
-        // Remove old entry directly from array (don't use removeDevice to avoid
-        // side effects like removing from lastSeenDevices - device still exists)
-        this.devices = this.devices.filter(d => d.ip !== existingDevice.ip);
-
-        // Remove from discovered devices
-        this.removeDiscoveredDevice(deviceIp);
-
-        // Remove from last seen devices (if has serial)
-        if (serial) {
-            this.globalStateManager.removeLastSeenDevice(this.networkId, serial);
-        }
-
-        // Clear lastUsedDeviceIp if the removed device was the last used
-        if (this.lastUsedDeviceIp === deviceIp) {
-            this.lastUsedDeviceIp = undefined;
-        }
-
-        this.emitDevicesChanged();
-    }
-
-    /**
      * Load last seen devices from cache.
      * Resets configured devices to pending and clears discovered devices.
      * Last seen devices are used to pre-populate the IP→serial mapping.
@@ -584,13 +501,8 @@ export class DeviceManager {
                 // If cache is fresh (within 5 minutes), treat as online
                 const cacheAge = Date.now() - cached.createdAt;
                 const isFresh = cacheAge < this.FRESH_CACHE_THRESHOLD_MS;
-                // Create device with serial (key computed by setDevice)
-                this.setDevice({
-                    ip: ip,
-                    serialNumber: serialNumber,
-                    deviceState: isFresh ? 'online' : 'pending',
-                    isDiscovered: false
-                });
+                // Add to discoveredDevices array
+                this.setDiscoveredDevice(ip, serialNumber, isFresh ? 'online' : 'pending');
             } else {
                 // No cached info - remove stale entry
                 this.globalStateManager.removeLastSeenDevice(this.networkId, serialNumber);
@@ -882,7 +794,7 @@ export class DeviceManager {
      */
     private healthCheckStaleDevices(): void {
         const now = Date.now();
-        const staleDevices = this.devices.filter(device => {
+        const staleDevices = this.getAllDevices().filter(device => {
             if (!device.serialNumber) {
                 // No serial = no cache, consider stale
                 return true;
@@ -1051,6 +963,30 @@ export class DeviceManager {
         if (idx >= 0) {
             this.discoveredDevices.splice(idx, 1);
         }
+    }
+
+    /**
+     * Remove a device by IP. Clears from discoveredDevices, updates lastSeenDevices,
+     * and clears lastUsedDeviceIp if it matches.
+     */
+    private removeDevice(ip: string): void {
+        // Find the device first to get its serial number
+        const device = this.discoveredDevices.find(d => d.ip === ip);
+
+        // Remove from discoveredDevices array
+        this.removeDiscoveredDevice(ip);
+
+        // Clear lastUsedDeviceIp if it matches
+        if (this.lastUsedDeviceIp === ip) {
+            this.lastUsedDeviceIp = undefined;
+        }
+
+        // Remove from lastSeenDevices if we have a serial
+        if (device?.serialNumber) {
+            this.globalStateManager.removeLastSeenDevice(this.networkId, device.serialNumber);
+        }
+
+        this.emitDevicesChanged();
     }
 
     /**
@@ -1240,11 +1176,7 @@ export class DeviceManager {
         });
 
         this.finder.on('lost', (ip: string) => {
-            // Find and remove device by IP
-            const device = this.getDeviceEntry({ ip: ip });
-            if (device) {
-                this.removeDevice(device.ip);
-            }
+            this.removeDevice(ip);
         });
 
         // Forward scan events from RokuFinder

--- a/src/deviceDiscovery/DeviceManager.ts
+++ b/src/deviceDiscovery/DeviceManager.ts
@@ -791,9 +791,7 @@ export class DeviceManager {
 
             // Only emit if state actually changed
             this.setDeviceState({ ip: device.ip, serialNumber: serial }, 'online');
-            if (currentStateObject.state !== 'online') {
-                this.emitDevicesChanged();
-            }
+            this.emitDevicesChanged();
             return true;
         } else {
             // Remove from discoveredDevices (ephemeral - offline devices are removed)
@@ -803,9 +801,7 @@ export class DeviceManager {
             // Use known serial if available for proper key management
             this.setDeviceState({ ip: device.ip, serialNumber: knownSerial }, 'offline');
 
-            if (currentStateObject.state !== 'offline') {
-                this.emitDevicesChanged();
-            }
+            this.emitDevicesChanged();
             return false;
         }
     }

--- a/src/deviceDiscovery/DeviceManager.ts
+++ b/src/deviceDiscovery/DeviceManager.ts
@@ -143,6 +143,7 @@ export class DeviceManager {
     private discoveredDevices: DiscoveredDeviceEntry[] = [];
     private deviceStates = new Map<DeviceStateKey, DeviceStateEntry>();
     private scanNeeded = false;
+    private suppressEmitDevicesChanged = false;
     private lastUsedDeviceIp: string | undefined = undefined;
     private networkId: string;
 
@@ -223,6 +224,7 @@ export class DeviceManager {
      * @returns The device if reachable, undefined otherwise
      */
     public async validateAndAddDevice(ip: string): Promise<RokuDevice | undefined> {
+        this.setDiscoveredDevice(ip, undefined);
         await this.resolveDevice({ ip: ip }, false);
         return this.getDevice({ ip: ip });
     }
@@ -240,6 +242,16 @@ export class DeviceManager {
      * Respects includeNonDeveloperDevices setting.
      */
     public getDevicesForUI(): RokuDevice[] {
+        return this.buildAllDevices().filter(d => this.shouldShowDevice(d));
+    }
+
+    public async healthCheckStaleDevicesThenGetDevicesForUI(): Promise<RokuDevice[]> {
+        this.suppressEmitDevicesChanged = true;
+        try {
+            await this.healthCheckStaleDevices();
+        } finally {
+            this.suppressEmitDevicesChanged = false;
+        }
         return this.buildAllDevices().filter(d => this.shouldShowDevice(d));
     }
 
@@ -602,8 +614,7 @@ export class DeviceManager {
         if (this.includeNonDeveloperDevices) {
             return true;
         }
-        // Must have device info AND be developer-enabled to show
-        return device.deviceInfo?.['developer-enabled'] === 'true';
+        return device?.deviceInfo?.['developer-enabled'] !== 'false';
     }
 
     /**
@@ -732,7 +743,7 @@ export class DeviceManager {
         }
     }
 
-    private async resolveDevice(device: RokuDevice | { ip: string; serialNumber?: string }, doSyntheticDelay = true): Promise<boolean> {
+    private async resolveDevice(device: RokuDevice | { ip: string }, doSyntheticDelay = true): Promise<boolean> {
         // Extract serial from device if available (for proper state key management)
         const knownSerial = 'serialNumber' in device ? device.serialNumber : undefined;
 
@@ -776,7 +787,9 @@ export class DeviceManager {
             }
 
             // Update discoveredDevices array (handles mismatch detection internally)
-            this.setDiscoveredDevice(device.ip, serial);
+            if ('isDiscovered' in device && device.isDiscovered) {
+                this.setDiscoveredDevice(device.ip, serial);
+            }
 
             // Mark any configured devices at this IP with different serials as offline
             this.markMismatchedConfiguredDevicesOffline(device.ip, serial);
@@ -896,7 +909,7 @@ export class DeviceManager {
      * Health check devices that didn't respond to a scan.
      * Called after scan-ended. Checks devices whose cache is older than STALE_DEVICE_AFTER_SCAN_MS.
      */
-    private healthCheckStaleDevices(): void {
+    private async healthCheckStaleDevices() {
         const now = Date.now();
         const staleDevices = this.getAllDevices().filter(device => {
             if (!device.serialNumber) {
@@ -915,10 +928,7 @@ export class DeviceManager {
             return;
         }
 
-        // Health check each stale device
-        for (const device of staleDevices) {
-            void this.resolveDevice(device, false);
-        }
+        await Promise.all(staleDevices.map(device => this.resolveDevice(device, false)));
     }
 
     /**
@@ -1252,7 +1262,7 @@ export class DeviceManager {
         this.finder.on('scan-ended', () => {
             this.emitter.emit('scan-ended');
             // Health check devices that didn't respond to the scan (stale cache)
-            this.healthCheckStaleDevices();
+            this.healthCheckStaleDevices().catch(() => { });
         });
     }
 
@@ -1312,6 +1322,9 @@ export class DeviceManager {
     }
 
     private emitDevicesChanged = throttleBounce(() => {
+        if (this.suppressEmitDevicesChanged) {
+            return;
+        }
         this.emitter.emit('devices-changed');
     }, this.DEVICES_CHANGED_DEBOUNCE_MS);
 

--- a/src/deviceDiscovery/DeviceManager.ts
+++ b/src/deviceDiscovery/DeviceManager.ts
@@ -866,20 +866,19 @@ export class DeviceManager {
             if (entryBySerial) {
                 // Found configured device with matching serial - update its resolved IP
                 entryBySerial.resolvedIp = ip;
-                return;
             }
         }
 
-        // No configured device with this serial - check if there's one configured at this IP
-        const entryByIp = this.getConfiguredDevice({ ip: ip });
-        if (entryByIp) {
-            if (entryByIp.serialNumber && serialNumber && entryByIp.serialNumber !== serialNumber) {
-                // Configured device has a different serial than what's actually at this IP
-                // Mark the configured device as offline (it's not where it should be)
-                this.setDeviceState({ serialNumber: entryByIp.serialNumber }, 'offline');
-            } else if (!entryByIp.serialNumber) {
+        // Mark all OTHER configured devices at this IP (with different serials) as offline
+        for (const entry of this.configuredDevices) {
+            const isAtThisIp = entry.host === ip || entry.resolvedIp === ip;
+            const hasDifferentSerial = entry.serialNumber && serialNumber && entry.serialNumber !== serialNumber;
+
+            if (isAtThisIp && hasDifferentSerial) {
+                this.setDeviceState({ serialNumber: entry.serialNumber }, 'offline');
+            } else if (isAtThisIp && !entry.serialNumber) {
                 // Configured device has no serial - update its resolvedIp via IP matching
-                entryByIp.resolvedIp = ip;
+                entry.resolvedIp = ip;
             }
         }
     }

--- a/src/deviceDiscovery/DeviceManager.ts
+++ b/src/deviceDiscovery/DeviceManager.ts
@@ -52,6 +52,11 @@ export class DeviceManager {
                 this.emitDevicesChanged();
             }
 
+            //if the `includeNonDeveloperDevices` setting was changed, refresh the UI to show/hide devices
+            if (event?.affectsConfiguration('brightscript.deviceDiscovery.includeNonDeveloperDevices')) {
+                this.emitDevicesChanged();
+            }
+
             //if the `devices` setting was changed, re-apply configured devices
             if (event?.affectsConfiguration('brightscript.devices')) {
                 this.loadConfiguredDevices().then(() => {
@@ -907,11 +912,16 @@ export class DeviceManager {
         // IP dedupe: find existing entry at same IP
         const existingIdx = this.discoveredDevices.findIndex(d => d.ip === ip);
         if (existingIdx >= 0) {
+            const existing = this.discoveredDevices[existingIdx];
+            // Don't downgrade from online to pending
+            const newState = (existing.deviceState === 'online' && deviceState === 'pending')
+                ? 'online'
+                : deviceState;
             // Update existing entry
             this.discoveredDevices[existingIdx] = {
                 ip: ip,
-                serialNumber: serialNumber,
-                deviceState: deviceState
+                serialNumber: serialNumber ?? existing.serialNumber,
+                deviceState: newState
             };
         } else {
             // Add new entry

--- a/src/deviceDiscovery/DeviceManager.ts
+++ b/src/deviceDiscovery/DeviceManager.ts
@@ -746,18 +746,12 @@ export class DeviceManager {
             // Extract serial from response, fall back to known serial
             const serial = deviceInfo['serial-number']?.toString?.() ?? knownSerial;
 
-            // Check for serial mismatch before updating state
-            // If a different device is now at this IP, reload configurations
-            if (this.checkForSerialMismatch(device.ip, serial)) {
-                void this.loadConfiguredDevices();
-            }
-
             if (serial) {
                 // Add to last seen devices (successfully resolved with serial)
                 this.globalStateManager.addLastSeenDevice(this.networkId, serial);
             }
 
-            // Update discoveredDevices array
+            // Update discoveredDevices array (handles mismatch detection internally)
             this.setDiscoveredDevice(device.ip, serial);
 
             // Update resolvedIp for configured device if applicable
@@ -787,9 +781,12 @@ export class DeviceManager {
      * a device has changed IPs or a different device is now at a known IP.
      *
      * Mismatch scenarios:
-     * - deviceInfo for IP1 expected SerialA, got SerialB
-     * - deviceInfo for IP1 (no serial known) returns any serial
-     * - SSDP arrives with IP1 + SerialB but lists had IP1 + SerialA
+     * - Stored IP→serial map has SerialA for IP1, but got SerialB
+     * - Discovered device at IP1 had SerialA, but now has SerialB
+     *
+     * Note: We intentionally don't check configured device serials here.
+     * If a user misconfigured a serial, reloading won't fix it and would
+     * cause an infinite reload loop.
      *
      * @param ip - The IP address
      * @param newSerial - The newly discovered serial number
@@ -809,12 +806,6 @@ export class DeviceManager {
             return true;
         }
 
-        // Check if any configured device at this IP has a different serial
-        const configuredDevice = this.getConfiguredDevice({ ip: ip });
-        if (configuredDevice?.serialNumber && configuredDevice.serialNumber !== newSerial) {
-            // Configured device has a different serial than what's actually at the IP
-            return true;
-        }
 
         // Check if any discovered device at this IP has a different serial
         const discoveredDevice = this.discoveredDevices.find(d => d.ip === ip);
@@ -979,6 +970,9 @@ export class DeviceManager {
      * Also sets device state using intelligent defaults (cache freshness check).
      */
     private setDiscoveredDevice(ip: string, serialNumber: string | undefined): void {
+        // Check for serial mismatch before updating state
+        const hasMismatch = this.checkForSerialMismatch(ip, serialNumber);
+
         // Serial dedupe: if same serial exists at different IP, remove old entry
         if (serialNumber) {
             const oldIdx = this.discoveredDevices.findIndex(d => d.ip !== ip && d.serialNumber === serialNumber);
@@ -1012,6 +1006,11 @@ export class DeviceManager {
 
         // Set device state using intelligent defaults (preserves existing online state or uses cache freshness)
         this.setDeviceState({ serialNumber: serialNumber, ip: ip });
+
+        // If a different device is now at this IP, reload configurations
+        if (hasMismatch) {
+            this.loadConfiguredDevices().catch(() => { });
+        }
     }
 
     /**
@@ -1221,12 +1220,6 @@ export class DeviceManager {
     private setupFinderListeners() {
         this.finder.removeAllListeners();
         this.finder.on('found', (ip: string, options?: { serialNumber?: string }) => {
-            // Check for serial mismatch before updating state
-            // If a different device is now at this IP, reload configurations
-            if (this.checkForSerialMismatch(ip, options?.serialNumber)) {
-                void this.loadConfiguredDevices();
-            }
-
             this.setDiscoveredDevice(ip, options?.serialNumber);
             this.emitDevicesChanged();
         });

--- a/src/deviceDiscovery/DeviceManager.ts
+++ b/src/deviceDiscovery/DeviceManager.ts
@@ -57,10 +57,10 @@ export class DeviceManager {
                 this.emitDevicesChanged();
             }
 
-            //if the `devices` setting was changed, re-apply configured devices
+            //if the `devices` setting was changed, re-apply configured devices and health check them
             if (event?.affectsConfiguration('brightscript.devices')) {
                 this.loadConfiguredDevices().then(() => {
-                    this.emitDevicesChanged();
+                    return this.healthCheckAllDevices(false, true);
                 }).catch(() => { });
             }
 
@@ -93,7 +93,6 @@ export class DeviceManager {
         });
         this.networkChangeMonitor = new NetworkChangeMonitor(() => {
             this.networkId = getNetworkHash();
-            this.fetchDeviceThrottleData.clear();
 
             //reset all device states to pending - need to re-verify on new network
             this.deviceStates.clear();
@@ -143,7 +142,6 @@ export class DeviceManager {
     private discoveredDevices: DiscoveredDeviceEntry[] = [];
     private deviceStates = new Map<DeviceStateKey, DeviceStateEntry>();
     private scanNeeded = false;
-    private suppressEmitDevicesChanged = false;
     private lastUsedDeviceIp: string | undefined = undefined;
     private networkId: string;
 
@@ -153,9 +151,8 @@ export class DeviceManager {
     private finder = new RokuFinder();
 
     // Health check tracking and cooldowns
-    private lastHealthCheckTime = new Map<string, number>();
     private resolveDeviceSequence = new Map<string, number>();
-    private readonly HEALTH_CHECK_COOLDOWN_MS = 5 * 60 * 1_000; // 5 minutes
+    private readonly DEVICE_INFO_CACHE_MS = 5 * 60 * 1_000; // 5 minutes - cache duration for fetchDeviceInfo
     private readonly FRESH_CACHE_THRESHOLD_MS = 5 * 60 * 1_000; // 5 minutes - cache fresher than this = online on load
     private readonly STALE_DEVICE_AFTER_SCAN_MS = 10_000; // 10 seconds - health check devices with cache older than this after scan
     public static readonly HEALTH_CHECK_TIMEOUT_MS = 2_000; // 2 seconds
@@ -243,16 +240,6 @@ export class DeviceManager {
      * Respects includeNonDeveloperDevices setting.
      */
     public getDevicesForUI(): RokuDevice[] {
-        return this.buildAllDevices().filter(d => this.shouldShowDevice(d));
-    }
-
-    public async healthCheckStaleDevicesThenGetDevicesForUI(): Promise<RokuDevice[]> {
-        this.suppressEmitDevicesChanged = true;
-        try {
-            await this.healthCheckStaleDevices();
-        } finally {
-            this.suppressEmitDevicesChanged = false;
-        }
         return this.buildAllDevices().filter(d => this.shouldShowDevice(d));
     }
 
@@ -472,9 +459,6 @@ export class DeviceManager {
         // Clear discovered devices (ephemeral)
         this.discoveredDevices = [];
 
-        // Clear short-lived device info cache
-        this.fetchDeviceThrottleData.clear();
-
         // Only clear lastUsedDeviceIp if it belonged to a discovered-only device
         if (this.lastUsedDeviceIp) {
             const stillExists = this.configuredDevices.some(
@@ -502,17 +486,10 @@ export class DeviceManager {
 
         // Clear all timestamps and per-device state
         this.lastScanDate = null;
-        this.lastHealthCheckTime.clear();
         this.resolveDeviceSequence.clear();
         this.deviceStates.clear();
 
-        // Clear cache cleanup timer
-        if (this.fetchDeviceInfoThrottleTimer) {
-            clearTimeout(this.fetchDeviceInfoThrottleTimer);
-            this.fetchDeviceInfoThrottleTimer = null;
-        }
-
-        // Clear discovered devices and short-lived caches
+        // Clear discovered devices
         this.clearCurrentDeviceList();
     }
 
@@ -526,17 +503,8 @@ export class DeviceManager {
             return false;
         }
 
-        // If not forcing, respect the per-device cooldown
-        if (!force) {
-            const lastCheck = this.lastHealthCheckTime.get(device.ip) ?? 0;
-            const now = Date.now();
-            if (now - lastCheck <= this.HEALTH_CHECK_COOLDOWN_MS) {
-                return true;
-            }
-            this.lastHealthCheckTime.set(device.ip, now);
-        }
-
-        const isHealthy = await this.resolveDevice(device, doSyntheticDelay);
+        // Cooldown is handled by fetchDeviceInfo cache; force bypasses it
+        const isHealthy = await this.resolveDevice(device, doSyntheticDelay, force);
         if (!isHealthy && device.isDiscovered) {
             // force a scan if passive scan is permitted
             this.refresh(this.deviceDiscoveryEnabled);
@@ -581,9 +549,6 @@ export class DeviceManager {
         this.configuredDevices = [];
         this.discoveredDevices = [];
         this.emitter.removeAllListeners();
-
-        //clear any timeouts
-        clearTimeout(this.fetchDeviceInfoThrottleTimer);
     }
 
     /**
@@ -742,9 +707,11 @@ export class DeviceManager {
             // Set device state using configured serial (not cache - cache might be stale)
             this.setDeviceState({ serialNumber: configured.serialNumber, ip: ip });
         }
+
+        this.emitDevicesChanged();
     }
 
-    private async resolveDevice(device: RokuDevice | { ip: string }, doSyntheticDelay = true): Promise<boolean> {
+    private async resolveDevice(device: RokuDevice | { ip: string }, doSyntheticDelay = true, force = false): Promise<boolean> {
         // Extract serial from device if available (for proper state key management)
         const knownSerial = 'serialNumber' in device ? device.serialNumber : undefined;
 
@@ -760,16 +727,28 @@ export class DeviceManager {
             this.emitDevicesChanged();
         }
 
-        // Fetch latest device info from the network (with short-lived cache)
+        // Get device info from cache or network
         let deviceInfo: DeviceInfoRaw | undefined;
-        try {
-            deviceInfo = await this.fetchDeviceInfo(device.ip, 8060);
 
-            if (doSyntheticDelay) {
-                await this.randomDelay(400, 1_000);
+        // Try to find cached data via serial number
+        const serialForCache = knownSerial ?? this.globalStateManager.getSerialNumberForIp(device.ip, this.networkId);
+        const cached = serialForCache ? this.globalStateManager.getCachedDevice(serialForCache) : undefined;
+        const cacheIsFresh = cached && Date.now() - cached.createdAt < this.DEVICE_INFO_CACHE_MS;
+
+        if (!force && cacheIsFresh) {
+            // Use cached data
+            deviceInfo = cached.deviceInfo as DeviceInfoRaw;
+        } else {
+            // Fetch fresh data from network
+            try {
+                deviceInfo = await this.fetchDeviceInfo(device.ip, 8060);
+
+                if (doSyntheticDelay) {
+                    await this.randomDelay(400, 1_000);
+                }
+            } catch {
+                deviceInfo = undefined;
             }
-        } catch {
-            deviceInfo = undefined;
         }
 
         // Only apply result if this is still the latest request for this device
@@ -872,30 +851,23 @@ export class DeviceManager {
     }
 
     private async healthCheckAllDevices(force = false, doSyntheticDelay = true): Promise<void> {
-        // Get all devices (health check all devices)
+        // Get all devices
         const devices = this.getAllDevices();
 
-        // Filter to devices that need checking
-        const devicesToCheck = force ? devices : devices.filter(d => {
-            const lastCheck = this.lastHealthCheckTime.get(d.ip) ?? 0;
-            return Date.now() - lastCheck > this.HEALTH_CHECK_COOLDOWN_MS;
-        });
-
-        if (devicesToCheck.length === 0) {
+        if (devices.length === 0) {
             return;
         }
 
         // Set all to pending and emit before async work
-        for (const device of devicesToCheck) {
+        for (const device of devices) {
             this.setDeviceState({ ip: device.ip, serialNumber: device.serialNumber }, 'pending');
-            this.lastHealthCheckTime.set(device.ip, Date.now());
         }
         this.emitDevicesChanged();
 
-        // Check all devices
+        // Check all devices (force flag bypasses fetch cache)
         let needsScan = false;
-        await Promise.all(devicesToCheck.map(async (device) => {
-            const isHealthy = await this.resolveDevice(device, doSyntheticDelay);
+        await Promise.all(devices.map(async (device) => {
+            const isHealthy = await this.resolveDevice(device, doSyntheticDelay, force);
             if (!isHealthy && device.isDiscovered) {
                 needsScan = true;
             }
@@ -918,12 +890,6 @@ export class DeviceManager {
                 return false;
             }
 
-            // Skip devices that are currently being health checked
-            const lastCheck = this.lastHealthCheckTime.get(device.ip) ?? 0;
-            if (now - lastCheck < this.STALE_DEVICE_AFTER_SCAN_MS) {
-                return false;
-            }
-
             if (!device.serialNumber) {
                 // No serial = no cache, consider stale
                 return true;
@@ -940,35 +906,15 @@ export class DeviceManager {
             return;
         }
 
+        // Cooldown is handled by fetchDeviceInfo cache
         await Promise.all(staleDevices.map(device => this.resolveDevice(device, false)));
     }
 
     /**
-     * Reset the cache cleanup timer. After inactivity, the cache will be cleared.
-     */
-    private resetCacheCleanupTimer(): void {
-        if (this.fetchDeviceInfoThrottleTimer) {
-            clearTimeout(this.fetchDeviceInfoThrottleTimer);
-        }
-        this.fetchDeviceInfoThrottleTimer = setTimeout(() => {
-            this.fetchDeviceThrottleData.clear();
-            this.fetchDeviceInfoThrottleTimer = null;
-        }, 10_000);
-    }
-
-    /**
-     * Cached wrapper around rokuDeploy.getDeviceInfo to prevent duplicate calls
-     * when health checks and SSDP responses race during refresh.
-     *
-     * We cache many things about this in globalState since we just verified this device really exists at that location
+     * Fetch device info from the network. Always makes a network request.
+     * Caches the result in globalStateManager for future lookups.
      */
     private async fetchDeviceInfo(ip: string, port: number): Promise<DeviceInfoRaw> {
-        this.resetCacheCleanupTimer();
-
-        const cached = this.fetchDeviceThrottleData.get(ip);
-        if (cached && Date.now() - cached.timestamp < 5_000) {
-            return cached.info;
-        }
         try {
             const info = await rokuDeploy.getDeviceInfo({
                 host: ip,
@@ -984,15 +930,12 @@ export class DeviceManager {
                 this.globalStateManager.setSerialNumberForIp(this.networkId, ip, info['serial-number']);
             }
 
-            this.fetchDeviceThrottleData.set(ip, { info: info, timestamp: Date.now() });
             return info;
         } catch (e) {
             console.error(e);
             return undefined;
         }
     }
-    private fetchDeviceThrottleData = new Map<string, { info: DeviceInfoRaw; timestamp: number }>();
-    private fetchDeviceInfoThrottleTimer: ReturnType<typeof setTimeout> | null = null;
 
     /**
      * Discover all Roku devices on the network and watch for new ones that connect
@@ -1313,9 +1256,6 @@ export class DeviceManager {
     }
 
     private emitDevicesChanged = throttleBounce(() => {
-        if (this.suppressEmitDevicesChanged) {
-            return;
-        }
         this.emitter.emit('devices-changed');
     }, this.DEVICES_CHANGED_DEBOUNCE_MS);
 

--- a/src/deviceDiscovery/DeviceManager.ts
+++ b/src/deviceDiscovery/DeviceManager.ts
@@ -482,13 +482,10 @@ export class DeviceManager {
         // Stop any in-progress scan (finder.stop() emits scan-ended if scanning)
         this.finder.stop();
 
-        // Clear current device list
+        // Clear discovered devices and short-lived caches
         this.clearCurrentDeviceList();
 
-        // Clear new arrays completely (clearCurrentDeviceList already cleared discoveredDevices)
-        this.configuredDevices = [];
-
-        // Clear global state
+        // Clear persisted global state
         this.globalStateManager.clearLastSeenDevices();
         this.globalStateManager.clearDeviceCache();
         this.globalStateManager.clearSerialNumberByIpForNetwork();
@@ -725,24 +722,13 @@ export class DeviceManager {
 
             const ip = resolvedIp ?? configured.host;
 
-            // Look up serial from cache if not provided in config
-            let serialNumber = configured.serialNumber;
-            if (!serialNumber) {
-                serialNumber = this.globalStateManager.getSerialNumberForIp(ip, this.networkId);
-            }
-
             this.configuredDevices.push({
                 ...configured,
                 resolvedIp: resolvedIp
             });
 
-            // Set up IP→serial mapping if we have serial
-            if (serialNumber) {
-                this.globalStateManager.setSerialNumberForIp(this.networkId, ip, serialNumber);
-            }
-
-            // Set device state using intelligent defaults (preserves existing state or uses cache freshness)
-            this.setDeviceState({ serialNumber: serialNumber, ip: ip });
+            // Set device state using configured serial (not cache - cache might be stale)
+            this.setDeviceState({ serialNumber: configured.serialNumber, ip: ip });
         }
     }
 
@@ -792,8 +778,8 @@ export class DeviceManager {
             // Update discoveredDevices array (handles mismatch detection internally)
             this.setDiscoveredDevice(device.ip, serial);
 
-            // Update resolvedIp for configured device if applicable
-            this.updateConfiguredDeviceResolvedIp(device.ip, serial);
+            // Mark any configured devices at this IP with different serials as offline
+            this.markMismatchedConfiguredDevicesOffline(device.ip, serial);
 
             // Set state to online
             this.setDeviceState({ ip: device.ip, serialNumber: serial }, 'online');
@@ -856,29 +842,17 @@ export class DeviceManager {
     }
 
     /**
-     * Update resolvedIp for a configured device by IP or serial number.
-     * Also marks configured devices as offline when a different device is found at their IP.
+     * Mark configured devices as offline when a different device is found at their IP.
+     * Note: resolvedIp is only set during DNS resolution in loadConfiguredDevices(),
+     * not updated here when discovering devices.
      */
-    private updateConfiguredDeviceResolvedIp(ip: string, serialNumber: string | undefined): void {
-        // Try to find by serial first (more reliable)
-        if (serialNumber) {
-            const entryBySerial = this.getConfiguredDevice({ serialNumber: serialNumber });
-            if (entryBySerial) {
-                // Found configured device with matching serial - update its resolved IP
-                entryBySerial.resolvedIp = ip;
-            }
-        }
-
-        // Mark all OTHER configured devices at this IP (with different serials) as offline
+    private markMismatchedConfiguredDevicesOffline(ip: string, serialNumber: string | undefined): void {
         for (const entry of this.configuredDevices) {
             const isAtThisIp = entry.host === ip || entry.resolvedIp === ip;
             const hasDifferentSerial = entry.serialNumber && serialNumber && entry.serialNumber !== serialNumber;
 
             if (isAtThisIp && hasDifferentSerial) {
                 this.setDeviceState({ serialNumber: entry.serialNumber }, 'offline');
-            } else if (isAtThisIp && !entry.serialNumber) {
-                // Configured device has no serial - update its resolvedIp via IP matching
-                entry.resolvedIp = ip;
             }
         }
     }
@@ -979,9 +953,9 @@ export class DeviceManager {
                 remotePort: port,
                 timeout: DeviceManager.HEALTH_CHECK_TIMEOUT_MS
             });
-            if (info?.serialNumber) {
-                this.globalStateManager.setCachedDevice(info.serialNumber, {
-                    serialNumber: info.serialNumber,
+            if (info['serial-number']) {
+                this.globalStateManager.setCachedDevice(info['serial-number'], {
+                    serialNumber: info['serial-number'],
                     deviceInfo: info,
                     createdAt: Date.now()
                 });
@@ -1096,17 +1070,6 @@ export class DeviceManager {
     }
 
     /**
-     * Find a configured device by serial number or IP.
-     */
-    private getConfiguredDevice(lookup: { serialNumber: string } | { ip: string }): ConfiguredDeviceEntry | undefined {
-        if ('serialNumber' in lookup) {
-            return this.configuredDevices.find(d => d.serialNumber === lookup.serialNumber);
-        } else {
-            return this.configuredDevices.find(d => d.resolvedIp === lookup.ip || d.host === lookup.ip);
-        }
-    }
-
-    /**
      * Build a merged RokuDevice by decoding an encoded key (s:serial or i:ip).
      */
     private buildMergedDevice(key: string): RokuDevice | undefined;
@@ -1184,11 +1147,12 @@ export class DeviceManager {
             ip = configuredEntry.host;
         }
 
-        // Determine serial: configured entry has highest priority (user's explicit config),
-        // then cache (for lookup-by-IP scenarios), then discovered
+        // Determine serial: configured > discovered > cache
+        // Configured is user's explicit config, discovered is fresh network data,
+        // cache is fallback for initial load before discovery runs
         const serialNumber = configuredEntry?.serialNumber ??
-            this.globalStateManager.getSerialNumberForIp(ip, this.networkId) ??
-            discovered?.serialNumber;
+            discovered?.serialNumber ??
+            this.globalStateManager.getSerialNumberForIp(ip, this.networkId);
 
         // Get merged state from state map
         const deviceState = this.getDeviceState({ serialNumber: serialNumber, ip: ip });

--- a/src/deviceDiscovery/DeviceManager.ts
+++ b/src/deviceDiscovery/DeviceManager.ts
@@ -155,6 +155,7 @@ export class DeviceManager {
     private readonly DEVICE_INFO_CACHE_MS = 5 * 60 * 1_000; // 5 minutes - cache duration for fetchDeviceInfo
     private readonly FRESH_CACHE_THRESHOLD_MS = 5 * 60 * 1_000; // 5 minutes - cache fresher than this = online on load
     private readonly STALE_DEVICE_AFTER_SCAN_MS = 10_000; // 10 seconds - health check devices with cache older than this after scan
+    private readonly OFFLINE_COOLDOWN_MS = 5_000; // 5 seconds - minimum time between resolve attempts for offline devices
     public static readonly HEALTH_CHECK_TIMEOUT_MS = 2_000; // 2 seconds
 
     // Notifications and event debouncing
@@ -347,12 +348,12 @@ export class DeviceManager {
      * @param lookup - Device lookup by serial and/or IP
      * @returns The device state, defaulting to 'pending' if not found
      */
-    public getDeviceState(lookup: { serialNumber?: string; ip?: string }): DeviceState {
+    public getDeviceState(lookup: { serialNumber?: string; ip?: string }): DeviceStateEntry {
         // Try serial key first (most stable)
         if (lookup.serialNumber) {
             const serialEntry = this.deviceStates.get(`s:${lookup.serialNumber}`);
             if (serialEntry) {
-                return serialEntry.state;
+                return serialEntry;
             }
         }
 
@@ -360,11 +361,11 @@ export class DeviceManager {
         if (lookup.ip) {
             const ipEntry = this.deviceStates.get(`i:${lookup.ip}`);
             if (ipEntry) {
-                return ipEntry.state;
+                return ipEntry;
             }
         }
 
-        return 'pending';
+        return { state: 'pending', lastUpdated: Date.now() };
     }
 
     /**
@@ -386,7 +387,7 @@ export class DeviceManager {
             resolvedState = state;
         } else {
             // Intelligent default: check current state and cache freshness
-            const currentState = this.getDeviceState(lookup);
+            const currentState = this.getDeviceState(lookup).state;
             if (currentState === 'online') {
                 // Already online, keep it online
                 resolvedState = 'online';
@@ -715,17 +716,20 @@ export class DeviceManager {
         // Extract serial from device if available (for proper state key management)
         const knownSerial = 'serialNumber' in device ? device.serialNumber : undefined;
 
+        const currentStateObject = this.getDeviceState({ ip: device.ip, serialNumber: knownSerial });
+
+        // Offline cooldown: if device is offline and we recently checked, skip unless forced
+        // This prevents the loop: healthCheck → resolve → offline → emit → refresh → healthCheck...
+        const isOffline = currentStateObject.state === 'offline';
+        const recentlyCheckedOffline = isOffline && (Date.now() - currentStateObject.lastUpdated < this.OFFLINE_COOLDOWN_MS);
+        if (!force && recentlyCheckedOffline) {
+            return false;
+        }
+
         // Increment and capture sequence number to handle concurrent refresh calls
         // Use IP for sequence tracking (primary key)
         const currentSeq = (this.resolveDeviceSequence.get(device.ip) ?? 0) + 1;
         this.resolveDeviceSequence.set(device.ip, currentSeq);
-
-        // Set to pending during health check with immediate UI feedback
-        const currentState = this.getDeviceState({ ip: device.ip, serialNumber: knownSerial });
-        if (currentState !== 'pending') {
-            this.setDeviceState({ ip: device.ip, serialNumber: knownSerial }, 'pending');
-            this.emitDevicesChanged();
-        }
 
         // Get device info from cache or network
         let deviceInfo: DeviceInfoRaw | undefined;
@@ -733,12 +737,23 @@ export class DeviceManager {
         // Try to find cached data via serial number
         const serialForCache = knownSerial ?? this.globalStateManager.getSerialNumberForIp(device.ip, this.networkId);
         const cached = serialForCache ? this.globalStateManager.getCachedDevice(serialForCache) : undefined;
-        const cacheIsFresh = cached && Date.now() - cached.createdAt < this.DEVICE_INFO_CACHE_MS;
+        const cacheIsFresh = cached && (Date.now() - cached.createdAt < this.DEVICE_INFO_CACHE_MS);
 
-        if (!force && cacheIsFresh) {
+        // Use cache only if:
+        // - Not forced
+        // - Cache is fresh
+        // - Device is not offline (offline devices should always hit network to check if back online)
+        if (!force && cacheIsFresh && !isOffline) {
             // Use cached data
             deviceInfo = cached.deviceInfo as DeviceInfoRaw;
         } else {
+            // Set to pending before making network call
+            // This prevents unnecessary state flicker (online→pending→online) when using cache
+            if (currentStateObject.state !== 'pending') {
+                this.setDeviceState({ ip: device.ip, serialNumber: knownSerial }, 'pending');
+                this.emitDevicesChanged();
+            }
+
             // Fetch fresh data from network
             try {
                 deviceInfo = await this.fetchDeviceInfo(device.ip, 8060);
@@ -774,10 +789,11 @@ export class DeviceManager {
             // Mark any configured devices at this IP with different serials as offline
             this.markMismatchedConfiguredDevicesOffline(device.ip, serial);
 
-            // Set state to online
+            // Only emit if state actually changed
             this.setDeviceState({ ip: device.ip, serialNumber: serial }, 'online');
-
-            this.emitDevicesChanged();
+            if (currentStateObject.state !== 'online') {
+                this.emitDevicesChanged();
+            }
             return true;
         } else {
             // Remove from discoveredDevices (ephemeral - offline devices are removed)
@@ -787,7 +803,9 @@ export class DeviceManager {
             // Use known serial if available for proper key management
             this.setDeviceState({ ip: device.ip, serialNumber: knownSerial }, 'offline');
 
-            this.emitDevicesChanged();
+            if (currentStateObject.state !== 'offline') {
+                this.emitDevicesChanged();
+            }
             return false;
         }
     }
@@ -1104,7 +1122,7 @@ export class DeviceManager {
             discoveredEntry?.serialNumber ??
             this.globalStateManager.getSerialNumberForIp(ip, this.networkId);
 
-        const deviceState = this.getDeviceState({ serialNumber: serialNumber, ip: ip });
+        const deviceState = this.getDeviceState({ serialNumber: serialNumber, ip: ip }).state;
 
         // Build key
         const key = serialNumber ? `s:${serialNumber}` : `i:${ip}`;

--- a/src/deviceDiscovery/DeviceManager.ts
+++ b/src/deviceDiscovery/DeviceManager.ts
@@ -190,35 +190,20 @@ export class DeviceManager {
     /**
      * Get device by encoded key string.
      * Key format: "s:{serialNumber}" or "i:{ip}"
-     * Respects includeNonDeveloperDevices setting.
      *
      * @param key - Encoded device key
-     * @returns Device with deviceInfo or undefined if not found/filtered
+     * @returns Device with deviceInfo or undefined if not found
      */
     public getDevice(key: string): RokuDevice | undefined;
     /**
      * Get device by IP or serial number.
      * Returns device with deviceInfo hydrated from cache.
-     * Respects includeNonDeveloperDevices setting.
      *
      * @param lookup - Object with optional ip and/or serialNumber
-     * @returns Device with deviceInfo or undefined if not found/filtered
+     * @returns Device with deviceInfo or undefined if not found
      */
     public getDevice(lookup: { ip?: string; serialNumber?: string }): RokuDevice | undefined;
     public getDevice(keyOrLookup: string | { ip?: string; serialNumber?: string }): RokuDevice | undefined {
-        const device = this.getDeviceUnfiltered(keyOrLookup as any);
-        if (device && !this.shouldShowDevice(device)) {
-            return undefined;
-        }
-        return device;
-    }
-
-    /**
-     * Get device without filtering. Used internally.
-     */
-    private getDeviceUnfiltered(key: string): RokuDevice | undefined;
-    private getDeviceUnfiltered(lookup: { ip?: string; serialNumber?: string }): RokuDevice | undefined;
-    private getDeviceUnfiltered(keyOrLookup: string | { ip?: string; serialNumber?: string }): RokuDevice | undefined {
         const device = this.buildMergedDevice(keyOrLookup as any);
 
         // If lookup object with both ip and serialNumber, verify exact match
@@ -232,19 +217,26 @@ export class DeviceManager {
     }
 
     /**
-     * Get a list of all visible roku devices.
-     * Respects includeNonDeveloperDevices setting.
+     * Get a list of all roku devices.
+     * Returns all devices without filtering.
      */
     public getAllDevices(): RokuDevice[] {
-        return this.getAllDevicesUnfiltered().filter(d => this.shouldShowDevice(d));
+        return this.buildAllDevices();
     }
 
     /**
-     * Get all devices without filtering. Used internally.
-     * Builds merged view on-demand from configuredDevices and discoveredDevices arrays.
+     * Get all devices filtered for UI display.
+     * Respects includeNonDeveloperDevices setting.
+     */
+    public getDevicesForUI(): RokuDevice[] {
+        return this.buildAllDevices().filter(d => this.shouldShowDevice(d));
+    }
+
+    /**
+     * Build all devices from configuredDevices and discoveredDevices arrays.
      * Deduplication by serial number (preferred) or IP (fallback).
      */
-    private getAllDevicesUnfiltered(): RokuDevice[] {
+    private buildAllDevices(): RokuDevice[] {
         const mergedDevices = new Map<string, RokuDevice>();
         const processedDiscoveredIndices = new Set<number>();
 
@@ -325,7 +317,7 @@ export class DeviceManager {
      * Compute merged device state from configured and discovered states.
      * Priority: online > offline > pending
      */
-    private computeMergedState(
+    private computeDeviceState(
         configuredState: DeviceState,
         discoveredState: 'pending' | 'online' | undefined
     ): DeviceState {
@@ -350,7 +342,7 @@ export class DeviceManager {
      * Re-scan the network for devices and health-check existing ones
      */
     public refresh(force = false, doSyntheticDelay = true): boolean {
-        this.checkDevicesHealth(force, doSyntheticDelay).catch(() => { });
+        this.healthCheckAllDevices(force, doSyntheticDelay).catch(() => { });
         // Block automatic scans when device discovery is disabled
         if (!force && !this.deviceDiscoveryEnabled) {
             return false;
@@ -378,11 +370,6 @@ export class DeviceManager {
     public clearCurrentDeviceList() {
         // Clear discovered devices (ephemeral)
         this.discoveredDevices = [];
-
-        // Reset configured devices to pending (they persist but need re-verification)
-        for (const entry of this.configuredDevices) {
-            entry.deviceState = 'pending';
-        }
 
         // Clear short-lived device info cache
         this.fetchDeviceThrottleData.clear();
@@ -430,11 +417,11 @@ export class DeviceManager {
         }
     }
 
-    public async checkDeviceHealth(deviceOrLookup: RokuDevice | { ip?: string; serialNumber?: string }, force = false, doSyntheticDelay = true): Promise<boolean> {
+    public async healthCheckDevice(deviceOrLookup: RokuDevice | { ip?: string; serialNumber?: string }, force = false, doSyntheticDelay = true): Promise<boolean> {
         // If already a device object with deviceState, use it directly; otherwise look it up
         const device = 'deviceState' in deviceOrLookup
             ? deviceOrLookup
-            : this.getDeviceUnfiltered(deviceOrLookup);
+            : this.getDevice(deviceOrLookup);
 
         if (!device) {
             return false;
@@ -558,11 +545,8 @@ export class DeviceManager {
                     this.globalStateManager.removeLastSeenDevice(this.networkId, serialNumber);
                     continue;
                 }
-                // If cache is fresh (within 5 minutes), treat as online
-                const cacheAge = Date.now() - cached.createdAt;
-                const isFresh = cacheAge < this.FRESH_CACHE_THRESHOLD_MS;
-                // Add to discoveredDevices array
-                this.setDiscoveredDevice(ip, serialNumber, isFresh ? 'online' : 'pending');
+                // Add to discoveredDevices array (state determined from cache freshness)
+                this.setDiscoveredDevice(ip, serialNumber);
             } else {
                 // No cached info - remove stale entry
                 this.globalStateManager.removeLastSeenDevice(this.networkId, serialNumber);
@@ -623,7 +607,14 @@ export class DeviceManager {
         // Clear and rebuild
         this.configuredDevices = [];
 
-        for (const configured of deviceMap.values()) {
+        // Sort devices by deterministic key for consistent ordering
+        const sortedDevices = Array.from(deviceMap.values()).sort((a, b) => {
+            const keyA = a.serialNumber || a.host;
+            const keyB = b.serialNumber || b.host;
+            return keyA.localeCompare(keyB);
+        });
+
+        for (const configured of sortedDevices) {
             // Resolve hostname to IP address (handles both hostnames and IPs)
             let resolvedIp: string | undefined;
             try {
@@ -670,7 +661,7 @@ export class DeviceManager {
         // Update both arrays to show pending state
         let stateChanged = false;
 
-        const configuredEntry = this.getConfiguredDeviceByIp(device.ip);
+        const configuredEntry = this.getConfiguredDevice({ ip: device.ip });
         if (configuredEntry && configuredEntry.deviceState !== 'pending') {
             configuredEntry.deviceState = 'pending';
             stateChanged = true;
@@ -712,8 +703,8 @@ export class DeviceManager {
                 this.globalStateManager.addLastSeenDevice(this.networkId, serial);
             }
 
-            // Update discoveredDevices array
-            this.setDiscoveredDevice(device.ip, serial, 'online');
+            // Update discoveredDevices array (cache was just updated, so state will be 'online')
+            this.setDiscoveredDevice(device.ip, serial);
 
             // Update configuredDevices if this device is configured
             this.updateConfiguredDeviceState(device.ip, serial, 'online');
@@ -739,10 +730,10 @@ export class DeviceManager {
         // Try to find by serial first (more reliable), then by IP
         let entry: ConfiguredDeviceEntry | undefined;
         if (serialNumber) {
-            entry = this.getConfiguredDeviceBySerial(serialNumber);
+            entry = this.getConfiguredDevice({ serialNumber: serialNumber });
         }
         if (!entry) {
-            entry = this.getConfiguredDeviceByIp(ip);
+            entry = this.getConfiguredDevice({ ip: ip });
         }
 
         if (entry) {
@@ -754,9 +745,9 @@ export class DeviceManager {
         }
     }
 
-    private async checkDevicesHealth(force = false, doSyntheticDelay = true): Promise<void> {
-        // Get all devices (unfiltered - health check all devices)
-        const devices = this.getAllDevicesUnfiltered();
+    private async healthCheckAllDevices(force = false, doSyntheticDelay = true): Promise<void> {
+        // Get all devices (health check all devices)
+        const devices = this.getAllDevices();
 
         // Filter to devices that need checking
         const devicesToCheck = force ? devices : devices.filter(d => {
@@ -771,7 +762,7 @@ export class DeviceManager {
         // Set all to pending and emit before async work
         for (const device of devicesToCheck) {
             // Update state in source arrays (both configured and discovered)
-            const configuredEntry = this.getConfiguredDeviceByIp(device.ip);
+            const configuredEntry = this.getConfiguredDevice({ ip: device.ip });
             if (configuredEntry) {
                 configuredEntry.deviceState = 'pending';
             }
@@ -803,7 +794,7 @@ export class DeviceManager {
      */
     private healthCheckStaleDevices(): void {
         const now = Date.now();
-        const staleDevices = this.getAllDevicesUnfiltered().filter(device => {
+        const staleDevices = this.getAllDevices().filter(device => {
             if (!device.serialNumber) {
                 // No serial = no cache, consider stale
                 return true;
@@ -894,8 +885,9 @@ export class DeviceManager {
     /**
      * Add or update a device in the discoveredDevices array.
      * Handles deduplication by serial number (removes old IP entry if serial matches).
+     * Determines device state from cache freshness; keeps 'online' sticky.
      */
-    private setDiscoveredDevice(ip: string, serialNumber: string | undefined, deviceState: 'pending' | 'online'): void {
+    private setDiscoveredDevice(ip: string, serialNumber: string | undefined): void {
         // Serial dedupe: if same serial exists at different IP, remove old entry
         if (serialNumber) {
             const oldIdx = this.discoveredDevices.findIndex(d => d.ip !== ip && d.serialNumber === serialNumber);
@@ -911,17 +903,25 @@ export class DeviceManager {
 
         // IP dedupe: find existing entry at same IP
         const existingIdx = this.discoveredDevices.findIndex(d => d.ip === ip);
-        if (existingIdx >= 0) {
-            const existing = this.discoveredDevices[existingIdx];
-            // Don't downgrade from online to pending
-            const newState = (existing.deviceState === 'online' && deviceState === 'pending')
-                ? 'online'
-                : deviceState;
+        const existing = existingIdx >= 0 ? this.discoveredDevices[existingIdx] : undefined;
+
+        // Determine state: check cache freshness or keep existing online state (sticky)
+        let deviceState: 'pending' | 'online' = 'pending';
+        if (existing?.deviceState === 'online') {
+            deviceState = 'online'; // Sticky online
+        } else if (serialNumber) {
+            const cached = this.globalStateManager.getCachedDevice(serialNumber);
+            if (cached && Date.now() - cached.createdAt < this.FRESH_CACHE_THRESHOLD_MS) {
+                deviceState = 'online';
+            }
+        }
+
+        if (existing) {
             // Update existing entry
             this.discoveredDevices[existingIdx] = {
                 ip: ip,
                 serialNumber: serialNumber ?? existing.serialNumber,
-                deviceState: newState
+                deviceState: deviceState
             };
         } else {
             // Add new entry
@@ -968,17 +968,14 @@ export class DeviceManager {
     }
 
     /**
-     * Find a configured device by serial number.
+     * Find a configured device by serial number or IP.
      */
-    private getConfiguredDeviceBySerial(serialNumber: string): ConfiguredDeviceEntry | undefined {
-        return this.configuredDevices.find(d => d.serialNumber === serialNumber);
-    }
-
-    /**
-     * Find a configured device by host or resolved IP.
-     */
-    private getConfiguredDeviceByIp(ip: string): ConfiguredDeviceEntry | undefined {
-        return this.configuredDevices.find(d => d.resolvedIp === ip || d.host === ip);
+    private getConfiguredDevice(lookup: { serialNumber: string } | { ip: string }): ConfiguredDeviceEntry | undefined {
+        if ('serialNumber' in lookup) {
+            return this.configuredDevices.find(d => d.serialNumber === lookup.serialNumber);
+        } else {
+            return this.configuredDevices.find(d => d.resolvedIp === lookup.ip || d.host === lookup.ip);
+        }
     }
 
     /**
@@ -1065,7 +1062,7 @@ export class DeviceManager {
             discovered?.serialNumber;
 
         // Compute merged state: online > offline > pending
-        const deviceState = this.computeMergedState(
+        const deviceState = this.computeDeviceState(
             configuredEntry?.deviceState,
             discovered?.deviceState
         );
@@ -1146,7 +1143,7 @@ export class DeviceManager {
     private setupFinderListeners() {
         this.finder.removeAllListeners();
         this.finder.on('found', (ip: string, options?: { serialNumber?: string }) => {
-            this.setDiscoveredDevice(ip, options?.serialNumber, 'pending');
+            this.setDiscoveredDevice(ip, options?.serialNumber);
             this.emitDevicesChanged();
         });
 

--- a/src/deviceDiscovery/DeviceManager.ts
+++ b/src/deviceDiscovery/DeviceManager.ts
@@ -480,17 +480,19 @@ export class DeviceManager {
         if (isNewDevice) {
             this.devices.push(device);
         } else {
-            // Merge: incoming wins for most fields, but preserve configured properties
+            // Merge: incoming wins for fields that are present, preserve existing for omitted fields.
+            // This lets config loading pass explicit undefined to clear, while discovery
+            // (which omits these fields) preserves existing config.
             const existing = this.devices[index];
             this.devices[index] = {
                 ...existing,
                 ...device,
-                // Preserve configured status from either side
-                isDiscovered: device.isDiscovered ?? existing.isDiscovered,
-                isConfigured: device.isConfigured ?? existing.isConfigured,
-                configuredIn: device.configuredIn ?? existing.configuredIn,
-                configuredName: device.configuredName ?? existing.configuredName,
-                configuredPassword: device.configuredPassword ?? existing.configuredPassword
+                // Preserve if not explicitly provided (property absent vs undefined)
+                isDiscovered: 'isDiscovered' in input ? input.isDiscovered : existing.isDiscovered,
+                isConfigured: 'isConfigured' in input ? input.isConfigured : existing.isConfigured,
+                configuredIn: 'configuredIn' in input ? input.configuredIn : existing.configuredIn,
+                configuredName: 'configuredName' in input ? input.configuredName : existing.configuredName,
+                configuredPassword: 'configuredPassword' in input ? input.configuredPassword : existing.configuredPassword
             };
         }
 
@@ -713,14 +715,6 @@ export class DeviceManager {
 
             // Check if device already exists by IP (primary key)
             const existingDevice = this.getDeviceEntry({ ip: ip });
-
-            // Clear config-specific fields before update so setDevice's ?? merge
-            // doesn't preserve stale values. Config is authoritative for these fields.
-            if (existingDevice) {
-                existingDevice.configuredIn = [];
-                existingDevice.configuredName = undefined;
-                existingDevice.configuredPassword = undefined;
-            }
 
             // Preserve state if device exists
             const deviceState = existingDevice?.deviceState ?? 'pending';

--- a/src/deviceDiscovery/DeviceManager.ts
+++ b/src/deviceDiscovery/DeviceManager.ts
@@ -95,10 +95,8 @@ export class DeviceManager {
             this.networkId = getNetworkHash();
             this.fetchDeviceThrottleData.clear();
 
-            //reset configured devices to pending - need to re-verify on new network
-            for (const entry of this.configuredDevices) {
-                entry.deviceState = 'pending';
-            }
+            //reset all device states to pending - need to re-verify on new network
+            this.deviceStates.clear();
 
             //clear and reload discovered devices anytime this network changes
             this.discoveredDevices = [];
@@ -143,6 +141,7 @@ export class DeviceManager {
     // Core state and dependencies
     private configuredDevices: ConfiguredDeviceEntry[] = [];
     private discoveredDevices: DiscoveredDeviceEntry[] = [];
+    private deviceStates = new Map<DeviceStateKey, DeviceStateEntry>();
     private scanNeeded = false;
     private lastUsedDeviceIp: string | undefined = undefined;
     private networkId: string;
@@ -313,22 +312,94 @@ export class DeviceManager {
         );
     }
 
+    // #region Device State Management
     /**
-     * Compute merged device state from configured and discovered states.
-     * Priority: online > offline > pending
+     * Get the state key for a device lookup.
+     * Prefers serial number over IP for stable identity.
+     * @returns Key in format "s:{serial}" or "i:{ip}"
      */
-    private computeDeviceState(
-        configuredState: DeviceState,
-        discoveredState: 'pending' | 'online' | undefined
-    ): DeviceState {
-        if (configuredState === 'online' || discoveredState === 'online') {
-            return 'online';
+    private getStateKey(lookup: { serialNumber?: string; ip?: string }): DeviceStateKey {
+        if (lookup.serialNumber) {
+            return `s:${lookup.serialNumber}`;
         }
-        if (configuredState === 'offline') {
-            return 'offline';
+        return `i:${lookup.ip}`;
+    }
+
+    /**
+     * Get device state from the separate state map.
+     * @param lookup - Device lookup by serial and/or IP
+     * @returns The device state, defaulting to 'pending' if not found
+     */
+    public getDeviceState(lookup: { serialNumber?: string; ip?: string }): DeviceState {
+        // Try serial key first (most stable)
+        if (lookup.serialNumber) {
+            const serialEntry = this.deviceStates.get(`s:${lookup.serialNumber}`);
+            if (serialEntry) {
+                return serialEntry.state;
+            }
         }
+
+        // Try IP key as fallback
+        if (lookup.ip) {
+            const ipEntry = this.deviceStates.get(`i:${lookup.ip}`);
+            if (ipEntry) {
+                return ipEntry.state;
+            }
+        }
+
         return 'pending';
     }
+
+    /**
+     * Set device state in the separate state map.
+     * When called without explicit state, uses intelligent defaults:
+     * - If already online, stays online
+     * - Else checks cache freshness (5 min threshold) to determine online vs pending
+     * Handles key migration: when serial becomes known, migrates i:{ip} entry to s:{serial}
+     *
+     * @param lookup - Device lookup by serial and/or IP
+     * @param state - Explicit state to set, or undefined for intelligent default
+     */
+    public setDeviceState(lookup: { serialNumber?: string; ip?: string }, state?: DeviceState): void {
+        const now = Date.now();
+        let resolvedState: DeviceState;
+
+        if (state !== undefined) {
+            // Explicit state provided
+            resolvedState = state;
+        } else {
+            // Intelligent default: check current state and cache freshness
+            const currentState = this.getDeviceState(lookup);
+            if (currentState === 'online') {
+                // Already online, keep it online
+                resolvedState = 'online';
+            } else if (lookup.serialNumber) {
+                // Check cache freshness to determine state
+                const cached = this.globalStateManager.getCachedDevice(lookup.serialNumber);
+                if (cached && now - cached.createdAt < this.FRESH_CACHE_THRESHOLD_MS) {
+                    resolvedState = 'online';
+                } else {
+                    resolvedState = 'pending';
+                }
+            } else {
+                resolvedState = 'pending';
+            }
+        }
+
+        // Handle key migration: when serial becomes known, migrate from IP key to serial key
+        if (lookup.serialNumber && lookup.ip) {
+            const ipKey = `i:${lookup.ip}` as DeviceStateKey;
+            if (this.deviceStates.has(ipKey)) {
+                // Remove the old IP-based entry
+                this.deviceStates.delete(ipKey);
+            }
+        }
+
+        // Set state using preferred key (serial if available, else IP)
+        const key = this.getStateKey(lookup);
+        this.deviceStates.set(key, { state: resolvedState, lastUpdated: now });
+    }
+    // #endregion
 
     /**
      * Check if a device has cached info (has been successfully resolved before).
@@ -409,6 +480,7 @@ export class DeviceManager {
         this.lastScanDate = null;
         this.lastHealthCheckTime.clear();
         this.resolveDeviceSequence.clear();
+        this.deviceStates.clear();
 
         // Clear cache cleanup timer
         if (this.fetchDeviceInfoThrottleTimer) {
@@ -594,17 +666,7 @@ export class DeviceManager {
         addDevicesFromScope(userDevices, 'user');
         addDevicesFromScope(workspaceDevices, 'workspace');
 
-        // Capture existing states before clearing (to avoid UI flicker)
-        const previousStatesByHost = new Map<string, DeviceState>();
-        const previousStatesBySerial = new Map<string, DeviceState>();
-        for (const entry of this.configuredDevices) {
-            previousStatesByHost.set(entry.host, entry.deviceState);
-            if (entry.serialNumber) {
-                previousStatesBySerial.set(entry.serialNumber, entry.deviceState);
-            }
-        }
-
-        // Clear and rebuild
+        // Clear and rebuild configuredDevices array
         this.configuredDevices = [];
 
         // Sort devices by deterministic key for consistent ordering
@@ -631,26 +693,24 @@ export class DeviceManager {
                 serialNumber = this.globalStateManager.getSerialNumberForIp(ip, this.networkId);
             }
 
-            // Restore previous state if available (prefer serial match over host match)
-            const deviceState =
-                previousStatesBySerial.get(configured.serialNumber) ??
-                previousStatesByHost.get(configured.host) ??
-                'pending';
-
             this.configuredDevices.push({
                 ...configured,
-                resolvedIp: resolvedIp,
-                deviceState: deviceState
+                resolvedIp: resolvedIp
             });
 
             // Set up IP→serial mapping if we have serial
             if (serialNumber) {
                 this.globalStateManager.setSerialNumberForIp(this.networkId, ip, serialNumber);
             }
+
+            // Set device state using intelligent defaults (preserves existing state or uses cache freshness)
+            this.setDeviceState({ serialNumber: serialNumber, ip: ip });
         }
     }
 
-    private async resolveDevice(device: RokuDevice | { ip: string }, doSyntheticDelay = true): Promise<boolean> {
+    private async resolveDevice(device: RokuDevice | { ip: string; serialNumber?: string }, doSyntheticDelay = true): Promise<boolean> {
+        // Extract serial from device if available (for proper state key management)
+        const knownSerial = 'serialNumber' in device ? device.serialNumber : undefined;
 
         // Increment and capture sequence number to handle concurrent refresh calls
         // Use IP for sequence tracking (primary key)
@@ -658,22 +718,9 @@ export class DeviceManager {
         this.resolveDeviceSequence.set(device.ip, currentSeq);
 
         // Set to pending during health check with immediate UI feedback
-        // Update both arrays to show pending state
-        let stateChanged = false;
-
-        const configuredEntry = this.getConfiguredDevice({ ip: device.ip });
-        if (configuredEntry && configuredEntry.deviceState !== 'pending') {
-            configuredEntry.deviceState = 'pending';
-            stateChanged = true;
-        }
-
-        const discoveredEntry = this.discoveredDevices.find(d => d.ip === device.ip);
-        if (discoveredEntry && discoveredEntry.deviceState !== 'pending') {
-            discoveredEntry.deviceState = 'pending';
-            stateChanged = true;
-        }
-
-        if (stateChanged) {
+        const currentState = this.getDeviceState({ ip: device.ip, serialNumber: knownSerial });
+        if (currentState !== 'pending') {
+            this.setDeviceState({ ip: device.ip, serialNumber: knownSerial }, 'pending');
             this.emitDevicesChanged();
         }
 
@@ -696,18 +743,22 @@ export class DeviceManager {
         }
 
         if (deviceInfo) {
-            // Extract serial and cache the deviceInfo
-            const serial = deviceInfo['serial-number']?.toString?.();
+            // Extract serial from response, fall back to known serial
+            const serial = deviceInfo['serial-number']?.toString?.() ?? knownSerial;
+
             if (serial) {
                 // Add to last seen devices (successfully resolved with serial)
                 this.globalStateManager.addLastSeenDevice(this.networkId, serial);
             }
 
-            // Update discoveredDevices array (cache was just updated, so state will be 'online')
+            // Update discoveredDevices array
             this.setDiscoveredDevice(device.ip, serial);
 
-            // Update configuredDevices if this device is configured
-            this.updateConfiguredDeviceState(device.ip, serial, 'online');
+            // Update resolvedIp for configured device if applicable
+            this.updateConfiguredDeviceResolvedIp(device.ip, serial);
+
+            // Set state to online
+            this.setDeviceState({ ip: device.ip, serialNumber: serial }, 'online');
 
             this.emitDevicesChanged();
             return true;
@@ -715,8 +766,9 @@ export class DeviceManager {
             // Remove from discoveredDevices (ephemeral - offline devices are removed)
             this.removeDiscoveredDevice(device.ip);
 
-            // Update configured device state to offline (configured devices persist)
-            this.updateConfiguredDeviceState(device.ip, undefined, 'offline');
+            // Set state to offline (configured devices persist with offline state)
+            // Use known serial if available for proper key management
+            this.setDeviceState({ ip: device.ip, serialNumber: knownSerial }, 'offline');
 
             this.emitDevicesChanged();
             return false;
@@ -724,9 +776,9 @@ export class DeviceManager {
     }
 
     /**
-     * Update state for a configured device by IP or serial number.
+     * Update resolvedIp for a configured device by IP or serial number.
      */
-    private updateConfiguredDeviceState(ip: string, serialNumber: string | undefined, state: DeviceState): void {
+    private updateConfiguredDeviceResolvedIp(ip: string, serialNumber: string | undefined): void {
         // Try to find by serial first (more reliable), then by IP
         let entry: ConfiguredDeviceEntry | undefined;
         if (serialNumber) {
@@ -737,11 +789,7 @@ export class DeviceManager {
         }
 
         if (entry) {
-            entry.deviceState = state;
-            // Update resolvedIp if we have a successful resolution
-            if (state === 'online' && ip) {
-                entry.resolvedIp = ip;
-            }
+            entry.resolvedIp = ip;
         }
     }
 
@@ -761,15 +809,7 @@ export class DeviceManager {
 
         // Set all to pending and emit before async work
         for (const device of devicesToCheck) {
-            // Update state in source arrays (both configured and discovered)
-            const configuredEntry = this.getConfiguredDevice({ ip: device.ip });
-            if (configuredEntry) {
-                configuredEntry.deviceState = 'pending';
-            }
-            const discoveredEntry = this.discoveredDevices.find(d => d.ip === device.ip);
-            if (discoveredEntry) {
-                discoveredEntry.deviceState = 'pending';
-            }
+            this.setDeviceState({ ip: device.ip, serialNumber: device.serialNumber }, 'pending');
             this.lastHealthCheckTime.set(device.ip, Date.now());
         }
         this.emitDevicesChanged();
@@ -843,27 +883,27 @@ export class DeviceManager {
         if (cached && Date.now() - cached.timestamp < 5_000) {
             return cached.info;
         }
-
-        const info = await rokuDeploy.getDeviceInfo({
-            host: ip,
-            remotePort: port,
-            timeout: DeviceManager.HEALTH_CHECK_TIMEOUT_MS
-        });
-
-        const serial = info['serial-number'];
-
-        //immediately cache this info
-        if (serial) {
-            this.globalStateManager.setCachedDevice(serial, {
-                serialNumber: serial,
-                deviceInfo: info,
-                createdAt: Date.now()
+        try {
+            const info = await rokuDeploy.getDeviceInfo({
+                host: ip,
+                remotePort: port,
+                timeout: DeviceManager.HEALTH_CHECK_TIMEOUT_MS
             });
-            this.globalStateManager.setSerialNumberForIp(this.networkId, ip, serial);
-        }
+            if (info?.serialNumber) {
+                this.globalStateManager.setCachedDevice(info.serialNumber, {
+                    serialNumber: info.serialNumber,
+                    deviceInfo: info,
+                    createdAt: Date.now()
+                });
+                this.globalStateManager.setSerialNumberForIp(this.networkId, ip, info.serialNumber);
+            }
 
-        this.fetchDeviceThrottleData.set(ip, { info: info, timestamp: Date.now() });
-        return info;
+            this.fetchDeviceThrottleData.set(ip, { info: info, timestamp: Date.now() });
+            return info;
+        } catch (e) {
+            console.error(e);
+            return undefined;
+        }
     }
     private fetchDeviceThrottleData = new Map<string, { info: DeviceInfoRaw; timestamp: number }>();
     private fetchDeviceInfoThrottleTimer: ReturnType<typeof setTimeout> | null = null;
@@ -885,7 +925,7 @@ export class DeviceManager {
     /**
      * Add or update a device in the discoveredDevices array.
      * Handles deduplication by serial number (removes old IP entry if serial matches).
-     * Determines device state from cache freshness; keeps 'online' sticky.
+     * Also sets device state using intelligent defaults (cache freshness check).
      */
     private setDiscoveredDevice(ip: string, serialNumber: string | undefined): void {
         // Serial dedupe: if same serial exists at different IP, remove old entry
@@ -905,32 +945,22 @@ export class DeviceManager {
         const existingIdx = this.discoveredDevices.findIndex(d => d.ip === ip);
         const existing = existingIdx >= 0 ? this.discoveredDevices[existingIdx] : undefined;
 
-        // Determine state: check cache freshness or keep existing online state (sticky)
-        let deviceState: 'pending' | 'online' = 'pending';
-        if (existing?.deviceState === 'online') {
-            deviceState = 'online'; // Sticky online
-        } else if (serialNumber) {
-            const cached = this.globalStateManager.getCachedDevice(serialNumber);
-            if (cached && Date.now() - cached.createdAt < this.FRESH_CACHE_THRESHOLD_MS) {
-                deviceState = 'online';
-            }
-        }
-
         if (existing) {
             // Update existing entry
             this.discoveredDevices[existingIdx] = {
                 ip: ip,
-                serialNumber: serialNumber ?? existing.serialNumber,
-                deviceState: deviceState
+                serialNumber: serialNumber ?? existing.serialNumber
             };
         } else {
             // Add new entry
             this.discoveredDevices.push({
                 ip: ip,
-                serialNumber: serialNumber,
-                deviceState: deviceState
+                serialNumber: serialNumber
             });
         }
+
+        // Set device state using intelligent defaults (preserves existing online state or uses cache freshness)
+        this.setDeviceState({ serialNumber: serialNumber, ip: ip });
     }
 
     /**
@@ -1061,11 +1091,8 @@ export class DeviceManager {
             configuredEntry?.serialNumber ??
             discovered?.serialNumber;
 
-        // Compute merged state: online > offline > pending
-        const deviceState = this.computeDeviceState(
-            configuredEntry?.deviceState,
-            discovered?.deviceState
-        );
+        // Get merged state from state map
+        const deviceState = this.getDeviceState({ serialNumber: serialNumber, ip: ip });
 
         // Build key
         const key = serialNumber ? `s:${serialNumber}` : `i:${ip}`;
@@ -1257,10 +1284,6 @@ interface ConfiguredDeviceEntry extends ConfiguredDevice {
      */
     resolvedIp?: string;
     /**
-     * Device state: pending/online/offline (persists even when offline)
-     */
-    deviceState: DeviceState;
-    /**
      * Which settings scopes this device is configured in
      */
     configuredIn?: ConfigurationScope[];
@@ -1279,10 +1302,19 @@ interface DiscoveredDeviceEntry {
      * Serial number from device-info response
      */
     serialNumber?: string;
-    /**
-     * Device state: pending/online only (offline = removed from array)
-     */
-    deviceState: 'pending' | 'online';
+}
+
+/**
+ * Key format for device state map: "s:{serial}" or "i:{ip}"
+ */
+type DeviceStateKey = `s:${string}` | `i:${string}`;
+
+/**
+ * Entry in the device state map
+ */
+interface DeviceStateEntry {
+    state: DeviceState;
+    lastUpdated: number;
 }
 
 /**

--- a/src/deviceDiscovery/DeviceManager.ts
+++ b/src/deviceDiscovery/DeviceManager.ts
@@ -468,73 +468,67 @@ export class DeviceManager {
     /**
      * Add or update a device in the devices array.
      * Computes the device key from serialNumber (or falls back to IP).
+     * Handles deduplication when a device changes IP (same serial, different IP).
      */
     private setDevice(input: Omit<DeviceEntry, 'key'>): void {
-        const index = this.devices.findIndex(d => d.ip === input.ip);
-        const isNewDevice = index < 0;
+        /**
+         * Apply merge rules: preserve state from existing entry based on discovered/configured status.
+         * - Keep highest device state: online > offline > pending
+         * - If existing is discovered and input is configuring: keep discovered state, apply config
+         * - If existing is configured and input is discovering: keep config props, apply discovered
+         */
+        const applyMergeRules = (existing: DeviceEntry) => {
+            // Keep highest device state: online > offline > pending
+            const stateRank: Record<DeviceState, number> = { online: 2, offline: 1, pending: 0 };
+            if (stateRank[existing.deviceState] > stateRank[input.deviceState]) {
+                input.deviceState = existing.deviceState;
+            }
+
+            if (existing.isDiscovered && 'isConfigured' in input && input.isConfigured) {
+                input.isDiscovered = existing.isDiscovered;
+            } else if (existing.isConfigured && 'isDiscovered' in input && input.isDiscovered) {
+                input.isConfigured = existing.isConfigured;
+                input.configuredName = existing.configuredName;
+                input.configuredPassword = existing.configuredPassword;
+                input.configuredIn = existing.configuredIn;
+            }
+        };
+
+        // Serial dedupe: check for existing device with same serial at DIFFERENT IP
+        if (input.serialNumber) {
+            const oldEntry = this.devices.find(d => d.ip !== input.ip && this.getSerial(d) === input.serialNumber);
+            if (oldEntry) {
+                // If old is discovered and new is config, keep the discovered IP
+                if (oldEntry.isDiscovered && 'isConfigured' in input && input.isConfigured) {
+                    input.ip = oldEntry.ip;
+                }
+
+                applyMergeRules(oldEntry);
+
+                // Transfer lastUsedDeviceIp to new IP if it was pointing to old device
+                if (this.lastUsedDeviceIp === oldEntry.ip) {
+                    this.lastUsedDeviceIp = input.ip;
+                }
+
+                // Remove old entry directly from array
+                this.devices = this.devices.filter(d => d.ip !== oldEntry.ip);
+            }
+        }
+
+        // IP dedupe: check for existing device at same IP
+        const existingIndex = this.devices.findIndex(d => d.ip === input.ip);
+        if (existingIndex >= 0) {
+            applyMergeRules(this.devices[existingIndex]);
+            this.devices = this.devices.filter((_, i) => i !== existingIndex);
+        }
 
         // Compute key: serial-based when available, IP-based as fallback
         const key = input.serialNumber ? `s:${input.serialNumber}` : `i:${input.ip}`;
         const device: DeviceEntry = { ...input, key: key };
 
-        if (isNewDevice) {
-            this.devices.push(device);
-        } else {
-            // Merge: incoming wins for fields that are present, preserve existing for omitted fields.
-            // This lets config loading pass explicit undefined to clear, while discovery
-            // (which omits these fields) preserves existing config.
-            const existing = this.devices[index];
-            this.devices[index] = {
-                ...existing,
-                ...device,
-                // Preserve if not explicitly provided (property absent vs undefined)
-                isDiscovered: 'isDiscovered' in input ? input.isDiscovered : existing.isDiscovered,
-                isConfigured: 'isConfigured' in input ? input.isConfigured : existing.isConfigured,
-                configuredIn: 'configuredIn' in input ? input.configuredIn : existing.configuredIn,
-                configuredName: 'configuredName' in input ? input.configuredName : existing.configuredName,
-                configuredPassword: 'configuredPassword' in input ? input.configuredPassword : existing.configuredPassword
-            };
-        }
+        this.devices.push(device);
 
         this.emitDevicesChanged();
-    }
-
-    /**
-     * Deduplicate devices by serial number when a device changes IP (e.g., DHCP reassignment).
-     * If an existing device with the same serial exists at a DIFFERENT IP, removes it and
-     * returns its configured properties to be preserved on the new entry.
-     *
-     * @param newIp - The IP address where the device was just discovered/resolved
-     * @param serial - The serial number from the device
-     * @returns Configured properties to preserve, or undefined if no deduplication needed
-     */
-    private dedupeBySerial(newIp: string, serial: string): Pick<DeviceEntry, 'isConfigured' | 'configuredIn' | 'configuredName' | 'configuredPassword'> | undefined {
-        // Find existing device with same serial at a DIFFERENT IP
-        const existingDevice = this.devices.find(d => d.ip !== newIp && this.getSerial(d) === serial);
-
-        if (!existingDevice) {
-            return undefined;
-        }
-
-        // Capture configured properties to preserve
-        const preserved = {
-            isConfigured: existingDevice.isConfigured,
-            configuredIn: existingDevice.configuredIn,
-            configuredName: existingDevice.configuredName,
-            configuredPassword: existingDevice.configuredPassword
-        };
-
-        // Transfer lastUsedDeviceIp to new IP if it was pointing to old device
-        // (User's "active device" should follow the physical device, not the stale IP)
-        if (this.lastUsedDeviceIp === existingDevice.ip) {
-            this.lastUsedDeviceIp = newIp;
-        }
-
-        // Remove old entry directly from array (don't use removeDevice to avoid
-        // side effects like removing from lastSeenDevices - device still exists)
-        this.devices = this.devices.filter(d => d.ip !== existingDevice.ip);
-
-        return preserved;
     }
 
     /**
@@ -817,19 +811,12 @@ export class DeviceManager {
                 this.globalStateManager.addLastSeenDevice(this.networkId, serial);
             }
 
-            // Dedupe by serial - if device moved IPs, remove old entry and preserve its config
-            const preserved = serial ? this.dedupeBySerial(device.ip, serial) : undefined;
-
-            // Create device with serial (key computed by setDevice)
+            // Create device with serial (key computed by setDevice, dedupe handled internally)
             this.setDevice({
                 ip: device.ip,
                 serialNumber: serial,
                 deviceState: 'online',
-                isConfigured: preserved?.isConfigured ?? device.isConfigured,
-                configuredIn: preserved?.configuredIn ?? device.configuredIn,
-                isDiscovered: true,
-                configuredName: preserved?.configuredName ?? device.configuredName,
-                configuredPassword: preserved?.configuredPassword ?? device.configuredPassword
+                isDiscovered: true
             });
 
             return true;
@@ -939,9 +926,6 @@ export class DeviceManager {
                 return;
             }
 
-            // Check if device already exists (by IP)
-            const existingDevice = this.getDeviceEntry({ ip: ip });
-
             // Extract serial and cache the deviceInfo
             const serial = deviceInfo['serial-number']?.toString?.();
             if (serial) {
@@ -953,19 +937,12 @@ export class DeviceManager {
                 this.globalStateManager.setSerialNumberForIp(this.networkId, ip, serial);
             }
 
-            // Dedupe by serial - if device moved IPs, remove old entry and preserve its config
-            const preserved = serial ? this.dedupeBySerial(ip, serial) : undefined;
-
-            // Create device with serial (key computed by setDevice)
+            // Create device with serial (key computed by setDevice, dedupe handled internally)
             this.setDevice({
                 ip: ip,
                 serialNumber: serial,
                 deviceState: 'online',
-                isConfigured: preserved?.isConfigured ?? existingDevice?.isConfigured ?? false,
-                configuredIn: preserved?.configuredIn ?? existingDevice?.configuredIn,
-                isDiscovered: true,
-                configuredName: preserved?.configuredName ?? existingDevice?.configuredName,
-                configuredPassword: preserved?.configuredPassword ?? existingDevice?.configuredPassword
+                isDiscovered: true
             });
         } catch {
             // Device unreachable, ignore

--- a/src/deviceDiscovery/DeviceManager.ts
+++ b/src/deviceDiscovery/DeviceManager.ts
@@ -746,6 +746,12 @@ export class DeviceManager {
             // Extract serial from response, fall back to known serial
             const serial = deviceInfo['serial-number']?.toString?.() ?? knownSerial;
 
+            // Check for serial mismatch before updating state
+            // If a different device is now at this IP, reload configurations
+            if (this.checkForSerialMismatch(device.ip, serial)) {
+                void this.loadConfiguredDevices();
+            }
+
             if (serial) {
                 // Add to last seen devices (successfully resolved with serial)
                 this.globalStateManager.addLastSeenDevice(this.networkId, serial);
@@ -773,6 +779,51 @@ export class DeviceManager {
             this.emitDevicesChanged();
             return false;
         }
+    }
+
+    /**
+     * Check if a newly discovered serial number at an IP represents a mismatch
+     * with what we currently have stored. Used to trigger config reload when
+     * a device has changed IPs or a different device is now at a known IP.
+     *
+     * Mismatch scenarios:
+     * - deviceInfo for IP1 expected SerialA, got SerialB
+     * - deviceInfo for IP1 (no serial known) returns any serial
+     * - SSDP arrives with IP1 + SerialB but lists had IP1 + SerialA
+     *
+     * @param ip - The IP address
+     * @param newSerial - The newly discovered serial number
+     * @returns true if there's a mismatch that warrants reloading configurations
+     */
+    private checkForSerialMismatch(ip: string, newSerial: string | undefined): boolean {
+        if (!newSerial) {
+            // No new serial to compare
+            return false;
+        }
+
+        // Check what serial we have stored for this IP in the IP→serial map
+        const storedSerial = this.globalStateManager.getSerialNumberForIp(ip, this.networkId);
+
+        if (storedSerial && storedSerial !== newSerial) {
+            // Different device is now at this IP
+            return true;
+        }
+
+        // Check if any configured device at this IP has a different serial
+        const configuredDevice = this.getConfiguredDevice({ ip: ip });
+        if (configuredDevice?.serialNumber && configuredDevice.serialNumber !== newSerial) {
+            // Configured device has a different serial than what's actually at the IP
+            return true;
+        }
+
+        // Check if any discovered device at this IP has a different serial
+        const discoveredDevice = this.discoveredDevices.find(d => d.ip === ip);
+        if (discoveredDevice?.serialNumber && discoveredDevice.serialNumber !== newSerial) {
+            // Discovered device has a different serial than what's actually at the IP
+            return true;
+        }
+
+        return false;
     }
 
     /**
@@ -1170,6 +1221,12 @@ export class DeviceManager {
     private setupFinderListeners() {
         this.finder.removeAllListeners();
         this.finder.on('found', (ip: string, options?: { serialNumber?: string }) => {
+            // Check for serial mismatch before updating state
+            // If a different device is now at this IP, reload configurations
+            if (this.checkForSerialMismatch(ip, options?.serialNumber)) {
+                void this.loadConfiguredDevices();
+            }
+
             this.setDiscoveredDevice(ip, options?.serialNumber);
             this.emitDevicesChanged();
         });

--- a/src/deviceDiscovery/DeviceManager.ts
+++ b/src/deviceDiscovery/DeviceManager.ts
@@ -204,7 +204,8 @@ export class DeviceManager {
      */
     public getDevice(lookup: { ip?: string; serialNumber?: string }): RokuDevice | undefined;
     public getDevice(keyOrLookup: string | { ip?: string; serialNumber?: string }): RokuDevice | undefined {
-        const device = this.buildMergedDevice(keyOrLookup as any);
+        const { configured, discovered } = this.findDeviceEntries(keyOrLookup);
+        const device = this.buildMergedDevice(configured, discovered);
 
         // If lookup object with both ip and serialNumber, verify exact match
         if (typeof keyOrLookup !== 'string' && keyOrLookup.ip && keyOrLookup.serialNumber && device) {
@@ -1057,25 +1058,18 @@ export class DeviceManager {
     }
 
     /**
-     * Remove a device from the discoveredDevices array by IP.
+     * Remove a discovered device by IP. Clears from discoveredDevices array,
+     * clears lastUsedDeviceIp if it matches, and removes from lastSeenDevices cache.
      */
     private removeDiscoveredDevice(ip: string): void {
-        const idx = this.discoveredDevices.findIndex(d => d.ip === ip);
-        if (idx >= 0) {
-            this.discoveredDevices.splice(idx, 1);
-        }
-    }
-
-    /**
-     * Remove a device by IP. Clears from discoveredDevices, updates lastSeenDevices,
-     * and clears lastUsedDeviceIp if it matches.
-     */
-    private removeDevice(ip: string): void {
         // Find the device first to get its serial number
-        const device = this.discoveredDevices.find(d => d.ip === ip);
+        const idx = this.discoveredDevices.findIndex(d => d.ip === ip);
+        if (idx < 0) {
+            return;
+        }
 
-        // Remove from discoveredDevices array
-        this.removeDiscoveredDevice(ip);
+        const device = this.discoveredDevices[idx];
+        this.discoveredDevices.splice(idx, 1);
 
         // Clear lastUsedDeviceIp if it matches
         if (this.lastUsedDeviceIp === ip) {
@@ -1086,67 +1080,48 @@ export class DeviceManager {
         if (device?.serialNumber) {
             this.globalStateManager.removeLastSeenDevice(this.networkId, device.serialNumber);
         }
-
-        this.emitDevicesChanged();
     }
 
     /**
-     * Build a merged RokuDevice by decoding an encoded key (s:serial or i:ip).
+     * Find configured and discovered device entries by key or lookup criteria.
+     * Key format: "s:{serialNumber}" or "i:{ip}"
+     * Lookup format: { ip?: string; serialNumber?: string }
      */
-    private buildMergedDevice(key: string): RokuDevice | undefined;
-    /**
-     * Build a merged RokuDevice by looking up in source arrays.
-     */
-    private buildMergedDevice(lookup: { ip?: string; serialNumber?: string }): RokuDevice | undefined;
-    /**
-     * Build a merged RokuDevice from provided entries.
-     */
-    private buildMergedDevice(configuredEntry: ConfiguredDeviceEntry | undefined, discoveredEntry: DiscoveredDeviceEntry | undefined): RokuDevice | undefined;
-    private buildMergedDevice(
-        keyOrLookupOrConfigured: string | { ip?: string; serialNumber?: string } | ConfiguredDeviceEntry | undefined,
-        discoveredEntry?: DiscoveredDeviceEntry | undefined
-    ): RokuDevice | undefined {
-        let configuredEntry: ConfiguredDeviceEntry | undefined;
+    private findDeviceEntries(keyOrLookup: string | { ip?: string; serialNumber?: string }): {
+        configured: ConfiguredDeviceEntry | undefined;
+        discovered: DiscoveredDeviceEntry | undefined;
+    } {
+        let configured: ConfiguredDeviceEntry | undefined;
         let discovered: DiscoveredDeviceEntry | undefined;
 
-        // Determine which overload was called
-        if (typeof keyOrLookupOrConfigured === 'string') {
-            // Called with encoded key - decode and look up
-            const key = keyOrLookupOrConfigured;
+        if (typeof keyOrLookup === 'string') {
+            // Decode encoded key
+            const key = keyOrLookup;
             if (key.startsWith('s:')) {
                 const serial = key.slice(2);
-                if (!serial) {
-                    return undefined;
+                if (serial) {
+                    configured = this.configuredDevices.find(c => c.serialNumber === serial);
+                    discovered = this.discoveredDevices.find(d => d.serialNumber === serial);
                 }
-                configuredEntry = this.configuredDevices.find(c => c.serialNumber === serial);
-                discovered = this.discoveredDevices.find(d => d.serialNumber === serial);
             } else if (key.startsWith('i:')) {
                 const ip = key.slice(2);
-                if (!ip) {
-                    return undefined;
+                if (ip) {
+                    configured = this.configuredDevices.find(c => c.resolvedIp === ip || c.host === ip);
+                    discovered = this.discoveredDevices.find(d => d.ip === ip);
                 }
-                configuredEntry = this.configuredDevices.find(c => c.resolvedIp === ip || c.host === ip);
-                discovered = this.discoveredDevices.find(d => d.ip === ip);
-            } else {
-                // Invalid key format
-                return undefined;
             }
-        } else if (discoveredEntry !== undefined || this.isConfiguredDeviceEntry(keyOrLookupOrConfigured)) {
-            // Called with entries directly
-            configuredEntry = keyOrLookupOrConfigured as ConfiguredDeviceEntry | undefined;
-            discovered = discoveredEntry;
-        } else if (keyOrLookupOrConfigured && ('ip' in keyOrLookupOrConfigured || 'serialNumber' in keyOrLookupOrConfigured)) {
-            // Called with lookup object - find entries in source arrays
-            const lookup = keyOrLookupOrConfigured as { ip?: string; serialNumber?: string };
+        } else {
+            // Lookup object
+            const lookup = keyOrLookup;
 
             if (lookup.serialNumber) {
-                configuredEntry = this.configuredDevices.find(c => c.serialNumber === lookup.serialNumber);
+                configured = this.configuredDevices.find(c => c.serialNumber === lookup.serialNumber);
                 discovered = this.discoveredDevices.find(d => d.serialNumber === lookup.serialNumber);
             }
 
             if (lookup.ip) {
-                if (!configuredEntry) {
-                    configuredEntry = this.configuredDevices.find(c => c.resolvedIp === lookup.ip || c.host === lookup.ip);
+                if (!configured) {
+                    configured = this.configuredDevices.find(c => c.resolvedIp === lookup.ip || c.host === lookup.ip);
                 }
                 if (!discovered) {
                     discovered = this.discoveredDevices.find(d => d.ip === lookup.ip);
@@ -1154,14 +1129,25 @@ export class DeviceManager {
             }
         }
 
-        if (!configuredEntry && !discovered) {
+        return { configured: configured, discovered: discovered };
+    }
+
+    /**
+     * Build a merged RokuDevice from configured and discovered entries.
+     * At least one of configured or discovered must be provided.
+     */
+    private buildMergedDevice(
+        configuredEntry: ConfiguredDeviceEntry | undefined,
+        discoveredEntry: DiscoveredDeviceEntry | undefined
+    ): RokuDevice | undefined {
+        if (!configuredEntry && !discoveredEntry) {
             return undefined;
         }
 
         // Determine IP: discovered > resolvedIp > host
         let ip: string;
-        if (discovered) {
-            ip = discovered.ip;
+        if (discoveredEntry) {
+            ip = discoveredEntry.ip;
         } else if (configuredEntry?.resolvedIp) {
             ip = configuredEntry.resolvedIp;
         } else {
@@ -1172,7 +1158,7 @@ export class DeviceManager {
         // Configured is user's explicit config, discovered is fresh network data,
         // cache is fallback for initial load before discovery runs
         const serialNumber = configuredEntry?.serialNumber ??
-            discovered?.serialNumber ??
+            discoveredEntry?.serialNumber ??
             this.globalStateManager.getSerialNumberForIp(ip, this.networkId);
 
         const deviceState = this.getDeviceState({ serialNumber: serialNumber, ip: ip });
@@ -1189,19 +1175,12 @@ export class DeviceManager {
             key: key,
             deviceState: deviceState,
             deviceInfo: cached?.deviceInfo ?? {},
-            isDiscovered: !!discovered,
+            isDiscovered: !!discoveredEntry,
             isConfigured: !!configuredEntry,
             configuredIn: configuredEntry?.configuredIn,
             configuredName: configuredEntry?.name,
             configuredPassword: configuredEntry?.password ?? this.getDefaultPassword()
         };
-    }
-
-    /**
-     * Type guard to check if an object is a ConfiguredDeviceEntry.
-     */
-    private isConfiguredDeviceEntry(obj: unknown): obj is ConfiguredDeviceEntry {
-        return obj !== null && typeof obj === 'object' && 'host' in obj;
     }
 
     /**
@@ -1262,7 +1241,8 @@ export class DeviceManager {
         });
 
         this.finder.on('lost', (ip: string) => {
-            this.removeDevice(ip);
+            this.removeDiscoveredDevice(ip);
+            this.emitDevicesChanged();
         });
 
         // Forward scan events from RokuFinder

--- a/src/deviceDiscovery/DeviceManager.ts
+++ b/src/deviceDiscovery/DeviceManager.ts
@@ -111,11 +111,8 @@ export class DeviceManager {
         });
 
         this.finder.on('lost', (ip: string) => {
-            // Find and remove device by IP
-            const device = this.getDeviceEntry({ ip: ip });
-            if (device) {
-                this.removeDevice(device.ip);
-            }
+            // Remove device from discovered array and update state
+            this.removeDevice(ip);
         });
 
         // Forward scan events from RokuFinder
@@ -146,7 +143,8 @@ export class DeviceManager {
     // #endregion
 
     // Core state and dependencies
-    private devices: DeviceEntry[] = [];
+    private configuredDevices: ConfiguredDeviceEntry[] = [];
+    private discoveredDevices: DiscoveredDeviceEntry[] = [];
     private scanNeeded = false;
     private lastUsedDeviceIp: string | undefined = undefined;
     private networkId: string;
@@ -212,60 +210,78 @@ export class DeviceManager {
      */
     public getDevice(lookup: { ip?: string; serialNumber?: string }): RokuDevice | undefined;
     public getDevice(keyOrLookup: string | { ip?: string; serialNumber?: string }): RokuDevice | undefined {
-        // Normalize input to lookup object
-        let lookup: { ip?: string; serialNumber?: string };
-        if (typeof keyOrLookup === 'string') {
-            // Decode string key - require explicit "s:" or "i:" prefix
-            if (keyOrLookup.startsWith('s:')) {
-                const serial = keyOrLookup.slice(2);
-                if (!serial) {
-                    return undefined;
-                }
-                lookup = { serialNumber: serial };
-            } else if (keyOrLookup.startsWith('i:')) {
-                const ip = keyOrLookup.slice(2);
-                if (!ip) {
-                    return undefined;
-                }
-                lookup = { ip: ip };
-            } else {
+        const device = this.buildMergedDevice(keyOrLookup as any);
+
+        // If lookup object with both ip and serialNumber, verify exact match
+        if (typeof keyOrLookup !== 'string' && keyOrLookup.ip && keyOrLookup.serialNumber && device) {
+            if (device.ip !== keyOrLookup.ip || device.serialNumber !== keyOrLookup.serialNumber) {
                 return undefined;
             }
-        } else {
-            lookup = keyOrLookup;
         }
 
-        const device = this.getDeviceEntry(lookup);
-        if (!device) {
-            return undefined;
-        }
-
-        // Hydrate deviceInfo from cache (use getSerial for fallback to IP→serial mapping)
-        const serial = this.getSerial(device);
-        const cached = serial ? this.globalStateManager.getCachedDevice(serial) : undefined;
-
-        return {
-            ...device,
-            deviceInfo: cached?.deviceInfo ?? {}
-        };
+        return device;
     }
 
     /**
      * Get a list of all roku devices known by this extension (by scanning, hardcoded lists, etc)
      * Returns full devices with deviceInfo hydrated from cache.
-     * Configured devices are sorted first, then by form factor, name, and id.
+     * Builds merged view on-demand from configuredDevices and discoveredDevices arrays.
+     * Deduplication by serial number (preferred) or IP (fallback).
      */
     public getAllDevices(): RokuDevice[] {
-        // Hydrate each device using getDevice()
-        const devices: RokuDevice[] = [];
-        for (const device of this.devices) {
-            const deviceDetail = this.getDevice({ ip: device.ip });
-            if (deviceDetail) {
-                devices.push(deviceDetail);
+        const mergedDevices = new Map<string, RokuDevice>();
+        const processedDiscoveredIndices = new Set<number>();
+
+        // Process configured devices first, finding matching discovered entries
+        for (const configured of this.configuredDevices) {
+            // Find matching discovered entry by serial, resolvedIp, or host
+            let discoveredIdx = -1;
+            let discovered: DiscoveredDeviceEntry | undefined;
+
+            if (configured.serialNumber) {
+                discoveredIdx = this.discoveredDevices.findIndex(d => d.serialNumber === configured.serialNumber);
+            }
+            if (discoveredIdx < 0 && configured.resolvedIp) {
+                discoveredIdx = this.discoveredDevices.findIndex(d => d.ip === configured.resolvedIp);
+            }
+            if (discoveredIdx < 0) {
+                discoveredIdx = this.discoveredDevices.findIndex(d => d.ip === configured.host);
+            }
+
+            if (discoveredIdx >= 0) {
+                discovered = this.discoveredDevices[discoveredIdx];
+                processedDiscoveredIndices.add(discoveredIdx);
+            }
+
+            const device = this.buildMergedDevice(configured, discovered);
+            if (device) {
+                mergedDevices.set(device.key, device);
             }
         }
 
-        return devices.sort(
+        // Process discovered-only devices (not already merged via configured)
+        for (let i = 0; i < this.discoveredDevices.length; i++) {
+            if (processedDiscoveredIndices.has(i)) {
+                continue;
+            }
+
+            const discovered = this.discoveredDevices[i];
+            const device = this.buildMergedDevice(undefined, discovered);
+            if (device) {
+                // Check for duplicate by key or IP
+                if (mergedDevices.has(device.key)) {
+                    continue;
+                }
+                const existingByIp = Array.from(mergedDevices.values()).find(d => d.ip === device.ip);
+                if (existingByIp) {
+                    continue;
+                }
+                mergedDevices.set(device.key, device);
+            }
+        }
+
+        // Convert to array and sort
+        return Array.from(mergedDevices.values()).sort(
             // Sort by form factor
             firstBy<RokuDevice>((a, b) => {
                 return this.getPriorityForDeviceFormFactor(a.deviceInfo) - this.getPriorityForDeviceFormFactor(b.deviceInfo);
@@ -290,6 +306,23 @@ export class DeviceManager {
     }
 
     /**
+     * Compute merged device state from configured and discovered states.
+     * Priority: online > offline > pending
+     */
+    private computeMergedState(
+        configuredState: DeviceState,
+        discoveredState: 'pending' | 'online' | undefined
+    ): DeviceState {
+        if (configuredState === 'online' || discoveredState === 'online') {
+            return 'online';
+        }
+        if (configuredState === 'offline') {
+            return 'offline';
+        }
+        return 'pending';
+    }
+
+    /**
      * Check if a device has cached info (has been successfully resolved before).
      * Used by view providers to determine icon: warning (no cache) vs disconnect (has cache).
      */
@@ -300,8 +333,8 @@ export class DeviceManager {
     /**
      * Re-scan the network for devices and health-check existing ones
      */
-    public refresh(force = false): boolean {
-        this.checkDevicesHealth(force).catch(() => { });
+    public refresh(force = false, doSyntheticDelay = true): boolean {
+        this.checkDevicesHealth(force, doSyntheticDelay).catch(() => { });
         // Block automatic scans when device discovery is disabled
         if (!force && !this.deviceDiscoveryEnabled) {
             return false;
@@ -314,15 +347,25 @@ export class DeviceManager {
      * Useful for refreshing the network scan without losing user-configured devices.
      */
     public clearCurrentDeviceList() {
-        // Keep configured devices, remove discovered-only devices
-        this.devices = this.devices.filter(d => d.isConfigured);
+        // Clear discovered devices (ephemeral)
+        this.discoveredDevices = [];
+
+        // Reset configured devices to pending (they persist but need re-verification)
+        for (const entry of this.configuredDevices) {
+            entry.deviceState = 'pending';
+        }
 
         // Clear short-lived device info cache
         this.deviceInfoCache.clear();
 
-        // Only clear lastUsedDeviceIp if it belonged to a discovered device that was removed
-        if (this.lastUsedDeviceIp && !this.devices.some(d => d.ip === this.lastUsedDeviceIp)) {
-            this.lastUsedDeviceIp = undefined;
+        // Only clear lastUsedDeviceIp if it belonged to a discovered-only device
+        if (this.lastUsedDeviceIp) {
+            const stillExists = this.configuredDevices.some(
+                d => d.resolvedIp === this.lastUsedDeviceIp || d.host === this.lastUsedDeviceIp
+            );
+            if (!stillExists) {
+                this.lastUsedDeviceIp = undefined;
+            }
         }
 
         this.emitDevicesChanged();
@@ -334,6 +377,9 @@ export class DeviceManager {
 
         // Clear current device list
         this.clearCurrentDeviceList();
+
+        // Clear new arrays completely (clearCurrentDeviceList already cleared discoveredDevices)
+        this.configuredDevices = [];
 
         // Clear global state
         this.globalStateManager.clearLastSeenDevices();
@@ -393,7 +439,8 @@ export class DeviceManager {
         this.systemSleepMonitor?.dispose?.();
         this.networkChangeMonitor?.dispose?.();
         this.finder?.dispose?.();
-        this.devices = [];
+        this.configuredDevices = [];
+        this.discoveredDevices = [];
         this.emitter.removeAllListeners();
 
         //clear any timeouts
@@ -414,40 +461,6 @@ export class DeviceManager {
         return util.getConfiguration('brightscript')?.deviceDiscovery?.showInfoMessages ?? true;
     }
 
-    /**
-     * Get device reference from array (lightweight, no cache lookup).
-     * For internal use only - doesn't hydrate from cache.
-     *
-     * @param lookup - Object with optional ip and/or serialNumber
-     * @returns Device reference from array or undefined
-     */
-    private getDeviceEntry(lookup: { ip?: string; serialNumber?: string }): DeviceEntry | undefined {
-        if (!lookup.ip && !lookup.serialNumber) {
-            return undefined;
-        }
-
-        if (lookup.ip && lookup.serialNumber) {
-            // Both provided: Must match both
-            return this.devices.find(d => d.ip === lookup.ip && this.getSerial(d) === lookup.serialNumber);
-        } else if (lookup.ip) {
-            // IP only: Match by IP (primary key)
-            return this.devices.find(d => d.ip === lookup.ip);
-        } else if (lookup.serialNumber) {
-            // Serial only: Match by serial in deviceInfo
-            return this.devices.find(d => this.getSerial(d) === lookup.serialNumber);
-        }
-
-        return undefined;
-    }
-
-    /**
-     * Get serial number for a device.
-     * Checks device.serialNumber first, falls back to IP→serial mapping.
-     */
-    private getSerial(device: DeviceEntry): string | undefined {
-        return device.serialNumber ?? this.globalStateManager.getSerialNumberForIp(device.ip, this.networkId);
-    }
-
     private get timeSinceLastScan(): number {
         if (!this.lastScanDate) {
             return Infinity; // Never scanned, so always stale
@@ -466,133 +479,44 @@ export class DeviceManager {
     }
 
     /**
-     * Add or update a device in the devices array.
-     * Computes the device key from serialNumber (or falls back to IP).
-     * Handles deduplication when a device changes IP (same serial, different IP).
+     * Remove a device from the discoveredDevices array and update lastSeenDevices.
      */
-    private setDevice(input: Omit<DeviceEntry, 'key'>): void {
-        /**
-         * Apply merge rules: preserve state from existing entry based on discovered/configured status.
-         * - Keep highest device state: online > offline > pending
-         * - If existing is discovered and input is configuring: keep discovered state, apply config
-         * - If existing is configured and input is discovering: keep config props, apply discovered
-         */
-        const applyMergeRules = (existing: DeviceEntry) => {
-            // Keep highest device state: online > offline > pending
-            const stateRank: Record<DeviceState, number> = { online: 2, offline: 1, pending: 0 };
-            if (stateRank[existing.deviceState] > stateRank[input.deviceState]) {
-                input.deviceState = existing.deviceState;
-            }
+    private removeDevice(deviceIp: string): void {
+        // Find the serial before removing
+        const discovered = this.discoveredDevices.find(d => d.ip === deviceIp);
+        const serial = discovered?.serialNumber ?? this.globalStateManager.getSerialNumberForIp(deviceIp, this.networkId);
 
-            if (existing.isDiscovered && 'isConfigured' in input && input.isConfigured) {
-                input.isDiscovered = existing.isDiscovered;
-            } else if (existing.isConfigured && 'isDiscovered' in input && input.isDiscovered) {
-                input.isConfigured = existing.isConfigured;
-                input.configuredName = existing.configuredName;
-                input.configuredPassword = existing.configuredPassword;
-                input.configuredIn = existing.configuredIn;
-            }
-        };
+        // Remove from discovered devices
+        this.removeDiscoveredDevice(deviceIp);
 
-        // Serial dedupe: check for existing device with same serial at DIFFERENT IP
-        if (input.serialNumber) {
-            const oldEntry = this.devices.find(d => d.ip !== input.ip && this.getSerial(d) === input.serialNumber);
-            if (oldEntry) {
-                // If old is discovered and new is config, keep the discovered IP
-                if (oldEntry.isDiscovered && 'isConfigured' in input && input.isConfigured) {
-                    input.ip = oldEntry.ip;
-                }
-
-                applyMergeRules(oldEntry);
-
-                // Transfer lastUsedDeviceIp to new IP if it was pointing to old device
-                if (this.lastUsedDeviceIp === oldEntry.ip) {
-                    this.lastUsedDeviceIp = input.ip;
-                }
-
-                // Remove old entry directly from array
-                this.devices = this.devices.filter(d => d.ip !== oldEntry.ip);
-            }
+        // Remove from last seen devices (if has serial)
+        if (serial) {
+            this.globalStateManager.removeLastSeenDevice(this.networkId, serial);
         }
 
-        // IP dedupe: check for existing device at same IP
-        const existingIndex = this.devices.findIndex(d => d.ip === input.ip);
-        if (existingIndex >= 0) {
-            applyMergeRules(this.devices[existingIndex]);
-            this.devices = this.devices.filter((_, i) => i !== existingIndex);
+        // Clear lastUsedDeviceIp if the removed device was the last used
+        if (this.lastUsedDeviceIp === deviceIp) {
+            this.lastUsedDeviceIp = undefined;
         }
-
-        // Compute key: serial-based when available, IP-based as fallback
-        const key = input.serialNumber ? `s:${input.serialNumber}` : `i:${input.ip}`;
-        const device: DeviceEntry = { ...input, key: key };
-
-        this.devices.push(device);
 
         this.emitDevicesChanged();
     }
 
     /**
-     * Mark a device as unreachable after a failed health check.
-     * - Configured devices: marked 'offline', isDiscovered = false
-     * - Discovered-only devices: removed from the list
-     */
-    private markDeviceUnreachable(deviceIp: string): void {
-        const device = this.getDeviceEntry({ ip: deviceIp });
-        if (!device) {
-            return;
-        }
-
-        if (device.isConfigured) {
-            // Configured devices stay but marked offline and not discovered
-            device.deviceState = 'offline';
-            device.isDiscovered = false;
-            this.emitDevicesChanged();
-        } else {
-            // Discovered-only device: remove it
-            this.removeDevice(deviceIp);
-        }
-    }
-
-    /**
-     * Remove a device from the devices array.
-     */
-    private removeDevice(deviceIp: string): void {
-        const device = this.getDeviceEntry({ ip: deviceIp });
-        if (device) {
-            this.devices = this.devices.filter(d => d.ip !== deviceIp);
-
-            // Remove from last seen devices (if has serial)
-            const serial = this.getSerial(device);
-            if (serial) {
-                this.globalStateManager.removeLastSeenDevice(this.networkId, serial);
-            }
-
-            // Clear lastUsedDeviceIp if the removed device was the last used
-            if (this.lastUsedDeviceIp === deviceIp) {
-                this.lastUsedDeviceIp = undefined;
-            }
-
-            this.emitDevicesChanged();
-        }
-    }
-
-    /**
      * Load last seen devices from cache.
-     * Removes non-configured devices and resets configured devices to pending (no-op at startup).
-     * Then loads cached devices for the current network.
+     * Resets configured devices to pending and clears discovered devices.
+     * Last seen devices are used to pre-populate the IP→serial mapping.
      */
     private loadLastSeenDevices(): void {
-        // flip configured devices to pending and remove all the rest
-        for (let i = this.devices.length - 1; i >= 0; i--) {
-            const device = this.devices[i];
-            if (device.isConfigured) {
-                device.deviceState = 'pending';
-            } else {
-                this.devices.splice(i, 1);
-            }
+        // Reset configured devices to pending
+        for (const entry of this.configuredDevices) {
+            entry.deviceState = 'pending';
         }
 
-        // Load cached devices for current network
+        // Clear discovered devices (ephemeral - reload from network)
+        this.discoveredDevices = [];
+
+        // Load cached devices for current network - add to discoveredDevices with 'pending' state
         const lastSeenDevices = this.globalStateManager.getLastSeenDevices(this.networkId);
         for (const serialNumber of lastSeenDevices) {
             const cached = this.globalStateManager.getCachedDevice(serialNumber);
@@ -604,15 +528,15 @@ export class DeviceManager {
                     this.globalStateManager.removeLastSeenDevice(this.networkId, serialNumber);
                     continue;
                 }
-                // Create device with serial (key computed by setDevice)
-                this.setDevice({
-                    ip: ip,
-                    serialNumber: serialNumber,
-                    deviceState: 'pending',
-                    isDiscovered: false
-                });
                 // Ensure IP→serial mapping is set up
                 this.globalStateManager.setSerialNumberForIp(this.networkId, ip, serialNumber);
+
+                // Add to discoveredDevices with 'pending' state (will be updated when device responds)
+                this.discoveredDevices.push({
+                    ip: ip,
+                    serialNumber: serialNumber,
+                    deviceState: 'pending'
+                });
             } else {
                 // No cached info - remove stale entry
                 this.globalStateManager.removeLastSeenDevice(this.networkId, serialNumber);
@@ -682,21 +606,33 @@ export class DeviceManager {
             });
         }
 
-        const configuredDevices = Array.from(deviceMap.values());
+        const configuredDevicesList = Array.from(deviceMap.values());
+
+        // Track which hosts are still in config (for removal logic)
+        const configuredHosts = new Set<string>();
+        const configuredSerials = new Set<string>();
 
         // Track resolved IPs so removal loop can compare against them (not hostnames)
         const configuredIps = new Set<string>();
 
         // First: add/update configured devices (with DNS resolution)
-        for (const configured of configuredDevices) {
-            // Resolve hostname to IP address (handles both hostnames and IPs)
-            let ip = configured.host;
-            try {
-                ip = await rokuDebugUtil.dnsLookup(configured.host);
-            } catch {
-                // DNS lookup failed - keep original host value as fallback
-                // This allows IP addresses to work even if DNS resolution fails
+        for (const configured of configuredDevicesList) {
+            configuredHosts.add(configured.host);
+            if (configured.serialNumber) {
+                configuredSerials.add(configured.serialNumber);
             }
+
+            // Resolve hostname to IP address (handles both hostnames and IPs)
+            let resolvedIp: string | undefined;
+            try {
+                resolvedIp = await rokuDebugUtil.dnsLookup(configured.host);
+            } catch {
+                // DNS lookup failed - resolvedIp remains undefined
+                // This allows the original host to be used if it's an IP
+            }
+
+            // Use resolved IP or fall back to host (if host looks like IP)
+            const ip = resolvedIp ?? configured.host;
 
             // Track resolved IP for removal loop
             configuredIps.add(ip);
@@ -707,64 +643,48 @@ export class DeviceManager {
                 serialNumber = this.globalStateManager.getSerialNumberForIp(ip, this.networkId);
             }
 
-            // Check if device already exists by IP (primary key)
-            const existingDevice = this.getDeviceEntry({ ip: ip });
+            // Check for existing entry in configuredDevices by host
+            const existingConfiguredIdx = this.configuredDevices.findIndex(
+                d => d.host === configured.host ||
+                    (configured.serialNumber && d.serialNumber === configured.serialNumber)
+            );
+            const existingConfigured = existingConfiguredIdx >= 0 ? this.configuredDevices[existingConfiguredIdx] : undefined;
 
             // Preserve state if device exists
-            const deviceState = existingDevice?.deviceState ?? 'pending';
-            const isDiscovered = existingDevice?.isDiscovered ?? false;
+            const deviceState = existingConfigured?.deviceState ?? 'pending';
+
+            // Update or add to configuredDevices array
+            const configuredEntry: ConfiguredDeviceEntry = {
+                ...configured,
+                resolvedIp: resolvedIp,
+                deviceState: deviceState
+            };
+
+            if (existingConfiguredIdx >= 0) {
+                this.configuredDevices[existingConfiguredIdx] = configuredEntry;
+            } else {
+                this.configuredDevices.push(configuredEntry);
+            }
 
             // Set up IP→serial mapping if we have serial (deviceInfo already cached if it exists)
             if (serialNumber) {
                 this.globalStateManager.setSerialNumberForIp(this.networkId, ip, serialNumber);
             }
-
-            // Create device with serial if known (key computed by setDevice)
-            this.setDevice({
-                ip: ip,
-                serialNumber: serialNumber,
-                deviceState: deviceState,
-                isConfigured: true,
-                configuredIn: configured.configuredIn,
-                isDiscovered: isDiscovered,
-                configuredName: configured.name,
-                configuredPassword: configured.password
-            });
         }
 
-        // Then: remove devices no longer in config (using resolved IPs, not hostnames)
-        for (let i = this.devices.length - 1; i >= 0; i--) {
-            const device = this.devices[i];
+        // Remove configured devices no longer in config
+        for (let i = this.configuredDevices.length - 1; i >= 0; i--) {
+            const entry = this.configuredDevices[i];
+            const stillConfigured = configuredHosts.has(entry.host) ||
+                (entry.serialNumber && configuredSerials.has(entry.serialNumber));
 
-            // Skip non-configured devices
-            if (!device.isConfigured) {
-                continue;
-            }
-
-            // Check if still in config (by resolved IP or serial)
-            const serial = this.getSerial(device);
-            const stillConfigured = configuredIps.has(device.ip) ||
-                configuredDevices.some(c => serial && c.serialNumber === serial);
-
-            if (stillConfigured) {
-                continue;
-            }
-
-            // Device removed from config
-            if (device.isDiscovered) {
-                // Keep as discovered-only device
-                device.isConfigured = false;
-                device.configuredIn = [];
-                device.configuredName = undefined;
-                device.configuredPassword = undefined;
-            } else {
-                // Not discovered either, remove completely
-                this.devices.splice(i, 1);
+            if (!stillConfigured) {
+                this.configuredDevices.splice(i, 1);
             }
         }
     }
 
-    private async resolveDevice(device: DeviceEntry, doSyntheticDelay = true): Promise<boolean> {
+    private async resolveDevice(device: RokuDevice | { ip: string }, doSyntheticDelay = true): Promise<boolean> {
 
         // Increment and capture sequence number to handle concurrent refresh calls
         // Use IP for sequence tracking (primary key)
@@ -772,9 +692,22 @@ export class DeviceManager {
         this.resolveDeviceSequence.set(device.ip, currentSeq);
 
         // Set to pending during health check with immediate UI feedback
-        const existingDevice = this.getDeviceEntry({ ip: device.ip });
-        if (existingDevice && existingDevice.deviceState !== 'pending') {
-            existingDevice.deviceState = 'pending';
+        // Update both arrays to show pending state
+        let stateChanged = false;
+
+        const configuredEntry = this.getConfiguredDeviceByIp(device.ip);
+        if (configuredEntry && configuredEntry.deviceState !== 'pending') {
+            configuredEntry.deviceState = 'pending';
+            stateChanged = true;
+        }
+
+        const discoveredEntry = this.discoveredDevices.find(d => d.ip === device.ip);
+        if (discoveredEntry && discoveredEntry.deviceState !== 'pending') {
+            discoveredEntry.deviceState = 'pending';
+            stateChanged = true;
+        }
+
+        if (stateChanged) {
             this.emitDevicesChanged();
         }
 
@@ -811,24 +744,51 @@ export class DeviceManager {
                 this.globalStateManager.addLastSeenDevice(this.networkId, serial);
             }
 
-            // Create device with serial (key computed by setDevice, dedupe handled internally)
-            this.setDevice({
-                ip: device.ip,
-                serialNumber: serial,
-                deviceState: 'online',
-                isDiscovered: true
-            });
+            // Update discoveredDevices array
+            this.setDiscoveredDevice(device.ip, serial, 'online');
 
+            // Update configuredDevices if this device is configured
+            this.updateConfiguredDeviceState(device.ip, serial, 'online');
+
+            this.emitDevicesChanged();
             return true;
         } else {
-            this.markDeviceUnreachable(device.ip);
+            // Remove from discoveredDevices (ephemeral - offline devices are removed)
+            this.removeDiscoveredDevice(device.ip);
+
+            // Update configured device state to offline (configured devices persist)
+            this.updateConfiguredDeviceState(device.ip, undefined, 'offline');
+
+            this.emitDevicesChanged();
             return false;
         }
     }
 
-    private async checkDevicesHealth(force = false): Promise<void> {
-        // Use internal devices array directly - no need to hydrate from cache
-        const devices = this.devices;
+    /**
+     * Update state for a configured device by IP or serial number.
+     */
+    private updateConfiguredDeviceState(ip: string, serialNumber: string | undefined, state: DeviceState): void {
+        // Try to find by serial first (more reliable), then by IP
+        let entry: ConfiguredDeviceEntry | undefined;
+        if (serialNumber) {
+            entry = this.getConfiguredDeviceBySerial(serialNumber);
+        }
+        if (!entry) {
+            entry = this.getConfiguredDeviceByIp(ip);
+        }
+
+        if (entry) {
+            entry.deviceState = state;
+            // Update resolvedIp if we have a successful resolution
+            if (state === 'online' && ip) {
+                entry.resolvedIp = ip;
+            }
+        }
+    }
+
+    private async checkDevicesHealth(force = false, doSyntheticDelay = true): Promise<void> {
+        // Get all devices from merged view
+        const devices = this.getAllDevices();
 
         // Filter to devices that need checking
         const devicesToCheck = force ? devices : devices.filter(d => {
@@ -842,7 +802,15 @@ export class DeviceManager {
 
         // Set all to pending and emit before async work
         for (const device of devicesToCheck) {
-            device.deviceState = 'pending';
+            // Update state in source arrays (both configured and discovered)
+            const configuredEntry = this.getConfiguredDeviceByIp(device.ip);
+            if (configuredEntry) {
+                configuredEntry.deviceState = 'pending';
+            }
+            const discoveredEntry = this.discoveredDevices.find(d => d.ip === device.ip);
+            if (discoveredEntry) {
+                discoveredEntry.deviceState = 'pending';
+            }
             this.lastHealthCheckTime.set(device.ip, Date.now());
         }
         this.emitDevicesChanged();
@@ -850,7 +818,7 @@ export class DeviceManager {
         // Check all devices
         let needsScan = false;
         await Promise.all(devicesToCheck.map(async (device) => {
-            const isHealthy = await this.resolveDevice(device);
+            const isHealthy = await this.resolveDevice(device, doSyntheticDelay);
             if (!isHealthy) {
                 needsScan = true;
             }
@@ -937,16 +905,194 @@ export class DeviceManager {
                 this.globalStateManager.setSerialNumberForIp(this.networkId, ip, serial);
             }
 
-            // Create device with serial (key computed by setDevice, dedupe handled internally)
-            this.setDevice({
-                ip: ip,
-                serialNumber: serial,
-                deviceState: 'online',
-                isDiscovered: true
-            });
+            // Update discoveredDevices array
+            this.setDiscoveredDevice(ip, serial, 'online');
+
+            // Update configured device state if present
+            this.updateConfiguredDeviceState(ip, serial, 'online');
+
+            this.emitDevicesChanged();
         } catch {
-            // Device unreachable, ignore
+            // Device unreachable - remove from discoveredDevices if present
+            this.removeDiscoveredDevice(ip);
         }
+    }
+
+    /**
+     * Add or update a device in the discoveredDevices array.
+     * Handles deduplication by serial number (removes old IP entry if serial matches).
+     */
+    private setDiscoveredDevice(ip: string, serialNumber: string | undefined, deviceState: 'pending' | 'online'): void {
+        // Serial dedupe: if same serial exists at different IP, remove old entry
+        if (serialNumber) {
+            const oldIdx = this.discoveredDevices.findIndex(d => d.ip !== ip && d.serialNumber === serialNumber);
+            if (oldIdx >= 0) {
+                const oldIp = this.discoveredDevices[oldIdx].ip;
+                // Transfer lastUsedDeviceIp to new IP if it was pointing to old IP
+                if (this.lastUsedDeviceIp === oldIp) {
+                    this.lastUsedDeviceIp = ip;
+                }
+                this.discoveredDevices.splice(oldIdx, 1);
+            }
+        }
+
+        // IP dedupe: find existing entry at same IP
+        const existingIdx = this.discoveredDevices.findIndex(d => d.ip === ip);
+        if (existingIdx >= 0) {
+            // Update existing entry
+            this.discoveredDevices[existingIdx] = {
+                ip: ip,
+                serialNumber: serialNumber,
+                deviceState: deviceState
+            };
+        } else {
+            // Add new entry
+            this.discoveredDevices.push({
+                ip: ip,
+                serialNumber: serialNumber,
+                deviceState: deviceState
+            });
+        }
+    }
+
+    /**
+     * Remove a device from the discoveredDevices array by IP.
+     */
+    private removeDiscoveredDevice(ip: string): void {
+        const idx = this.discoveredDevices.findIndex(d => d.ip === ip);
+        if (idx >= 0) {
+            this.discoveredDevices.splice(idx, 1);
+        }
+    }
+
+    /**
+     * Find a configured device by serial number.
+     */
+    private getConfiguredDeviceBySerial(serialNumber: string): ConfiguredDeviceEntry | undefined {
+        return this.configuredDevices.find(d => d.serialNumber === serialNumber);
+    }
+
+    /**
+     * Find a configured device by host or resolved IP.
+     */
+    private getConfiguredDeviceByIp(ip: string): ConfiguredDeviceEntry | undefined {
+        return this.configuredDevices.find(d => d.resolvedIp === ip || d.host === ip);
+    }
+
+    /**
+     * Build a merged RokuDevice by decoding an encoded key (s:serial or i:ip).
+     */
+    private buildMergedDevice(key: string): RokuDevice | undefined;
+    /**
+     * Build a merged RokuDevice by looking up in source arrays.
+     */
+    private buildMergedDevice(lookup: { ip?: string; serialNumber?: string }): RokuDevice | undefined;
+    /**
+     * Build a merged RokuDevice from provided entries.
+     */
+    private buildMergedDevice(configuredEntry: ConfiguredDeviceEntry | undefined, discoveredEntry: DiscoveredDeviceEntry | undefined): RokuDevice | undefined;
+    private buildMergedDevice(
+        keyOrLookupOrConfigured: string | { ip?: string; serialNumber?: string } | ConfiguredDeviceEntry | undefined,
+        discoveredEntry?: DiscoveredDeviceEntry | undefined
+    ): RokuDevice | undefined {
+        let configuredEntry: ConfiguredDeviceEntry | undefined;
+        let discovered: DiscoveredDeviceEntry | undefined;
+
+        // Determine which overload was called
+        if (typeof keyOrLookupOrConfigured === 'string') {
+            // Called with encoded key - decode and look up
+            const key = keyOrLookupOrConfigured;
+            if (key.startsWith('s:')) {
+                const serial = key.slice(2);
+                if (!serial) {
+                    return undefined;
+                }
+                configuredEntry = this.configuredDevices.find(c => c.serialNumber === serial);
+                discovered = this.discoveredDevices.find(d => d.serialNumber === serial);
+            } else if (key.startsWith('i:')) {
+                const ip = key.slice(2);
+                if (!ip) {
+                    return undefined;
+                }
+                configuredEntry = this.configuredDevices.find(c => c.resolvedIp === ip || c.host === ip);
+                discovered = this.discoveredDevices.find(d => d.ip === ip);
+            } else {
+                // Invalid key format
+                return undefined;
+            }
+        } else if (discoveredEntry !== undefined || this.isConfiguredDeviceEntry(keyOrLookupOrConfigured)) {
+            // Called with entries directly
+            configuredEntry = keyOrLookupOrConfigured as ConfiguredDeviceEntry | undefined;
+            discovered = discoveredEntry;
+        } else if (keyOrLookupOrConfigured && ('ip' in keyOrLookupOrConfigured || 'serialNumber' in keyOrLookupOrConfigured)) {
+            // Called with lookup object - find entries in source arrays
+            const lookup = keyOrLookupOrConfigured as { ip?: string; serialNumber?: string };
+
+            if (lookup.serialNumber) {
+                configuredEntry = this.configuredDevices.find(c => c.serialNumber === lookup.serialNumber);
+                discovered = this.discoveredDevices.find(d => d.serialNumber === lookup.serialNumber);
+            }
+
+            if (lookup.ip) {
+                if (!configuredEntry) {
+                    configuredEntry = this.configuredDevices.find(c => c.resolvedIp === lookup.ip || c.host === lookup.ip);
+                }
+                if (!discovered) {
+                    discovered = this.discoveredDevices.find(d => d.ip === lookup.ip);
+                }
+            }
+        }
+
+        if (!configuredEntry && !discovered) {
+            return undefined;
+        }
+
+        // Determine IP: discovered > resolvedIp > host
+        let ip: string;
+        if (discovered) {
+            ip = discovered.ip;
+        } else if (configuredEntry?.resolvedIp) {
+            ip = configuredEntry.resolvedIp;
+        } else {
+            ip = configuredEntry.host;
+        }
+
+        // Determine serial: cache > configured > discovered
+        const serialNumber = this.globalStateManager.getSerialNumberForIp(ip, this.networkId) ??
+            configuredEntry?.serialNumber ??
+            discovered?.serialNumber;
+
+        // Compute merged state: online > offline > pending
+        const deviceState = this.computeMergedState(
+            configuredEntry?.deviceState,
+            discovered?.deviceState
+        );
+
+        // Build key
+        const key = serialNumber ? `s:${serialNumber}` : `i:${ip}`;
+
+        // Hydrate deviceInfo from cache
+        const cached = serialNumber ? this.globalStateManager.getCachedDevice(serialNumber) : undefined;
+
+        return {
+            ip: ip,
+            serialNumber: serialNumber,
+            key: key,
+            deviceState: deviceState,
+            deviceInfo: cached?.deviceInfo ?? {},
+            isDiscovered: !!discovered,
+            isConfigured: !!configuredEntry,
+            configuredIn: configuredEntry?.configuredIn,
+            configuredName: configuredEntry?.name,
+            configuredPassword: configuredEntry?.password
+        };
+    }
+
+    /**
+     * Type guard to check if an object is a ConfiguredDeviceEntry.
+     */
+    private isConfiguredDeviceEntry(obj: unknown): obj is ConfiguredDeviceEntry {
+        return obj !== null && typeof obj === 'object' && 'host' in obj;
     }
 
     /**
@@ -1037,7 +1183,7 @@ export type ConfigurationScope = 'user' | 'workspace';
 /**
  * User-configured device from settings (brightscript.devices)
  */
-export interface ConfiguredDevice {
+interface ConfiguredDevice {
     host: string;
     name?: string;
     serialNumber?: string;
@@ -1045,53 +1191,89 @@ export interface ConfiguredDevice {
 }
 
 /**
- * Internal device entry with runtime state
- * Used internally by DeviceManager for tracking devices
+ * Internal: configured device from settings
+ * Extends the raw settings shape with runtime tracking fields.
+ * Persists even when device goes offline.
  */
-interface DeviceEntry {
-    ip: string;
+interface ConfiguredDeviceEntry extends ConfiguredDevice {
     /**
-     * Device serial number, when known. Set when device is resolved.
+     * IP from DNS lookup (updated on resolution)
      */
-    serialNumber?: string;
+    resolvedIp?: string;
     /**
-     * Encoded device key for identification.
-     * Format: "s:{serialNumber}" when serial is available, "i:{ip}" as fallback.
-     * Computed in setDevice() whenever device state changes.
+     * Device state: pending/online/offline (persists even when offline)
      */
-    key: string;
     deviceState: DeviceState;
     /**
-     * Current discovery state. True when device is actively discovered on network.
-     * Toggles false when device becomes unreachable.
-     */
-    isDiscovered?: boolean;
-    /**
-     * If true, this device was configured by the user (in any scope).
-     * Configured devices are never auto-removed.
-     */
-    isConfigured?: boolean;
-    /**
-     * Which settings scopes this device is configured in.
+     * Which settings scopes this device is configured in
      */
     configuredIn?: ConfigurationScope[];
-    /**
-     * User-provided name from config (brightscript.devices).
-     * UI should display this over deviceInfo['user-device-name'] when present.
-     */
-    configuredName?: string;
-    /**
-     * User-provided password from config.
-     */
-    configuredPassword?: string;
 }
 
 /**
- * Full device details returned by public API (extends DeviceEntry with cached data)
- * Includes runtime state plus cached deviceInfo from GlobalStateManager
+ * Internal: discovered device from network
+ * Removed when device goes offline (ephemeral)
  */
-export interface RokuDevice extends DeviceEntry {
+interface DiscoveredDeviceEntry {
+    /**
+     * Current IP from SSDP/resolution
+     */
+    ip: string;
+    /**
+     * Serial number from device-info response
+     */
+    serialNumber?: string;
+    /**
+     * Device state: pending/online only (offline = removed from array)
+     */
+    deviceState: 'pending' | 'online';
+}
+
+/**
+ * Full device details returned by public API
+ * Built on-demand by merging configured and discovered device data
+ */
+export interface RokuDevice {
+    /**
+     * Computed IP from resolution order: discovered > resolvedIp > host
+     */
+    ip: string;
+    /**
+     * Serial number from discovered or configured
+     */
+    serialNumber?: string;
+    /**
+     * Encoded device key: "s:{serial}" or "i:{ip}"
+     */
+    key: string;
+    /**
+     * Computed state: online > offline > pending (from both sources)
+     */
+    deviceState: DeviceState;
+    /**
+     * Cached device info from GlobalStateManager
+     */
     deviceInfo: Record<string, any>;
+    /**
+     * True if device exists in discoveredDevices array
+     */
+    isDiscovered: boolean;
+    /**
+     * True if device exists in configuredDevices array
+     */
+    isConfigured: boolean;
+    /**
+     * Which settings scopes this device is configured in
+     */
+    configuredIn?: ConfigurationScope[];
+    /**
+     * User-provided name from config
+     */
+    configuredName?: string;
+    /**
+     * User-provided password from config
+     */
+    configuredPassword?: string;
 }
 
 function throttleBounce<T extends (...args: any[]) => void>(

--- a/src/deviceDiscovery/DeviceManager.ts
+++ b/src/deviceDiscovery/DeviceManager.ts
@@ -90,6 +90,11 @@ export class DeviceManager {
             this.networkId = getNetworkHash();
             this.fetchDeviceThrottleData.clear();
 
+            //reset configured devices to pending - need to re-verify on new network
+            for (const entry of this.configuredDevices) {
+                entry.deviceState = 'pending';
+            }
+
             //clear and reload discovered devices anytime this network changes
             this.discoveredDevices = [];
             this.loadLastSeenDevices();
@@ -489,15 +494,9 @@ export class DeviceManager {
 
     /**
      * Load last seen devices from cache.
-     * Resets configured devices to pending and clears discovered devices.
      * Last seen devices are used to pre-populate the IP→serial mapping.
      */
     private loadLastSeenDevices(): void {
-        // Reset configured devices to pending
-        for (const entry of this.configuredDevices) {
-            entry.deviceState = 'pending';
-        }
-
         // Clear discovered devices (ephemeral - reload from network)
         this.discoveredDevices = [];
 
@@ -533,134 +532,83 @@ export class DeviceManager {
      */
     private async loadConfiguredDevices(): Promise<void> {
         // Read config from all VSCode scopes
-        const config = vscode.workspace.getConfiguration('brightscript');
-        // inspect may not be available in test mocks
-        if (typeof config.inspect !== 'function') {
-            return;
-        }
-        const inspection = config.inspect<ConfiguredDevice[]>('devices');
-
-        // Get devices from specific scopes we care about
+        const inspection = vscode.workspace.getConfiguration('brightscript').inspect<ConfiguredDevice[]>('devices');
         const userDevices = inspection?.globalValue ?? [];
         const workspaceDevices = inspection?.workspaceValue ?? [];
 
         // Build a map tracking which scopes each device is in
-        // Key is serialNumber or host, value includes scope info
         interface ConfiguredDeviceWithScope extends ConfiguredDevice {
             configuredIn: ConfigurationScope[];
         }
         const deviceMap = new Map<string, ConfiguredDeviceWithScope>();
 
-        // Process user settings
-        for (const device of userDevices) {
-            if (!device?.host) {
-                continue;
+        function addDevicesFromScope(devices: ConfiguredDevice[], scope: ConfigurationScope) {
+            for (const device of devices) {
+                if (!device?.host) {
+                    continue;
+                }
+                const key = device.serialNumber || device.host;
+                const existing = deviceMap.get(key);
+                const scopes = existing?.configuredIn ?? [];
+                if (!scopes.includes(scope)) {
+                    scopes.push(scope);
+                }
+                deviceMap.set(key, {
+                    ...existing,
+                    ...device,
+                    configuredIn: scopes
+                });
             }
-            const key = device.serialNumber || device.host;
-            const existing = deviceMap.get(key);
-            const scopes = existing?.configuredIn ?? [];
-            if (!scopes.includes('user')) {
-                scopes.push('user');
-            }
-            deviceMap.set(key, {
-                ...existing,
-                ...device,
-                configuredIn: scopes
-            });
         }
 
-        // Process workspace settings
-        for (const device of workspaceDevices) {
-            if (!device?.host) {
-                continue;
+        addDevicesFromScope(userDevices, 'user');
+        addDevicesFromScope(workspaceDevices, 'workspace');
+
+        // Capture existing states before clearing (to avoid UI flicker)
+        const previousStatesByHost = new Map<string, DeviceState>();
+        const previousStatesBySerial = new Map<string, DeviceState>();
+        for (const entry of this.configuredDevices) {
+            previousStatesByHost.set(entry.host, entry.deviceState);
+            if (entry.serialNumber) {
+                previousStatesBySerial.set(entry.serialNumber, entry.deviceState);
             }
-            const key = device.serialNumber || device.host;
-            const existing = deviceMap.get(key);
-            const scopes = existing?.configuredIn ?? [];
-            if (!scopes.includes('workspace')) {
-                scopes.push('workspace');
-            }
-            deviceMap.set(key, {
-                ...existing,
-                ...device,
-                configuredIn: scopes
-            });
         }
 
-        const configuredDevicesList = Array.from(deviceMap.values());
+        // Clear and rebuild
+        this.configuredDevices = [];
 
-        // Track which hosts are still in config (for removal logic)
-        const configuredHosts = new Set<string>();
-        const configuredSerials = new Set<string>();
-
-        // Track resolved IPs so removal loop can compare against them (not hostnames)
-        const configuredIps = new Set<string>();
-
-        // First: add/update configured devices (with DNS resolution)
-        for (const configured of configuredDevicesList) {
-            configuredHosts.add(configured.host);
-            if (configured.serialNumber) {
-                configuredSerials.add(configured.serialNumber);
-            }
-
+        for (const configured of deviceMap.values()) {
             // Resolve hostname to IP address (handles both hostnames and IPs)
             let resolvedIp: string | undefined;
             try {
                 resolvedIp = await rokuDebugUtil.dnsLookup(configured.host);
             } catch {
                 // DNS lookup failed - resolvedIp remains undefined
-                // This allows the original host to be used if it's an IP
             }
 
-            // Use resolved IP or fall back to host (if host looks like IP)
             const ip = resolvedIp ?? configured.host;
 
-            // Track resolved IP for removal loop
-            configuredIps.add(ip);
-
-            // Determine serial number (must be after DNS resolution so IP lookup works)
+            // Look up serial from cache if not provided in config
             let serialNumber = configured.serialNumber;
             if (!serialNumber) {
                 serialNumber = this.globalStateManager.getSerialNumberForIp(ip, this.networkId);
             }
 
-            // Check for existing entry in configuredDevices by host
-            const existingConfiguredIdx = this.configuredDevices.findIndex(
-                d => d.host === configured.host ||
-                    (configured.serialNumber && d.serialNumber === configured.serialNumber)
-            );
-            const existingConfigured = existingConfiguredIdx >= 0 ? this.configuredDevices[existingConfiguredIdx] : undefined;
+            // Restore previous state if available (prefer serial match over host match)
+            const deviceState =
+                previousStatesBySerial.get(configured.serialNumber) ??
+                previousStatesByHost.get(configured.host) ??
+                'pending';
 
-            // Preserve state if device exists
-            const deviceState = existingConfigured?.deviceState ?? 'pending';
-
-            // Update or add to configuredDevices array
-            const configuredEntry: ConfiguredDeviceEntry = {
+            this.configuredDevices.push({
                 ...configured,
                 resolvedIp: resolvedIp,
                 deviceState: deviceState
-            };
+            });
 
-            if (existingConfiguredIdx >= 0) {
-                this.configuredDevices[existingConfiguredIdx] = configuredEntry;
-            } else {
-                this.configuredDevices.push(configuredEntry);
-            }
-
-            // Set up IP→serial mapping if we have serial (deviceInfo already cached if it exists)
+            // Set up IP→serial mapping if we have serial
             if (serialNumber) {
                 this.globalStateManager.setSerialNumberForIp(this.networkId, ip, serialNumber);
-            }
-        }
-
-        // Remove configured devices no longer in config
-        for (let i = this.configuredDevices.length - 1; i >= 0; i--) {
-            const entry = this.configuredDevices[i];
-            const stillConfigured = configuredHosts.has(entry.host) ||
-                (entry.serialNumber && configuredSerials.has(entry.serialNumber));
-
-            if (!stillConfigured) {
-                this.configuredDevices.splice(i, 1);
             }
         }
     }

--- a/src/deviceDiscovery/DeviceManager.ts
+++ b/src/deviceDiscovery/DeviceManager.ts
@@ -738,6 +738,14 @@ export class DeviceManager {
             // Check if device already exists by IP (primary key)
             const existingDevice = this.getDeviceEntry({ ip: ip });
 
+            // Clear config-specific fields before update so setDevice's ?? merge
+            // doesn't preserve stale values. Config is authoritative for these fields.
+            if (existingDevice) {
+                existingDevice.configuredIn = [];
+                existingDevice.configuredName = undefined;
+                existingDevice.configuredPassword = undefined;
+            }
+
             // Preserve state if device exists
             const deviceState = existingDevice?.deviceState ?? 'pending';
             const isDiscovered = existingDevice?.isDiscovered ?? false;

--- a/src/deviceDiscovery/DeviceManager.ts
+++ b/src/deviceDiscovery/DeviceManager.ts
@@ -482,9 +482,6 @@ export class DeviceManager {
         // Stop any in-progress scan (finder.stop() emits scan-ended if scanning)
         this.finder.stop();
 
-        // Clear discovered devices and short-lived caches
-        this.clearCurrentDeviceList();
-
         // Clear persisted global state
         this.globalStateManager.clearLastSeenDevices();
         this.globalStateManager.clearDeviceCache();
@@ -501,6 +498,9 @@ export class DeviceManager {
             clearTimeout(this.fetchDeviceInfoThrottleTimer);
             this.fetchDeviceInfoThrottleTimer = null;
         }
+
+        // Clear discovered devices and short-lived caches
+        this.clearCurrentDeviceList();
     }
 
     public async healthCheckDevice(deviceOrLookup: RokuDevice | { ip?: string; serialNumber?: string }, force = false, doSyntheticDelay = true): Promise<boolean> {
@@ -524,7 +524,7 @@ export class DeviceManager {
         }
 
         const isHealthy = await this.resolveDevice(device, doSyntheticDelay);
-        if (!isHealthy) {
+        if (!isHealthy && device.isDiscovered) {
             // force a scan if passive scan is permitted
             this.refresh(this.deviceDiscoveryEnabled);
         }
@@ -882,7 +882,7 @@ export class DeviceManager {
         let needsScan = false;
         await Promise.all(devicesToCheck.map(async (device) => {
             const isHealthy = await this.resolveDevice(device, doSyntheticDelay);
-            if (!isHealthy) {
+            if (!isHealthy && device.isDiscovered) {
                 needsScan = true;
             }
         }));
@@ -1154,7 +1154,6 @@ export class DeviceManager {
             discovered?.serialNumber ??
             this.globalStateManager.getSerialNumberForIp(ip, this.networkId);
 
-        // Get merged state from state map
         const deviceState = this.getDeviceState({ serialNumber: serialNumber, ip: ip });
 
         // Build key

--- a/src/managers/UserInputManager.spec.ts
+++ b/src/managers/UserInputManager.spec.ts
@@ -56,6 +56,8 @@ describe('UserInputManager', () => {
             serialNumber: 'alpha',
             key: 's:alpha',
             deviceState: 'online',
+            isDiscovered: true,
+            isConfigured: false,
             deviceInfo: {
                 'user-device-name': 'roku1',
                 'serial-number': 'alpha',
@@ -67,6 +69,8 @@ describe('UserInputManager', () => {
             serialNumber: 'beta',
             key: 's:beta',
             deviceState: 'online',
+            isDiscovered: true,
+            isConfigured: false,
             deviceInfo: {
                 'user-device-name': 'roku2',
                 'serial-number': 'beta',
@@ -78,6 +82,8 @@ describe('UserInputManager', () => {
             serialNumber: 'charlie',
             key: 's:charlie',
             deviceState: 'online',
+            isDiscovered: true,
+            isConfigured: false,
             deviceInfo: {
                 'user-device-name': 'roku3',
                 'serial-number': 'charlie',

--- a/src/managers/UserInputManager.ts
+++ b/src/managers/UserInputManager.ts
@@ -66,7 +66,7 @@ export class UserInputManager {
 
         const scanTimeoutMs = 7_000;
         let scanTimeoutId: NodeJS.Timeout | null = null;
-        let hasScanned = this.deviceManager.refresh();
+        let hasScanned = this.deviceManager.refresh(false, false);
         this.deviceManager.on('scanNeeded-changed', () => {
             hasScanned = true;
             if (scanTimeoutId) {

--- a/src/managers/UserInputManager.ts
+++ b/src/managers/UserInputManager.ts
@@ -102,7 +102,7 @@ export class UserInputManager {
                         const device = (selectedDevice as any).device as RokuDevice;
                         // if the selected device isn't healthy, show an error and keep the picker open so they can select a different device
                         setBusy(true);
-                        const isHealthy = await this.deviceManager.checkDeviceHealth(device, true, false);
+                        const isHealthy = await this.deviceManager.healthCheckDevice(device, true, false);
                         setBusy(false);
                         if (!isHealthy) {
                             await vscode.window.showErrorMessage(`The selected device (${device.ip}) is not responding.`);
@@ -158,7 +158,7 @@ export class UserInputManager {
 
         const refreshList = () => {
             const items = this.createHostQuickPickList(
-                this.deviceManager.getAllDevices(),
+                this.deviceManager.getDevicesForUI(),
                 this.deviceManager.getLastUsedDeviceIp(),
                 itemCache
             );

--- a/src/managers/UserInputManager.ts
+++ b/src/managers/UserInputManager.ts
@@ -38,7 +38,7 @@ export class UserInputManager {
             const probed = await vscode.window.withProgress(
                 { location: vscode.ProgressLocation.Notification, title: `Contacting ${value}...` },
                 async () => {
-                    return this.deviceManager.getDevice({ ip: value }, { fetch: true });
+                    return this.deviceManager.validateAndAddDevice(value);
                 }
             );
             if (probed) {
@@ -134,7 +134,7 @@ export class UserInputManager {
             } else if (quickPick.value) {
                 const typedValue = quickPick.value;
                 setBusy(true);
-                const probed = await this.deviceManager.getDevice({ ip: typedValue }, { fetch: true });
+                const probed = await this.deviceManager.validateAndAddDevice(typedValue);
                 setBusy(false);
                 if (!probed) {
                     await vscode.window.showErrorMessage(`Unable to connect to a Roku at ${typedValue}. Check the IP and confirm developer mode is enabled.`);

--- a/src/mockVscode.spec.ts
+++ b/src/mockVscode.spec.ts
@@ -200,7 +200,9 @@ export let vscode = {
         onDidChangeWindowState: () => { },
         registerFileDecorationProvider: () => ({ dispose: () => { } }),
         createTreeView: () => ({
-            onDidChangeVisibility: () => { }
+            onDidChangeVisibility: () => { },
+            onDidExpandElement: () => { },
+            onDidCollapseElement: () => { }
         }),
         createQuickPick: () => {
             class QuickPick {

--- a/src/viewProviders/DevicesViewProvider.ts
+++ b/src/viewProviders/DevicesViewProvider.ts
@@ -34,7 +34,7 @@ export class DevicesViewProvider implements vscode.TreeDataProvider<vscode.TreeI
         this.decorationProvider.updateDevices(this.devices);
 
         this.deviceManager.on('devices-changed', () => {
-            this.handleDevicesChanged().catch(() => { });
+            this.handleDevicesChanged();
         });
 
         this.deviceManager.on('scanNeeded-changed', () => {
@@ -101,8 +101,8 @@ export class DevicesViewProvider implements vscode.TreeDataProvider<vscode.TreeI
         }
     }
 
-    private async handleDevicesChanged(): Promise<void> {
-        this.devices = await this.deviceManager.healthCheckStaleDevicesThenGetDevicesForUI();
+    private handleDevicesChanged(): void {
+        this.devices = this.deviceManager.getDevicesForUI();
         this.decorationProvider.updateDevices(this.devices);
         this._onDidChangeTreeData.fire(null);
     }
@@ -132,7 +132,7 @@ export class DevicesViewProvider implements vscode.TreeDataProvider<vscode.TreeI
         if (!element) {
             // Fetch directly if devices haven't been populated yet (avoids debounce delay on initial load)
             if (this.devices.length === 0) {
-                this.devices = await this.deviceManager.healthCheckStaleDevicesThenGetDevicesForUI();
+                this.devices = this.deviceManager.getDevicesForUI();
                 this.decorationProvider.updateDevices(this.devices);
             }
             if (this.devices) {

--- a/src/viewProviders/DevicesViewProvider.ts
+++ b/src/viewProviders/DevicesViewProvider.ts
@@ -28,11 +28,11 @@ export class DevicesViewProvider implements vscode.TreeDataProvider<vscode.TreeI
         vscode.window.registerFileDecorationProvider(this.decorationProvider);
 
         // Pre-populate devices and decorations so they're ready before first render
-        this.devices = this.deviceManager.getAllDevices();
+        this.devices = this.deviceManager.getDevicesForUI();
         this.decorationProvider.updateDevices(this.devices);
 
         this.deviceManager.on('devices-changed', () => {
-            this.devices = this.deviceManager.getAllDevices();
+            this.devices = this.deviceManager.getDevicesForUI();
             this.decorationProvider.updateDevices(this.devices);
             this._onDidChangeTreeData.fire(null);
         });
@@ -116,7 +116,7 @@ export class DevicesViewProvider implements vscode.TreeDataProvider<vscode.TreeI
         if (!element) {
             // Fetch directly if devices haven't been populated yet (avoids debounce delay on initial load)
             if (this.devices.length === 0) {
-                this.devices = this.deviceManager.getAllDevices();
+                this.devices = this.deviceManager.getDevicesForUI();
                 this.decorationProvider.updateDevices(this.devices);
             }
             if (this.devices) {
@@ -206,7 +206,7 @@ export class DevicesViewProvider implements vscode.TreeDataProvider<vscode.TreeI
             if (!device) {
                 return;
             }
-            this.deviceManager.checkDeviceHealth(device).catch(() => { });
+            this.deviceManager.healthCheckDevice(device).catch(() => { });
 
             if (device.deviceInfo?.['is-tv'] === 'true') {
                 result.unshift(

--- a/src/viewProviders/DevicesViewProvider.ts
+++ b/src/viewProviders/DevicesViewProvider.ts
@@ -67,6 +67,17 @@ export class DevicesViewProvider implements vscode.TreeDataProvider<vscode.TreeI
             this.deviceManager.refresh();
         });
 
+        // Health check device when expanded (not on every getChildren/devices-changed)
+        treeView.onDidExpandElement(e => {
+            const element = e.element as DeviceTreeItem;
+            if (element?.contextValue === 'device' && element.key) {
+                const device = this.deviceManager.getDevice(element.key);
+                if (device) {
+                    this.deviceManager.healthCheckDevice(device).catch(() => { });
+                }
+            }
+        });
+
         this.deviceManager.on('scan-started', () => {
             this.showScanProgress();
         });
@@ -222,7 +233,6 @@ export class DevicesViewProvider implements vscode.TreeDataProvider<vscode.TreeI
             if (!device) {
                 return;
             }
-            this.deviceManager.healthCheckDevice(device).catch(() => { });
 
             if (device.deviceInfo?.['is-tv'] === 'true') {
                 result.unshift(

--- a/src/viewProviders/DevicesViewProvider.ts
+++ b/src/viewProviders/DevicesViewProvider.ts
@@ -34,9 +34,7 @@ export class DevicesViewProvider implements vscode.TreeDataProvider<vscode.TreeI
         this.decorationProvider.updateDevices(this.devices);
 
         this.deviceManager.on('devices-changed', () => {
-            this.devices = this.deviceManager.getDevicesForUI();
-            this.decorationProvider.updateDevices(this.devices);
-            this._onDidChangeTreeData.fire(null);
+            this.handleDevicesChanged().catch(() => { });
         });
 
         this.deviceManager.on('scanNeeded-changed', () => {
@@ -103,6 +101,12 @@ export class DevicesViewProvider implements vscode.TreeDataProvider<vscode.TreeI
         }
     }
 
+    private async handleDevicesChanged(): Promise<void> {
+        this.devices = await this.deviceManager.healthCheckStaleDevicesThenGetDevicesForUI();
+        this.decorationProvider.updateDevices(this.devices);
+        this._onDidChangeTreeData.fire(null);
+    }
+
     /**
      * Should the unique info about a device be obfuscated (i.e. randomly modified to protect the data)?
      */
@@ -128,7 +132,7 @@ export class DevicesViewProvider implements vscode.TreeDataProvider<vscode.TreeI
         if (!element) {
             // Fetch directly if devices haven't been populated yet (avoids debounce delay on initial load)
             if (this.devices.length === 0) {
-                this.devices = this.deviceManager.getDevicesForUI();
+                this.devices = await this.deviceManager.healthCheckStaleDevicesThenGetDevicesForUI();
                 this.decorationProvider.updateDevices(this.devices);
             }
             if (this.devices) {

--- a/src/viewProviders/DevicesViewProvider.ts
+++ b/src/viewProviders/DevicesViewProvider.ts
@@ -171,7 +171,7 @@ export class DevicesViewProvider implements vscode.TreeDataProvider<vscode.TreeI
                         if (hasCache) {
                             treeItem.iconPath = new vscode.ThemeIcon('debug-disconnect', new vscode.ThemeColor('disabledForeground'));
                         } else {
-                            treeItem.iconPath = new vscode.ThemeIcon('warning', new vscode.ThemeColor('disabledForeground'));
+                            treeItem.iconPath = new vscode.ThemeIcon('question', new vscode.ThemeColor('disabledForeground'));
                         }
                     } else if (device.deviceState === 'pending') {
                         treeItem.iconPath = new vscode.ThemeIcon('circle-small', new vscode.ThemeColor('disabledForeground'));


### PR DESCRIPTION
Preserve existing values only when the property is omitted from input, not when explicitly set to undefined. This allows config loading to clear values (e.g., removing a device name) while discovery still preserves config it doesn't know about.                                                            
Resolve hostnames to IPs before looking up serials, since the IP→serial mapping requires resolved IPs. And use these resolved IPs to check if a device is still configured.
