### PR TITLE
Fix network change detection on wake from sleep

### DIFF
--- a/src/deviceDiscovery/DeviceManager.spec.ts
+++ b/src/deviceDiscovery/DeviceManager.spec.ts
@@ -1420,6 +1420,46 @@ describe('DeviceManager', () => {
 
             expect(manager['fetchDeviceThrottleData'].size).to.equal(0);
         });
+
+        it('calls setScanNeeded when network changes', () => {
+            manager = new DeviceManager(vscode.context, mockGlobalStateManager);
+
+            const setScanNeededSpy = sinon.spy(manager as any, 'setScanNeeded');
+
+            // Change the network hash
+            (NetworkChangeMonitorModule.getNetworkHash as sinon.SinonStub).returns('new-network-hash');
+
+            // Trigger the network change callback directly
+            manager['networkChangeMonitor']['onNetworkChanged']();
+
+            expect(setScanNeededSpy.calledOnce).to.be.true;
+        });
+
+        it('clears devices array when network changes', () => {
+            manager = new DeviceManager(vscode.context, mockGlobalStateManager);
+
+            // Add multiple devices
+            manager['devices'].push(createMockDevice({
+                serialNumber: 'device-123',
+                ip: '192.168.1.100',
+                isDiscovered: true
+            }));
+            manager['devices'].push(createMockDevice({
+                serialNumber: 'device-456',
+                ip: '192.168.1.101',
+                isConfigured: true
+            }));
+            expect(manager['devices'].length).to.equal(2);
+
+            // Change the network hash
+            (NetworkChangeMonitorModule.getNetworkHash as sinon.SinonStub).returns('new-network-hash');
+
+            // Trigger the network change callback directly
+            manager['networkChangeMonitor']['onNetworkChanged']();
+
+            // Devices array should be cleared (both discovered and configured)
+            expect(manager['devices'].length).to.equal(0);
+        });
     });
 
     describe('configured devices', () => {

--- a/src/deviceDiscovery/DeviceManager.spec.ts
+++ b/src/deviceDiscovery/DeviceManager.spec.ts
@@ -1277,12 +1277,85 @@ describe('DeviceManager', () => {
             await manager['getDeviceInfoCached']('192.168.1.100', 8060);
             expect(getDeviceInfoStub.callCount).to.equal(1);
 
+            // Simulate network change by changing the stub's return value to a different hash
+            (NetworkChangeMonitorModule.getNetworkHash as sinon.SinonStub).returns('new-network-hash');
+
             // Simulate network change by calling the networkChangeMonitor callback
+            // (now handlePotentialNetworkChange will see the different hash)
             manager['networkChangeMonitor']['onNetworkChanged']();
+
+            // Wait for the async handlePotentialNetworkChange to complete
+            await util.sleep(10);
 
             // Cache should be cleared, next call hits network
             await manager['getDeviceInfoCached']('192.168.1.100', 8060);
             expect(getDeviceInfoStub.callCount).to.equal(2);
+        });
+    });
+
+    describe('handlePotentialNetworkChange', () => {
+        it('returns false when network unchanged', async () => {
+            manager = new DeviceManager(vscode.context, mockGlobalStateManager);
+
+            // Network hash hasn't changed (stub returns same value)
+            const result = await manager['handlePotentialNetworkChange']();
+
+            expect(result).to.equal(false);
+        });
+
+        it('returns true and reloads devices when network changed', async () => {
+            manager = new DeviceManager(vscode.context, mockGlobalStateManager);
+
+            // Add a discovered device to verify it gets cleared on network change
+            manager['devices'].push(createMockDevice({
+                serialNumber: 'device-123',
+                ip: '192.168.1.100',
+                isDiscovered: true
+            }));
+            expect(manager['devices'].length).to.equal(1);
+
+            // Change the network hash
+            (NetworkChangeMonitorModule.getNetworkHash as sinon.SinonStub).returns('new-network-hash');
+
+            const result = await manager['handlePotentialNetworkChange']();
+
+            expect(result).to.equal(true);
+            // Discovered device should be removed (loadLastSeenDevices clears non-configured)
+            expect(manager['devices'].length).to.equal(0);
+            // networkId should be updated
+            expect(manager['networkId']).to.equal('new-network-hash');
+        });
+
+        it('clears deviceInfoCache when network changes', async () => {
+            manager = new DeviceManager(vscode.context, mockGlobalStateManager);
+
+            // Populate the cache
+            manager['deviceInfoCache'].set('192.168.1.100', {
+                info: { 'serial-number': 'device-123' } as any,
+                timestamp: Date.now()
+            });
+            expect(manager['deviceInfoCache'].size).to.equal(1);
+
+            // Change the network hash
+            (NetworkChangeMonitorModule.getNetworkHash as sinon.SinonStub).returns('new-network-hash');
+
+            await manager['handlePotentialNetworkChange']();
+
+            expect(manager['deviceInfoCache'].size).to.equal(0);
+        });
+
+        it('is called by SystemSleepMonitor callback', async () => {
+            manager = new DeviceManager(vscode.context, mockGlobalStateManager);
+
+            const handleSpy = sinon.spy(manager as any, 'handlePotentialNetworkChange');
+
+            // Trigger the sleep monitor callback
+            manager['systemSleepMonitor']['onSleepDetected']();
+
+            // Wait for async execution
+            await util.sleep(10);
+
+            expect(handleSpy.calledOnce).to.equal(true);
         });
     });
 

--- a/src/deviceDiscovery/DeviceManager.spec.ts
+++ b/src/deviceDiscovery/DeviceManager.spec.ts
@@ -1367,17 +1367,21 @@ describe('DeviceManager', () => {
         });
     });
 
-    describe('handlePotentialNetworkChange', () => {
-        it('returns false when network unchanged', async () => {
+    describe('network change handling', () => {
+        it('updates networkId when NetworkChangeMonitor triggers callback', () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
-            // Network hash hasn't changed (stub returns same value)
-            const result = await manager['handlePotentialNetworkChange']();
+            // Change the network hash
+            (NetworkChangeMonitorModule.getNetworkHash as sinon.SinonStub).returns('new-network-hash');
 
-            expect(result).to.equal(false);
+            // Trigger the network change callback directly
+            manager['networkChangeMonitor']['onNetworkChanged']();
+
+            // networkId should be updated
+            expect(manager['networkId']).to.equal('new-network-hash');
         });
 
-        it('returns true and reloads devices when network changed', async () => {
+        it('reloads devices when network changes', () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
             // Add a discovered device to verify it gets cleared on network change
@@ -1391,45 +1395,30 @@ describe('DeviceManager', () => {
             // Change the network hash
             (NetworkChangeMonitorModule.getNetworkHash as sinon.SinonStub).returns('new-network-hash');
 
-            const result = await manager['handlePotentialNetworkChange']();
+            // Trigger the network change callback directly
+            manager['networkChangeMonitor']['onNetworkChanged']();
 
-            expect(result).to.equal(true);
             // Discovered device should be removed (loadLastSeenDevices clears non-configured)
             expect(manager['devices'].length).to.equal(0);
-            // networkId should be updated
-            expect(manager['networkId']).to.equal('new-network-hash');
         });
 
-        it('clears deviceInfoCache when network changes', async () => {
+        it('clears fetchDeviceThrottleData when network changes', () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
             // Populate the cache
-            manager['deviceInfoCache'].set('192.168.1.100', {
+            manager['fetchDeviceThrottleData'].set('192.168.1.100', {
                 info: { 'serial-number': 'device-123' } as any,
                 timestamp: Date.now()
             });
-            expect(manager['deviceInfoCache'].size).to.equal(1);
+            expect(manager['fetchDeviceThrottleData'].size).to.equal(1);
 
             // Change the network hash
             (NetworkChangeMonitorModule.getNetworkHash as sinon.SinonStub).returns('new-network-hash');
 
-            await manager['handlePotentialNetworkChange']();
+            // Trigger the network change callback directly
+            manager['networkChangeMonitor']['onNetworkChanged']();
 
-            expect(manager['deviceInfoCache'].size).to.equal(0);
-        });
-
-        it('is called by SystemSleepMonitor callback', async () => {
-            manager = new DeviceManager(vscode.context, mockGlobalStateManager);
-
-            const handleSpy = sinon.spy(manager as any, 'handlePotentialNetworkChange');
-
-            // Trigger the sleep monitor callback
-            manager['systemSleepMonitor']['onSleepDetected']();
-
-            // Wait for async execution
-            await util.sleep(10);
-
-            expect(handleSpy.calledOnce).to.equal(true);
+            expect(manager['fetchDeviceThrottleData'].size).to.equal(0);
         });
     });
 

--- a/src/deviceDiscovery/DeviceManager.ts
+++ b/src/deviceDiscovery/DeviceManager.ts
@@ -78,46 +78,14 @@ export class DeviceManager {
 
     private setupMonitors() {
         this.systemSleepMonitor = new SystemSleepMonitor(() => {
-            this.handlePotentialNetworkChange().then(() => {
-                this.setScanNeeded();
-            }).catch(() => { });
+            this.setScanNeeded();
         });
         this.networkChangeMonitor = new NetworkChangeMonitor(() => {
-            this.handlePotentialNetworkChange().then((changed) => {
-                if (changed) {
-                    this.setScanNeeded();
-                }
-            }).catch(() => { });
+            this.networkId = getNetworkHash();
+            this.fetchDeviceThrottleData.clear();
+            this.loadLastSeenDevices();
+            this.restartRokuFinder();
         });
-    }
-
-    /**
-     * Check for network change and reload state if needed.
-     * Retries if 'no-network' detected (WiFi may still be connecting after wake).
-     * @returns true if network changed, false otherwise
-     */
-    private async handlePotentialNetworkChange(): Promise<boolean> {
-        let newHash = getNetworkHash();
-
-        // Retry if no network detected (WiFi might still be connecting after wake)
-        if (newHash === 'no-network') {
-            await util.sleep(2000);
-            newHash = getNetworkHash();
-        }
-        if (newHash === 'no-network') {
-            await util.sleep(4000);
-            newHash = getNetworkHash();
-        }
-
-        if (newHash === this.networkId) {
-            return false; // No change
-        }
-
-        this.networkId = newHash;
-        this.fetchDeviceThrottleData.clear();
-        this.loadLastSeenDevices();
-        this.restartRokuFinder();
-        return true;
     }
 
     private initialize() {
@@ -1123,7 +1091,6 @@ export class DeviceManager {
     }
 
     private notifyFocusGained() {
-        this.handlePotentialNetworkChange().catch(() => { }); // Immediate check (fire and forget)
         this.networkChangeMonitor.start();
     }
 

--- a/src/deviceDiscovery/DeviceManager.ts
+++ b/src/deviceDiscovery/DeviceManager.ts
@@ -1062,8 +1062,8 @@ export class DeviceManager {
      * Called when network changes to ensure SSDP can communicate on the new network.
      */
     private restartRokuFinder() {
-        // Dispose old finder (releases sockets, clears state)
-        this.finder?.dispose();
+        // Keep reference to old finder for delayed disposal
+        const oldFinder = this.finder;
 
         // Create new finder instance
         this.finder = new RokuFinder();
@@ -1077,6 +1077,11 @@ export class DeviceManager {
                 console.error('Failed to restart RokuFinder:', e);
             });
         }
+
+        // Dispose old finder after 3 seconds to allow overlap
+        setTimeout(() => {
+            oldFinder?.dispose();
+        }, 3_000);
     }
 
     /**

--- a/src/deviceDiscovery/DeviceManager.ts
+++ b/src/deviceDiscovery/DeviceManager.ts
@@ -1054,6 +1054,8 @@ export class DeviceManager {
 
         this.finder.on('scan-ended', () => {
             this.emitter.emit('scan-ended');
+            // Health check devices that didn't respond to the scan (stale cache)
+            this.healthCheckStaleDevices();
         });
     }
 

--- a/src/deviceDiscovery/DeviceManager.ts
+++ b/src/deviceDiscovery/DeviceManager.ts
@@ -78,16 +78,46 @@ export class DeviceManager {
 
     private setupMonitors() {
         this.systemSleepMonitor = new SystemSleepMonitor(() => {
-            this.setScanNeeded();
+            this.handlePotentialNetworkChange().then(() => {
+                this.setScanNeeded();
+            }).catch(() => { });
         });
         this.networkChangeMonitor = new NetworkChangeMonitor(() => {
-            this.networkId = getNetworkHash();
-            this.deviceInfoCache.clear();
-            this.loadLastSeenDevices();
-            this.restartRokuFinder();
-
-            this.setScanNeeded();
+            this.handlePotentialNetworkChange().then((changed) => {
+                if (changed) {
+                    this.setScanNeeded();
+                }
+            }).catch(() => { });
         });
+    }
+
+    /**
+     * Check for network change and reload state if needed.
+     * Retries if 'no-network' detected (WiFi may still be connecting after wake).
+     * @returns true if network changed, false otherwise
+     */
+    private async handlePotentialNetworkChange(): Promise<boolean> {
+        let newHash = getNetworkHash();
+
+        // Retry if no network detected (WiFi might still be connecting after wake)
+        if (newHash === 'no-network') {
+            await util.sleep(2000);
+            newHash = getNetworkHash();
+        }
+        if (newHash === 'no-network') {
+            await util.sleep(4000);
+            newHash = getNetworkHash();
+        }
+
+        if (newHash === this.networkId) {
+            return false; // No change
+        }
+
+        this.networkId = newHash;
+        this.deviceInfoCache.clear();
+        this.loadLastSeenDevices();
+        this.restartRokuFinder();
+        return true;
     }
 
     private initialize() {
@@ -1045,6 +1075,7 @@ export class DeviceManager {
     }
 
     private notifyFocusGained() {
+        this.handlePotentialNetworkChange().catch(() => { }); // Immediate check (fire and forget)
         this.networkChangeMonitor.start();
     }
 

--- a/src/deviceDiscovery/DeviceManager.ts
+++ b/src/deviceDiscovery/DeviceManager.ts
@@ -1073,17 +1073,15 @@ export class DeviceManager {
         // Re-attach event listeners
         this.setupFinderListeners();
 
+        // Dispose old finder
+        oldFinder?.dispose();
+
         // Restart if device discovery is enabled
         if (this.deviceDiscoveryEnabled) {
             this.startRokuFinder().catch((e) => {
                 console.error('Failed to restart RokuFinder:', e);
             });
         }
-
-        // Dispose old finder after 3 seconds to allow overlap
-        setTimeout(() => {
-            oldFinder?.dispose();
-        }, 3_000);
     }
 
     /**

--- a/src/deviceDiscovery/DeviceManager.ts
+++ b/src/deviceDiscovery/DeviceManager.ts
@@ -84,6 +84,8 @@ export class DeviceManager {
             this.networkId = getNetworkHash();
             this.deviceInfoCache.clear();
             this.loadLastSeenDevices();
+            this.restartRokuFinder();
+
             this.setScanNeeded();
         });
     }
@@ -96,36 +98,8 @@ export class DeviceManager {
         this.loadConfiguredDevices().catch(() => { });
         this.loadLastSeenDevices();
 
-        /**
-         * Set up event listeners for the RokuFinder.
-         * This must be called regardless of passiveScanPermitted so that
-         * active scan responses are processed.
-         */
-        this.finder.removeAllListeners();
-        this.finder.on('found', (ip: string, options?: { serialNumber?: string }) => {
-            void this.processDiscoveredIp(ip, options?.serialNumber);
-        });
-
-        this.finder.on('device-online', (ip: string, serialNumber?: string) => {
-            this.handleDeviceOnline(ip, serialNumber);
-        });
-
-        this.finder.on('lost', (ip: string) => {
-            // Find and remove device by IP
-            const device = this.getDeviceEntry({ ip: ip });
-            if (device) {
-                this.removeDevice(device.ip);
-            }
-        });
-
-        // Forward scan events from RokuFinder
-        this.finder.on('scan-started', () => {
-            this.emitter.emit('scan-started');
-        });
-
-        this.finder.on('scan-ended', () => {
-            this.emitter.emit('scan-ended');
-        });
+        // Set up event listeners for the RokuFinder
+        this.setupFinderListeners();
 
         if (this.deviceDiscoveryEnabled) {
             // Sleep monitor runs all the time when enabled (ignores focus state)
@@ -1002,6 +976,61 @@ export class DeviceManager {
     private deactivateMonitoring() {
         this.networkChangeMonitor.stop();
         this.stopRokuFinder();
+    }
+
+    /**
+     * Set up event listeners for the RokuFinder.
+     * This must be called regardless of deviceDiscoveryEnabled so that
+     * active scan responses are processed.
+     */
+    private setupFinderListeners() {
+        this.finder.removeAllListeners();
+        this.finder.on('found', (ip: string, options?: { serialNumber?: string }) => {
+            void this.processDiscoveredIp(ip, options?.serialNumber);
+        });
+
+        this.finder.on('device-online', (ip: string, serialNumber?: string) => {
+            this.handleDeviceOnline(ip, serialNumber);
+        });
+
+        this.finder.on('lost', (ip: string) => {
+            // Find and remove device by IP
+            const device = this.getDeviceEntry({ ip: ip });
+            if (device) {
+                this.removeDevice(device.ip);
+            }
+        });
+
+        // Forward scan events from RokuFinder
+        this.finder.on('scan-started', () => {
+            this.emitter.emit('scan-started');
+        });
+
+        this.finder.on('scan-ended', () => {
+            this.emitter.emit('scan-ended');
+        });
+    }
+
+    /**
+     * Restart the RokuFinder to rebind UDP sockets to new network interfaces.
+     * Called when network changes to ensure SSDP can communicate on the new network.
+     */
+    private restartRokuFinder() {
+        // Dispose old finder (releases sockets, clears state)
+        this.finder?.dispose();
+
+        // Create new finder instance
+        this.finder = new RokuFinder();
+
+        // Re-attach event listeners
+        this.setupFinderListeners();
+
+        // Restart if device discovery is enabled
+        if (this.deviceDiscoveryEnabled) {
+            this.startRokuFinder().catch((e) => {
+                console.error('Failed to restart RokuFinder:', e);
+            });
+        }
     }
 
     /**

--- a/src/deviceDiscovery/DeviceManager.ts
+++ b/src/deviceDiscovery/DeviceManager.ts
@@ -83,8 +83,16 @@ export class DeviceManager {
         this.networkChangeMonitor = new NetworkChangeMonitor(() => {
             this.networkId = getNetworkHash();
             this.fetchDeviceThrottleData.clear();
+
+            //clear and reload all devices anytime this network changes
+            this.devices = [];
             this.loadLastSeenDevices();
+            this.loadConfiguredDevices().catch(e => console.error(e));
+
             this.restartRokuFinder();
+
+            //this is important for telling the devices view to refresh and health check its devices
+            this.setScanNeeded();
         });
     }
 

--- a/src/deviceDiscovery/NetworkChangeMonitor.spec.ts
+++ b/src/deviceDiscovery/NetworkChangeMonitor.spec.ts
@@ -3,7 +3,15 @@ import * as sinon from 'sinon';
 import * as os from 'os';
 import { NetworkChangeMonitor, getNetworkHash } from './NetworkChangeMonitor';
 
-const DEFAULT_TIMEOUT = 3 * 60 * 1_000; // 3 minutes
+const IDLE_INTERVAL = 3 * 60 * 1_000; // 3 minutes
+const ALERT_TIER_1_INTERVAL = 1_000;
+const ALERT_TIER_1_DURATION = 30_000;
+const ALERT_TIER_2_INTERVAL = 5_000;
+const ALERT_TIER_2_DURATION = 30_000;
+const ALERT_TIER_3_INTERVAL = 15_000;
+const ALERT_TIER_3_DURATION = 180_000;
+const VERIFYING_INTERVAL = 1_000;
+const VERIFYING_REQUIRED_COUNT = 3;
 
 describe('NetworkChangeMonitor', () => {
     let networkInterfacesStub: sinon.SinonStub;
@@ -120,7 +128,7 @@ describe('NetworkChangeMonitor', () => {
         });
 
         afterEach(() => {
-            monitor?.stop();
+            monitor?.dispose();
             clock.restore();
         });
 
@@ -129,9 +137,64 @@ describe('NetworkChangeMonitor', () => {
                 monitor = new NetworkChangeMonitor(callback);
                 expect(callback.called).to.be.false;
             });
+
+            it('initializes in idle state', () => {
+                monitor = new NetworkChangeMonitor(callback);
+                expect(monitor.getState()).to.equal('idle');
+            });
         });
 
-        describe('network change detection', () => {
+        describe('idle state', () => {
+            it('fires callback when network changes', () => {
+                monitor = new NetworkChangeMonitor(callback);
+                monitor.start();
+
+                // Change the network
+                networkInterfacesStub.returns({
+                    'en0': [{
+                        address: '10.0.0.50',
+                        netmask: '255.255.255.0',
+                        family: 'IPv4',
+                        internal: false
+                    }]
+                });
+
+                clock.tick(IDLE_INTERVAL);
+
+                expect(callback.calledOnce).to.be.true;
+                expect(monitor.getState()).to.equal('idle');
+            });
+
+            it('does not fire callback when network unchanged', () => {
+                monitor = new NetworkChangeMonitor(callback);
+                monitor.start();
+
+                clock.tick(IDLE_INTERVAL);
+                clock.tick(IDLE_INTERVAL);
+                clock.tick(IDLE_INTERVAL);
+
+                expect(callback.called).to.be.false;
+            });
+
+            it('does not fire callback when network becomes no-network', () => {
+                monitor = new NetworkChangeMonitor(callback);
+                monitor.start();
+
+                // Network goes down
+                networkInterfacesStub.returns({
+                    'lo0': [{
+                        address: '127.0.0.1',
+                        netmask: '255.0.0.0',
+                        family: 'IPv4',
+                        internal: true
+                    }]
+                });
+
+                clock.tick(IDLE_INTERVAL);
+
+                expect(callback.called).to.be.false;
+            });
+
             it('fires callback when IP is added', () => {
                 monitor = new NetworkChangeMonitor(callback);
                 monitor.start();
@@ -152,7 +215,7 @@ describe('NetworkChangeMonitor', () => {
                     }]
                 });
 
-                clock.tick(DEFAULT_TIMEOUT); // Default interval
+                clock.tick(IDLE_INTERVAL);
 
                 expect(callback.calledOnce).to.be.true;
             });
@@ -187,39 +250,341 @@ describe('NetworkChangeMonitor', () => {
                     }]
                 });
 
-                clock.tick(DEFAULT_TIMEOUT); // Default interval
+                clock.tick(IDLE_INTERVAL);
 
                 expect(callback.calledOnce).to.be.true;
             });
+        });
 
-            it('does not fire callback when IPs unchanged', () => {
+        describe('sleep detection', () => {
+            it('enters alert state when sleep is simulated', () => {
                 monitor = new NetworkChangeMonitor(callback);
                 monitor.start();
 
-                // Same IPs
-                clock.tick(DEFAULT_TIMEOUT);
-                clock.tick(DEFAULT_TIMEOUT);
-                clock.tick(DEFAULT_TIMEOUT);
+                expect(monitor.getState()).to.equal('idle');
+
+                // Simulate sleep detection
+                monitor.simulateSleep();
+
+                expect(monitor.getState()).to.equal('alert');
+                expect(monitor.getAlertTier()).to.equal(1);
+            });
+        });
+
+        describe('alert state', () => {
+            beforeEach(() => {
+                monitor = new NetworkChangeMonitor(callback);
+                monitor.start();
+                // Simulate sleep to enter alert state
+                monitor.simulateSleep();
+                expect(monitor.getState()).to.equal('alert');
+            });
+
+            it('broadcasts and enters verifying when network detected with different hash', () => {
+                // Change network
+                networkInterfacesStub.returns({
+                    'en0': [{
+                        address: '10.0.0.50',
+                        netmask: '255.255.255.0',
+                        family: 'IPv4',
+                        internal: false
+                    }]
+                });
+
+                clock.tick(ALERT_TIER_1_INTERVAL);
+
+                expect(callback.calledOnce).to.be.true;
+                expect(monitor.getState()).to.equal('verifying');
+            });
+
+            it('enters verifying without broadcast when network detected with same hash', () => {
+                // Network unchanged (same as initial)
+                clock.tick(ALERT_TIER_1_INTERVAL);
+
+                expect(callback.called).to.be.false;
+                expect(monitor.getState()).to.equal('verifying');
+            });
+
+            it('advances from tier 1 to tier 2 on timeout with no network', () => {
+                // Simulate no network
+                networkInterfacesStub.returns({
+                    'lo0': [{
+                        address: '127.0.0.1',
+                        netmask: '255.0.0.0',
+                        family: 'IPv4',
+                        internal: true
+                    }]
+                });
+
+                // Tick through tier 1 duration
+                for (let elapsed = 0; elapsed < ALERT_TIER_1_DURATION; elapsed += ALERT_TIER_1_INTERVAL) {
+                    clock.tick(ALERT_TIER_1_INTERVAL);
+                }
+
+                expect(monitor.getState()).to.equal('alert');
+                expect(monitor.getAlertTier()).to.equal(2);
+            });
+
+            it('advances from tier 2 to tier 3 on timeout with no network', () => {
+                // Simulate no network
+                networkInterfacesStub.returns({
+                    'lo0': [{
+                        address: '127.0.0.1',
+                        netmask: '255.0.0.0',
+                        family: 'IPv4',
+                        internal: true
+                    }]
+                });
+
+                // Tick through tier 1
+                for (let elapsed = 0; elapsed < ALERT_TIER_1_DURATION; elapsed += ALERT_TIER_1_INTERVAL) {
+                    clock.tick(ALERT_TIER_1_INTERVAL);
+                }
+                expect(monitor.getAlertTier()).to.equal(2);
+
+                // Tick through tier 2
+                for (let elapsed = 0; elapsed < ALERT_TIER_2_DURATION; elapsed += ALERT_TIER_2_INTERVAL) {
+                    clock.tick(ALERT_TIER_2_INTERVAL);
+                }
+                expect(monitor.getAlertTier()).to.equal(3);
+            });
+
+            it('returns to idle when tier 3 times out (gave up)', () => {
+                // Simulate no network throughout
+                networkInterfacesStub.returns({
+                    'lo0': [{
+                        address: '127.0.0.1',
+                        netmask: '255.0.0.0',
+                        family: 'IPv4',
+                        internal: true
+                    }]
+                });
+
+                // Tick through all tiers
+                for (let elapsed = 0; elapsed < ALERT_TIER_1_DURATION; elapsed += ALERT_TIER_1_INTERVAL) {
+                    clock.tick(ALERT_TIER_1_INTERVAL);
+                }
+                expect(monitor.getAlertTier()).to.equal(2);
+
+                for (let elapsed = 0; elapsed < ALERT_TIER_2_DURATION; elapsed += ALERT_TIER_2_INTERVAL) {
+                    clock.tick(ALERT_TIER_2_INTERVAL);
+                }
+                expect(monitor.getAlertTier()).to.equal(3);
+
+                for (let elapsed = 0; elapsed < ALERT_TIER_3_DURATION; elapsed += ALERT_TIER_3_INTERVAL) {
+                    clock.tick(ALERT_TIER_3_INTERVAL);
+                }
+
+                expect(monitor.getState()).to.equal('idle');
+                // Should NOT have broadcast (gave up without finding network)
+                expect(callback.called).to.be.false;
+            });
+        });
+
+        describe('verifying state', () => {
+            beforeEach(() => {
+                monitor = new NetworkChangeMonitor(callback);
+                monitor.start();
+                // Simulate sleep then detect network to enter verifying
+                monitor.simulateSleep();
+                clock.tick(ALERT_TIER_1_INTERVAL); // Detect network, enter verifying
+                expect(monitor.getState()).to.equal('verifying');
+            });
+
+            it('returns to idle after 3 consecutive matching polls', () => {
+                // Tick through verifying checks
+                for (let i = 0; i < VERIFYING_REQUIRED_COUNT; i++) {
+                    clock.tick(VERIFYING_INTERVAL);
+                }
+
+                expect(monitor.getState()).to.equal('idle');
+            });
+
+            it('goes back to alert when hash changes (unstable)', () => {
+                clock.tick(VERIFYING_INTERVAL); // First verifying check passes
+
+                // Network changes during verifying
+                networkInterfacesStub.returns({
+                    'en0': [{
+                        address: '10.0.0.99',
+                        netmask: '255.255.255.0',
+                        family: 'IPv4',
+                        internal: false
+                    }]
+                });
+
+                clock.tick(VERIFYING_INTERVAL);
+
+                expect(monitor.getState()).to.equal('alert');
+            });
+
+            it('goes back to alert when no-network detected', () => {
+                clock.tick(VERIFYING_INTERVAL); // First verifying check passes
+
+                // Network goes down
+                networkInterfacesStub.returns({
+                    'lo0': [{
+                        address: '127.0.0.1',
+                        netmask: '255.0.0.0',
+                        family: 'IPv4',
+                        internal: true
+                    }]
+                });
+
+                clock.tick(VERIFYING_INTERVAL);
+
+                expect(monitor.getState()).to.equal('alert');
+            });
+        });
+
+        describe('full scenarios', () => {
+            it('sleep → no-network → network found → verifying passes → idle', () => {
+                monitor = new NetworkChangeMonitor(callback);
+                monitor.start();
+
+                // Start with network down (simulating sleep disconnect)
+                networkInterfacesStub.returns({
+                    'lo0': [{
+                        address: '127.0.0.1',
+                        netmask: '255.0.0.0',
+                        family: 'IPv4',
+                        internal: true
+                    }]
+                });
+
+                // Sleep detected
+                monitor.simulateSleep();
+                expect(monitor.getState()).to.equal('alert');
+
+                // Poll a few times with no network
+                clock.tick(ALERT_TIER_1_INTERVAL);
+                clock.tick(ALERT_TIER_1_INTERVAL);
+                expect(monitor.getState()).to.equal('alert');
+
+                // Network comes back (different from initial)
+                networkInterfacesStub.returns({
+                    'en0': [{
+                        address: '10.0.0.50',
+                        netmask: '255.255.255.0',
+                        family: 'IPv4',
+                        internal: false
+                    }]
+                });
+
+                clock.tick(ALERT_TIER_1_INTERVAL);
+                expect(callback.calledOnce).to.be.true; // Broadcast!
+                expect(monitor.getState()).to.equal('verifying');
+
+                // Verifying checks pass
+                for (let i = 0; i < VERIFYING_REQUIRED_COUNT; i++) {
+                    clock.tick(VERIFYING_INTERVAL);
+                }
+
+                expect(monitor.getState()).to.equal('idle');
+            });
+
+            it('wake on same network → no broadcast, quick verifying', () => {
+                monitor = new NetworkChangeMonitor(callback);
+                monitor.start();
+
+                // Sleep detected
+                monitor.simulateSleep();
+                expect(monitor.getState()).to.equal('alert');
+
+                // Network still same
+                clock.tick(ALERT_TIER_1_INTERVAL);
+                expect(callback.called).to.be.false; // No broadcast
+                expect(monitor.getState()).to.equal('verifying');
+
+                // Verifying passes
+                for (let i = 0; i < VERIFYING_REQUIRED_COUNT; i++) {
+                    clock.tick(VERIFYING_INTERVAL);
+                }
+
+                expect(monitor.getState()).to.equal('idle');
+                expect(callback.called).to.be.false; // Still no broadcast
+            });
+
+            it('flaky WiFi: broadcasts on each change, verifying fails, retries from alert', () => {
+                monitor = new NetworkChangeMonitor(callback);
+                monitor.start();
+
+                // Sleep detected
+                monitor.simulateSleep();
+                expect(monitor.getState()).to.equal('alert');
+
+                // Network comes back (changed)
+                networkInterfacesStub.returns({
+                    'en0': [{
+                        address: '10.0.0.50',
+                        netmask: '255.255.255.0',
+                        family: 'IPv4',
+                        internal: false
+                    }]
+                });
+                clock.tick(ALERT_TIER_1_INTERVAL);
+                expect(callback.callCount).to.equal(1);
+                expect(monitor.getState()).to.equal('verifying');
+
+                // Flaky: network changes again during verifying
+                networkInterfacesStub.returns({
+                    'en0': [{
+                        address: '10.0.0.51',
+                        netmask: '255.255.255.0',
+                        family: 'IPv4',
+                        internal: false
+                    }]
+                });
+                clock.tick(VERIFYING_INTERVAL);
+                expect(monitor.getState()).to.equal('alert'); // Back to alert
+
+                // New network detected → broadcast
+                clock.tick(ALERT_TIER_1_INTERVAL);
+                expect(callback.callCount).to.equal(2);
+                expect(monitor.getState()).to.equal('verifying');
+            });
+        });
+
+        describe('start/stop', () => {
+            it('stop prevents future checks', () => {
+                monitor = new NetworkChangeMonitor(callback);
+                monitor.start();
+                monitor.stop();
+
+                // Change the network
+                networkInterfacesStub.returns({
+                    'en0': [{
+                        address: '10.0.0.50',
+                        netmask: '255.255.255.0',
+                        family: 'IPv4',
+                        internal: false
+                    }]
+                });
+
+                clock.tick(IDLE_INTERVAL);
+                clock.tick(IDLE_INTERVAL);
 
                 expect(callback.called).to.be.false;
             });
 
-        });
+            it('stop is safe to call when not started', () => {
+                monitor = new NetworkChangeMonitor(callback);
+                expect(() => monitor.stop()).to.not.throw();
+            });
 
-        describe('start after long stop', () => {
             it('handles restart after being stopped longer than the interval', () => {
                 monitor = new NetworkChangeMonitor(callback);
                 monitor.start();
 
                 // Let it run for one full interval
-                clock.tick(DEFAULT_TIMEOUT);
+                clock.tick(IDLE_INTERVAL);
                 expect(callback.called).to.be.false; // No network change
 
                 // Stop the monitor
                 monitor.stop();
 
-                // Advance time well past another interval (e.g., 2x the interval)
-                clock.tick(DEFAULT_TIMEOUT * 2);
+                // Advance time well past another interval
+                clock.tick(IDLE_INTERVAL * 2);
 
                 // Change the network while stopped
                 networkInterfacesStub.returns({
@@ -235,76 +600,7 @@ describe('NetworkChangeMonitor', () => {
                 monitor.start();
 
                 // The callback should fire immediately since we've been stopped > interval
-                // and the network changed
                 expect(callback.calledOnce).to.be.true;
-            });
-
-            it('computes correct remaining time when restarted within interval', () => {
-                monitor = new NetworkChangeMonitor(callback);
-                monitor.start();
-
-                // Let it run for one full interval
-                clock.tick(DEFAULT_TIMEOUT);
-
-                // Stop after a short time (less than full interval)
-                clock.tick(DEFAULT_TIMEOUT / 2);
-                monitor.stop();
-
-                // Advance only a small amount (still within the "remaining" time)
-                clock.tick(DEFAULT_TIMEOUT / 4);
-
-                // Restart - should NOT immediately execute since we're within the interval
-                monitor.start();
-
-                // Change network
-                networkInterfacesStub.returns({
-                    'en0': [{
-                        address: '10.0.0.50',
-                        netmask: '255.255.255.0',
-                        family: 'IPv4',
-                        internal: false
-                    }]
-                });
-
-                // Callback should NOT have fired yet
-                expect(callback.called).to.be.false;
-
-                // Now advance to when the timer should fire
-                // We should need to wait: interval - (time since last execution)
-                // Last execution was at DEFAULT_TIMEOUT
-                // We're now at DEFAULT_TIMEOUT + DEFAULT_TIMEOUT/2 + DEFAULT_TIMEOUT/4 = 1.75 * DEFAULT_TIMEOUT
-                // Remaining should be: interval - 0.75*interval = 0.25*interval
-                clock.tick((DEFAULT_TIMEOUT / 4) + 1);
-
-                expect(callback.calledOnce).to.be.true;
-            });
-        });
-
-        describe('stop', () => {
-            it('prevents future checks', () => {
-                monitor = new NetworkChangeMonitor(callback);
-                monitor.start();
-                monitor.stop();
-
-                // Change the network
-                networkInterfacesStub.returns({
-                    'en0': [{
-                        address: '10.0.0.50',
-                        netmask: '255.255.255.0',
-                        family: 'IPv4',
-                        internal: false
-                    }]
-                });
-
-                clock.tick(DEFAULT_TIMEOUT);
-                clock.tick(DEFAULT_TIMEOUT);
-
-                expect(callback.called).to.be.false;
-            });
-
-            it('is safe to call when not started', () => {
-                monitor = new NetworkChangeMonitor(callback);
-                expect(() => monitor.stop()).to.not.throw();
             });
         });
     });

--- a/src/deviceDiscovery/NetworkChangeMonitor.spec.ts
+++ b/src/deviceDiscovery/NetworkChangeMonitor.spec.ts
@@ -174,7 +174,7 @@ describe('NetworkChangeMonitor', () => {
                 expect(callback.called).to.be.false;
             });
 
-            it('does not fire callback when network becomes no-network', () => {
+            it('fires callback when network becomes no-network', () => {
                 monitor = new NetworkChangeMonitor(callback);
                 monitor.start();
 
@@ -190,7 +190,7 @@ describe('NetworkChangeMonitor', () => {
 
                 clock.tick(ALERT_INTERVAL);
 
-                expect(callback.called).to.be.false;
+                expect(callback.calledOnce).to.be.true;
             });
 
             it('fires callback when reconnecting to same network after being disconnected', () => {
@@ -211,7 +211,7 @@ describe('NetworkChangeMonitor', () => {
                     }]
                 });
                 clock.tick(ALERT_INTERVAL);
-                expect(callback.called).to.be.false; // no broadcast for going to no-network
+                expect(callback.calledOnce).to.be.true; // callback fires for going to no-network
 
                 // Same network comes back
                 networkInterfacesStub.returns({
@@ -224,8 +224,8 @@ describe('NetworkChangeMonitor', () => {
                 });
                 clock.tick(ALERT_INTERVAL);
 
-                // Should broadcast because currentHash was 'no-network'
-                expect(callback.calledOnce).to.be.true;
+                // Should broadcast again because network changed back
+                expect(callback.calledTwice).to.be.true;
             });
         });
 

--- a/src/deviceDiscovery/NetworkChangeMonitor.spec.ts
+++ b/src/deviceDiscovery/NetworkChangeMonitor.spec.ts
@@ -3,15 +3,9 @@ import * as sinon from 'sinon';
 import * as os from 'os';
 import { NetworkChangeMonitor, getNetworkHash } from './NetworkChangeMonitor';
 
-const IDLE_INTERVAL = 3 * 60 * 1_000; // 3 minutes
-const ALERT_TIER_1_INTERVAL = 1_000;
-const ALERT_TIER_1_DURATION = 30_000;
-const ALERT_TIER_2_INTERVAL = 5_000;
-const ALERT_TIER_2_DURATION = 30_000;
-const ALERT_TIER_3_INTERVAL = 15_000;
-const ALERT_TIER_3_DURATION = 180_000;
-const VERIFYING_INTERVAL = 1_000;
-const VERIFYING_REQUIRED_COUNT = 3;
+const ALERT_INTERVAL = 1_000; // 1 second
+const NORMAL_INTERVAL = 15_000; // 15 seconds
+const ALERT_THRESHOLD = 30;
 
 describe('NetworkChangeMonitor', () => {
     let networkInterfacesStub: sinon.SinonStub;
@@ -138,13 +132,18 @@ describe('NetworkChangeMonitor', () => {
                 expect(callback.called).to.be.false;
             });
 
-            it('initializes in idle state', () => {
+            it('starts with alertCounter at 0', () => {
                 monitor = new NetworkChangeMonitor(callback);
-                expect(monitor.getState()).to.equal('idle');
+                expect(monitor.getAlertCounter()).to.equal(0);
+            });
+
+            it('starts in alert mode', () => {
+                monitor = new NetworkChangeMonitor(callback);
+                expect(monitor.isInAlertMode()).to.be.true;
             });
         });
 
-        describe('idle state', () => {
+        describe('network change detection', () => {
             it('fires callback when network changes', () => {
                 monitor = new NetworkChangeMonitor(callback);
                 monitor.start();
@@ -159,19 +158,18 @@ describe('NetworkChangeMonitor', () => {
                     }]
                 });
 
-                clock.tick(IDLE_INTERVAL);
+                clock.tick(ALERT_INTERVAL);
 
                 expect(callback.calledOnce).to.be.true;
-                expect(monitor.getState()).to.equal('idle');
             });
 
             it('does not fire callback when network unchanged', () => {
                 monitor = new NetworkChangeMonitor(callback);
                 monitor.start();
 
-                clock.tick(IDLE_INTERVAL);
-                clock.tick(IDLE_INTERVAL);
-                clock.tick(IDLE_INTERVAL);
+                clock.tick(ALERT_INTERVAL);
+                clock.tick(ALERT_INTERVAL);
+                clock.tick(ALERT_INTERVAL);
 
                 expect(callback.called).to.be.false;
             });
@@ -190,236 +188,18 @@ describe('NetworkChangeMonitor', () => {
                     }]
                 });
 
-                clock.tick(IDLE_INTERVAL);
+                clock.tick(ALERT_INTERVAL);
 
                 expect(callback.called).to.be.false;
             });
 
-            it('fires callback when IP is added', () => {
+            it('fires callback when reconnecting to same network after being disconnected', () => {
                 monitor = new NetworkChangeMonitor(callback);
                 monitor.start();
 
-                // Add a new IP
-                networkInterfacesStub.returns({
-                    'en0': [{
-                        address: '192.168.1.100',
-                        netmask: '255.255.255.0',
-                        family: 'IPv4',
-                        internal: false
-                    }],
-                    'en1': [{
-                        address: '192.168.1.101',
-                        netmask: '255.255.255.0',
-                        family: 'IPv4',
-                        internal: false
-                    }]
-                });
-
-                clock.tick(IDLE_INTERVAL);
-
-                expect(callback.calledOnce).to.be.true;
-            });
-
-            it('fires callback when IP is removed', () => {
-                // Start with two IPs
-                networkInterfacesStub.returns({
-                    'en0': [{
-                        address: '192.168.1.100',
-                        netmask: '255.255.255.0',
-                        family: 'IPv4',
-                        internal: false
-                    }],
-                    'en1': [{
-                        address: '192.168.1.101',
-                        netmask: '255.255.255.0',
-                        family: 'IPv4',
-                        internal: false
-                    }]
-                });
-
-                monitor = new NetworkChangeMonitor(callback);
-                monitor.start();
-
-                // Remove one IP
-                networkInterfacesStub.returns({
-                    'en0': [{
-                        address: '192.168.1.100',
-                        netmask: '255.255.255.0',
-                        family: 'IPv4',
-                        internal: false
-                    }]
-                });
-
-                clock.tick(IDLE_INTERVAL);
-
-                expect(callback.calledOnce).to.be.true;
-            });
-        });
-
-        describe('sleep detection', () => {
-            it('enters alert state when sleep is simulated', () => {
-                monitor = new NetworkChangeMonitor(callback);
-                monitor.start();
-
-                expect(monitor.getState()).to.equal('idle');
-
-                // Simulate sleep detection
-                monitor.simulateSleep();
-
-                expect(monitor.getState()).to.equal('alert');
-                expect(monitor.getAlertTier()).to.equal(1);
-            });
-        });
-
-        describe('alert state', () => {
-            beforeEach(() => {
-                monitor = new NetworkChangeMonitor(callback);
-                monitor.start();
-                // Simulate sleep to enter alert state
-                monitor.simulateSleep();
-                expect(monitor.getState()).to.equal('alert');
-            });
-
-            it('broadcasts and enters verifying when network detected with different hash', () => {
-                // Change network
-                networkInterfacesStub.returns({
-                    'en0': [{
-                        address: '10.0.0.50',
-                        netmask: '255.255.255.0',
-                        family: 'IPv4',
-                        internal: false
-                    }]
-                });
-
-                clock.tick(ALERT_TIER_1_INTERVAL);
-
-                expect(callback.calledOnce).to.be.true;
-                expect(monitor.getState()).to.equal('verifying');
-            });
-
-            it('enters verifying without broadcast when network detected with same hash', () => {
-                // Network unchanged (same as initial)
-                clock.tick(ALERT_TIER_1_INTERVAL);
-
+                // Start on a network
+                clock.tick(ALERT_INTERVAL);
                 expect(callback.called).to.be.false;
-                expect(monitor.getState()).to.equal('verifying');
-            });
-
-            it('advances from tier 1 to tier 2 on timeout with no network', () => {
-                // Simulate no network
-                networkInterfacesStub.returns({
-                    'lo0': [{
-                        address: '127.0.0.1',
-                        netmask: '255.0.0.0',
-                        family: 'IPv4',
-                        internal: true
-                    }]
-                });
-
-                // Tick through tier 1 duration
-                for (let elapsed = 0; elapsed < ALERT_TIER_1_DURATION; elapsed += ALERT_TIER_1_INTERVAL) {
-                    clock.tick(ALERT_TIER_1_INTERVAL);
-                }
-
-                expect(monitor.getState()).to.equal('alert');
-                expect(monitor.getAlertTier()).to.equal(2);
-            });
-
-            it('advances from tier 2 to tier 3 on timeout with no network', () => {
-                // Simulate no network
-                networkInterfacesStub.returns({
-                    'lo0': [{
-                        address: '127.0.0.1',
-                        netmask: '255.0.0.0',
-                        family: 'IPv4',
-                        internal: true
-                    }]
-                });
-
-                // Tick through tier 1
-                for (let elapsed = 0; elapsed < ALERT_TIER_1_DURATION; elapsed += ALERT_TIER_1_INTERVAL) {
-                    clock.tick(ALERT_TIER_1_INTERVAL);
-                }
-                expect(monitor.getAlertTier()).to.equal(2);
-
-                // Tick through tier 2
-                for (let elapsed = 0; elapsed < ALERT_TIER_2_DURATION; elapsed += ALERT_TIER_2_INTERVAL) {
-                    clock.tick(ALERT_TIER_2_INTERVAL);
-                }
-                expect(monitor.getAlertTier()).to.equal(3);
-            });
-
-            it('returns to idle when tier 3 times out (gave up)', () => {
-                // Simulate no network throughout
-                networkInterfacesStub.returns({
-                    'lo0': [{
-                        address: '127.0.0.1',
-                        netmask: '255.0.0.0',
-                        family: 'IPv4',
-                        internal: true
-                    }]
-                });
-
-                // Tick through all tiers
-                for (let elapsed = 0; elapsed < ALERT_TIER_1_DURATION; elapsed += ALERT_TIER_1_INTERVAL) {
-                    clock.tick(ALERT_TIER_1_INTERVAL);
-                }
-                expect(monitor.getAlertTier()).to.equal(2);
-
-                for (let elapsed = 0; elapsed < ALERT_TIER_2_DURATION; elapsed += ALERT_TIER_2_INTERVAL) {
-                    clock.tick(ALERT_TIER_2_INTERVAL);
-                }
-                expect(monitor.getAlertTier()).to.equal(3);
-
-                for (let elapsed = 0; elapsed < ALERT_TIER_3_DURATION; elapsed += ALERT_TIER_3_INTERVAL) {
-                    clock.tick(ALERT_TIER_3_INTERVAL);
-                }
-
-                expect(monitor.getState()).to.equal('idle');
-                // Should NOT have broadcast (gave up without finding network)
-                expect(callback.called).to.be.false;
-            });
-        });
-
-        describe('verifying state', () => {
-            beforeEach(() => {
-                monitor = new NetworkChangeMonitor(callback);
-                monitor.start();
-                // Simulate sleep then detect network to enter verifying
-                monitor.simulateSleep();
-                clock.tick(ALERT_TIER_1_INTERVAL); // Detect network, enter verifying
-                expect(monitor.getState()).to.equal('verifying');
-            });
-
-            it('returns to idle after 3 consecutive matching polls', () => {
-                // Tick through verifying checks
-                for (let i = 0; i < VERIFYING_REQUIRED_COUNT; i++) {
-                    clock.tick(VERIFYING_INTERVAL);
-                }
-
-                expect(monitor.getState()).to.equal('idle');
-            });
-
-            it('goes back to alert when hash changes (unstable)', () => {
-                clock.tick(VERIFYING_INTERVAL); // First verifying check passes
-
-                // Network changes during verifying
-                networkInterfacesStub.returns({
-                    'en0': [{
-                        address: '10.0.0.99',
-                        netmask: '255.255.255.0',
-                        family: 'IPv4',
-                        internal: false
-                    }]
-                });
-
-                clock.tick(VERIFYING_INTERVAL);
-
-                expect(monitor.getState()).to.equal('alert');
-            });
-
-            it('goes back to alert when no-network detected', () => {
-                clock.tick(VERIFYING_INTERVAL); // First verifying check passes
 
                 // Network goes down
                 networkInterfacesStub.returns({
@@ -430,38 +210,134 @@ describe('NetworkChangeMonitor', () => {
                         internal: true
                     }]
                 });
+                clock.tick(ALERT_INTERVAL);
+                expect(callback.called).to.be.false; // no broadcast for going to no-network
 
-                clock.tick(VERIFYING_INTERVAL);
+                // Same network comes back
+                networkInterfacesStub.returns({
+                    'en0': [{
+                        address: '192.168.1.100',
+                        netmask: '255.255.255.0',
+                        family: 'IPv4',
+                        internal: false
+                    }]
+                });
+                clock.tick(ALERT_INTERVAL);
 
-                expect(monitor.getState()).to.equal('alert');
+                // Should broadcast because currentHash was 'no-network'
+                expect(callback.calledOnce).to.be.true;
             });
         });
 
-        describe('full scenarios', () => {
-            it('sleep → no-network → network found → verifying passes → idle', () => {
+        describe('alert mode behavior', () => {
+            it('uses 1 second interval when in alert mode', () => {
                 monitor = new NetworkChangeMonitor(callback);
                 monitor.start();
 
-                // Start with network down (simulating sleep disconnect)
-                networkInterfacesStub.returns({
-                    'lo0': [{
-                        address: '127.0.0.1',
-                        netmask: '255.0.0.0',
-                        family: 'IPv4',
-                        internal: true
-                    }]
-                });
+                expect(monitor.isInAlertMode()).to.be.true;
 
-                // Sleep detected
+                // Should increment counter after 1 second
+                clock.tick(ALERT_INTERVAL);
+                expect(monitor.getAlertCounter()).to.equal(1);
+
+                clock.tick(ALERT_INTERVAL);
+                expect(monitor.getAlertCounter()).to.equal(2);
+            });
+
+            it('transitions to normal mode after threshold polls', () => {
+                monitor = new NetworkChangeMonitor(callback);
+                monitor.start();
+
+                expect(monitor.isInAlertMode()).to.be.true;
+
+                // Poll until threshold
+                for (let i = 0; i < ALERT_THRESHOLD; i++) {
+                    clock.tick(ALERT_INTERVAL);
+                }
+
+                expect(monitor.isInAlertMode()).to.be.false;
+                expect(monitor.getAlertCounter()).to.equal(ALERT_THRESHOLD);
+            });
+
+            it('uses 15 second interval in normal mode', () => {
+                monitor = new NetworkChangeMonitor(callback);
+                monitor.start();
+
+                // Get to normal mode
+                for (let i = 0; i < ALERT_THRESHOLD; i++) {
+                    clock.tick(ALERT_INTERVAL);
+                }
+
+                expect(monitor.isInAlertMode()).to.be.false;
+                const counterAtThreshold = monitor.getAlertCounter();
+
+                // Now should use 15 second interval
+                clock.tick(NORMAL_INTERVAL);
+                expect(monitor.getAlertCounter()).to.equal(counterAtThreshold + 1);
+            });
+        });
+
+        describe('sleep detection', () => {
+            it('resets counter to 0 when sleep is simulated', () => {
+                monitor = new NetworkChangeMonitor(callback);
+                monitor.start();
+
+                // Get past threshold into normal mode
+                for (let i = 0; i < ALERT_THRESHOLD + 5; i++) {
+                    clock.tick(ALERT_INTERVAL);
+                }
+
+                expect(monitor.isInAlertMode()).to.be.false;
+
+                // Simulate sleep
                 monitor.simulateSleep();
-                expect(monitor.getState()).to.equal('alert');
 
-                // Poll a few times with no network
-                clock.tick(ALERT_TIER_1_INTERVAL);
-                clock.tick(ALERT_TIER_1_INTERVAL);
-                expect(monitor.getState()).to.equal('alert');
+                expect(monitor.getAlertCounter()).to.equal(0);
+                expect(monitor.isInAlertMode()).to.be.true;
+            });
 
-                // Network comes back (different from initial)
+            it('returns to fast polling after sleep', () => {
+                monitor = new NetworkChangeMonitor(callback);
+                monitor.start();
+
+                // Get to normal mode
+                for (let i = 0; i < ALERT_THRESHOLD; i++) {
+                    clock.tick(ALERT_INTERVAL);
+                }
+                expect(monitor.isInAlertMode()).to.be.false;
+
+                // Simulate sleep - this resets counter and triggers immediate poll
+                monitor.simulateSleep();
+
+                // Should be back in alert mode with fast polling
+                expect(monitor.isInAlertMode()).to.be.true;
+
+                // Tick to trigger the next poll (first one happens immediately on simulateSleep)
+                clock.tick(ALERT_INTERVAL);
+
+                // Counter should be incrementing with fast 1s interval
+                const counterAfterFirstTick = monitor.getAlertCounter();
+                clock.tick(ALERT_INTERVAL);
+                expect(monitor.getAlertCounter()).to.equal(counterAfterFirstTick + 1);
+            });
+        });
+
+        describe('full scenario', () => {
+            it('sleep → fast polling → detects network change → broadcasts', () => {
+                monitor = new NetworkChangeMonitor(callback);
+                monitor.start();
+
+                // Get to normal mode
+                for (let i = 0; i < ALERT_THRESHOLD; i++) {
+                    clock.tick(ALERT_INTERVAL);
+                }
+                expect(monitor.isInAlertMode()).to.be.false;
+
+                // Simulate sleep (going from home to work)
+                monitor.simulateSleep();
+                expect(monitor.isInAlertMode()).to.be.true;
+
+                // Network changes (now at work)
                 networkInterfacesStub.returns({
                     'en0': [{
                         address: '10.0.0.50',
@@ -471,77 +347,28 @@ describe('NetworkChangeMonitor', () => {
                     }]
                 });
 
-                clock.tick(ALERT_TIER_1_INTERVAL);
-                expect(callback.calledOnce).to.be.true; // Broadcast!
-                expect(monitor.getState()).to.equal('verifying');
+                // Fast polling should detect it within 1 second
+                clock.tick(ALERT_INTERVAL);
 
-                // Verifying checks pass
-                for (let i = 0; i < VERIFYING_REQUIRED_COUNT; i++) {
-                    clock.tick(VERIFYING_INTERVAL);
-                }
-
-                expect(monitor.getState()).to.equal('idle');
+                expect(callback.calledOnce).to.be.true;
             });
 
-            it('wake on same network → no broadcast, quick verifying', () => {
+            it('wake on same network → no broadcast', () => {
                 monitor = new NetworkChangeMonitor(callback);
                 monitor.start();
 
-                // Sleep detected
-                monitor.simulateSleep();
-                expect(monitor.getState()).to.equal('alert');
-
-                // Network still same
-                clock.tick(ALERT_TIER_1_INTERVAL);
-                expect(callback.called).to.be.false; // No broadcast
-                expect(monitor.getState()).to.equal('verifying');
-
-                // Verifying passes
-                for (let i = 0; i < VERIFYING_REQUIRED_COUNT; i++) {
-                    clock.tick(VERIFYING_INTERVAL);
+                // Get to normal mode
+                for (let i = 0; i < ALERT_THRESHOLD; i++) {
+                    clock.tick(ALERT_INTERVAL);
                 }
 
-                expect(monitor.getState()).to.equal('idle');
-                expect(callback.called).to.be.false; // Still no broadcast
-            });
-
-            it('flaky WiFi: broadcasts on each change, verifying fails, retries from alert', () => {
-                monitor = new NetworkChangeMonitor(callback);
-                monitor.start();
-
-                // Sleep detected
+                // Simulate sleep
                 monitor.simulateSleep();
-                expect(monitor.getState()).to.equal('alert');
 
-                // Network comes back (changed)
-                networkInterfacesStub.returns({
-                    'en0': [{
-                        address: '10.0.0.50',
-                        netmask: '255.255.255.0',
-                        family: 'IPv4',
-                        internal: false
-                    }]
-                });
-                clock.tick(ALERT_TIER_1_INTERVAL);
-                expect(callback.callCount).to.equal(1);
-                expect(monitor.getState()).to.equal('verifying');
+                // Network unchanged
+                clock.tick(ALERT_INTERVAL);
 
-                // Flaky: network changes again during verifying
-                networkInterfacesStub.returns({
-                    'en0': [{
-                        address: '10.0.0.51',
-                        netmask: '255.255.255.0',
-                        family: 'IPv4',
-                        internal: false
-                    }]
-                });
-                clock.tick(VERIFYING_INTERVAL);
-                expect(monitor.getState()).to.equal('alert'); // Back to alert
-
-                // New network detected → broadcast
-                clock.tick(ALERT_TIER_1_INTERVAL);
-                expect(callback.callCount).to.equal(2);
-                expect(monitor.getState()).to.equal('verifying');
+                expect(callback.called).to.be.false;
             });
         });
 
@@ -561,8 +388,8 @@ describe('NetworkChangeMonitor', () => {
                     }]
                 });
 
-                clock.tick(IDLE_INTERVAL);
-                clock.tick(IDLE_INTERVAL);
+                clock.tick(ALERT_INTERVAL);
+                clock.tick(ALERT_INTERVAL);
 
                 expect(callback.called).to.be.false;
             });
@@ -576,15 +403,14 @@ describe('NetworkChangeMonitor', () => {
                 monitor = new NetworkChangeMonitor(callback);
                 monitor.start();
 
-                // Let it run for one full interval
-                clock.tick(IDLE_INTERVAL);
-                expect(callback.called).to.be.false; // No network change
+                // Let it run for a bit
+                clock.tick(ALERT_INTERVAL);
 
                 // Stop the monitor
                 monitor.stop();
 
-                // Advance time well past another interval
-                clock.tick(IDLE_INTERVAL * 2);
+                // Advance time
+                clock.tick(ALERT_INTERVAL * 10);
 
                 // Change the network while stopped
                 networkInterfacesStub.returns({
@@ -596,10 +422,9 @@ describe('NetworkChangeMonitor', () => {
                     }]
                 });
 
-                // Restart the monitor
+                // Restart the monitor - should detect change immediately
                 monitor.start();
 
-                // The callback should fire immediately since we've been stopped > interval
                 expect(callback.calledOnce).to.be.true;
             });
         });

--- a/src/deviceDiscovery/NetworkChangeMonitor.ts
+++ b/src/deviceDiscovery/NetworkChangeMonitor.ts
@@ -106,9 +106,7 @@ export class NetworkChangeMonitor {
         const hash = getNetworkHash();
         if (hash !== this.currentHash) {
             this.currentHash = hash;
-            if (hash !== 'no-network') {
-                this.onNetworkChanged();
-            }
+            this.onNetworkChanged();
         }
     }
 

--- a/src/deviceDiscovery/NetworkChangeMonitor.ts
+++ b/src/deviceDiscovery/NetworkChangeMonitor.ts
@@ -24,50 +24,37 @@ export function getNetworkHash(): string {
     return md5(parts.sort().join('|'));
 }
 
-export type MonitorState = 'idle' | 'alert' | 'verifying';
-
 /**
  * Monitor for network changes by polling IP addresses.
  *
- * Uses a state machine with backoff for wake-from-sleep scenarios:
- * - idle: Normal 3-minute polling
- * - alert: Aggressive polling after wake (tiers: 1s/5s/15s intervals)
- * - verifying: Validates network is stable (3 consecutive matching polls)
+ * Uses a simple counter-based approach for wake-from-sleep scenarios:
+ * - When sleep is detected, counter resets to 0 (fast 1s polling)
+ * - Each poll increments counter
+ * - Once counter >= threshold, switches to slower 15s polling
  */
 export class NetworkChangeMonitor {
 
     private onNetworkChanged: () => void;
     private timer: NodeJS.Timeout | null = null;
     private lastExecutionTime = 0;
-
-    // State machine
-    private state: MonitorState = 'idle';
     private currentHash: string;
-    private verifyingTarget = '';
-    private verifyingCount = 0;
-    private alertTier: 1 | 2 | 3 = 1;
-    private alertTierStartTime = 0;
 
-    // Timing configuration
-    private readonly CONFIG = {
-        idle: { interval: 3 * 60 * 1_000 },
-        alert: {
-            1: { interval: 1_000, duration: 30_000 },
-            2: { interval: 5_000, duration: 30_000 },
-            3: { interval: 15_000, duration: 180_000 }
-        },
-        verifying: { interval: 1_000, requiredCount: 3 }
-    };
+    // Counter-based polling
+    private alertCounter = 0;
+    private readonly ALERT_THRESHOLD = 30; // After 30 polls at 1s, switch to slow mode
+    private readonly ALERT_INTERVAL = 1_000; // 1 second
+    private readonly NORMAL_INTERVAL = 15_000; // 15 seconds
 
     private systemSleepMonitor: SystemSleepMonitor;
 
     constructor(onNetworkChanged: () => void) {
         this.onNetworkChanged = onNetworkChanged;
-        // Take initial snapshot - this is the hash we've "broadcast" about
         this.currentHash = getNetworkHash();
 
         this.systemSleepMonitor = new SystemSleepMonitor(() => {
-            this.enterAlert();
+            this.alertCounter = 0;
+            this.lastExecutionTime = 0; // Force immediate execution
+            this.setTimer();
         });
     }
 
@@ -90,20 +77,16 @@ export class NetworkChangeMonitor {
     }
 
     private executeTask() {
-        this.doWork();
+        this.checkForNetworkChange();
+        this.alertCounter++;
         this.lastExecutionTime = Date.now();
         this.setTimer();
     }
 
     private getCurrentInterval(): number {
-        switch (this.state) {
-            case 'idle':
-                return this.CONFIG.idle.interval;
-            case 'alert':
-                return this.CONFIG.alert[this.alertTier].interval;
-            case 'verifying':
-                return this.CONFIG.verifying.interval;
-        }
+        return this.alertCounter < this.ALERT_THRESHOLD
+            ? this.ALERT_INTERVAL
+            : this.NORMAL_INTERVAL;
     }
 
     private setTimer() {
@@ -119,156 +102,28 @@ export class NetworkChangeMonitor {
         }, remaining);
     }
 
-    private doWork() {
-        switch (this.state) {
-            case 'idle':
-                this.handleIdle();
-                break;
-            case 'alert':
-                this.handleAlert();
-                break;
-            case 'verifying':
-                this.handleVerifying();
-                break;
-        }
-    }
-
-    /**
-     * Idle: Normal polling mode
-     * - Network changed (hash ≠ currentHash, hash ≠ 'no-network') → broadcast, stay idle
-     * - Sleep detected → handled by SystemSleepMonitor callback
-     */
-    private handleIdle() {
+    private checkForNetworkChange() {
         const hash = getNetworkHash();
-        if (hash !== this.currentHash && hash !== 'no-network') {
+        if (hash !== this.currentHash) {
             this.currentHash = hash;
-            this.onNetworkChanged();
-        }
-        // Stay idle
-    }
-
-    /**
-     * Alert: Aggressive polling after wake
-     * - Network detected (hash ≠ 'no-network') → enter verifying (broadcast if hash changed)
-     * - Tier timeout → advance to next tier (or return to idle if tier 3 times out)
-     */
-    private handleAlert() {
-        const hash = getNetworkHash();
-        const now = Date.now();
-        const tierConfig = this.CONFIG.alert[this.alertTier];
-        const tierElapsed = now - this.alertTierStartTime;
-
-        // Check if we have a network
-        if (hash !== 'no-network') {
-            // Network detected - broadcast if it changed
-            if (hash !== this.currentHash) {
-                this.currentHash = hash;
+            if (hash !== 'no-network') {
                 this.onNetworkChanged();
             }
-            // Enter verifying to validate the network is stable
-            this.enterVerifying(hash);
-            return;
-        }
-
-        // No network - check for tier timeout
-        if (tierElapsed >= tierConfig.duration) {
-            this.advanceAlertTier();
         }
     }
 
     /**
-     * Verifying: Validates network is stable
-     * - 3 consecutive polls with same hash → stable, return to idle
-     * - Hash changed (unstable) → back to alert
-     * - 'no-network' detected → back to alert
+     * Get the current alert counter (for testing)
      */
-    private handleVerifying() {
-        const hash = getNetworkHash();
-
-        // Check for no-network or hash change (unstable)
-        if (hash === 'no-network' || hash !== this.verifyingTarget) {
-            // Network unstable - go back to alert
-            this.enterAlert();
-            return;
-        }
-
-        // Hash matches - increment verifying count
-        this.verifyingCount++;
-
-        const requiredCount = this.CONFIG.verifying.requiredCount;
-        if (this.verifyingCount >= requiredCount) {
-            // Stable! Return to idle
-            this.returnToIdle();
-        }
+    public getAlertCounter(): number {
+        return this.alertCounter;
     }
 
     /**
-     * Enter alert state after sleep detected
+     * Check if currently in alert mode (for testing)
      */
-    private enterAlert(): void {
-        this.state = 'alert';
-        this.alertTier = 1;
-        this.alertTierStartTime = Date.now();
-        this.lastExecutionTime = 0; // Force immediate execution
-        this.setTimer();
-    }
-
-    /**
-     * Enter verifying state
-     */
-    private enterVerifying(targetHash: string): void {
-        this.state = 'verifying';
-        this.verifyingTarget = targetHash;
-        this.verifyingCount = 0;
-        this.lastExecutionTime = Date.now();
-        this.setTimer();
-    }
-
-    /**
-     * Return to idle state
-     */
-    private returnToIdle(): void {
-        this.state = 'idle';
-        this.verifyingTarget = '';
-        this.verifyingCount = 0;
-        this.lastExecutionTime = Date.now();
-        this.setTimer();
-    }
-
-    /**
-     * Advance to the next alert tier, or return to idle if tier 3 times out
-     */
-    private advanceAlertTier(): void {
-        if (this.alertTier < 3) {
-            this.alertTier = (this.alertTier + 1) as 1 | 2 | 3;
-            this.alertTierStartTime = Date.now();
-            this.lastExecutionTime = Date.now();
-            this.setTimer();
-        } else {
-            // Gave up - return to idle without broadcasting
-            this.returnToIdle();
-        }
-    }
-
-    /**
-     * Get the current state (for testing)
-     */
-    public getState(): MonitorState {
-        return this.state;
-    }
-
-    /**
-     * Get the current alert tier (for testing)
-     */
-    public getAlertTier(): number {
-        return this.alertTier;
-    }
-
-    /**
-     * Get the current hash (for testing)
-     */
-    public getCurrentHash(): string {
-        return this.currentHash;
+    public isInAlertMode(): boolean {
+        return this.alertCounter < this.ALERT_THRESHOLD;
     }
 
     /**
@@ -276,7 +131,9 @@ export class NetworkChangeMonitor {
      * @internal
      */
     public simulateSleep(): void {
-        this.enterAlert();
+        this.alertCounter = 0;
+        this.lastExecutionTime = 0;
+        this.setTimer();
     }
 
     public dispose(): void {

--- a/src/deviceDiscovery/NetworkChangeMonitor.ts
+++ b/src/deviceDiscovery/NetworkChangeMonitor.ts
@@ -1,5 +1,6 @@
 import * as os from 'os';
 import * as md5 from 'md5';
+import { SystemSleepMonitor } from './SystemSleepMonitor';
 
 /**
  * Generate a hash of current network interfaces for detecting network changes
@@ -23,26 +24,57 @@ export function getNetworkHash(): string {
     return md5(parts.sort().join('|'));
 }
 
+export type MonitorState = 'idle' | 'alert' | 'verifying';
+
 /**
- * Monitor for network changes by polling IP addresses
+ * Monitor for network changes by polling IP addresses.
+ *
+ * Uses a state machine with backoff for wake-from-sleep scenarios:
+ * - idle: Normal 3-minute polling
+ * - alert: Aggressive polling after wake (tiers: 1s/5s/15s intervals)
+ * - verifying: Validates network is stable (3 consecutive matching polls)
  */
 export class NetworkChangeMonitor {
 
     private onNetworkChanged: () => void;
     private timer: NodeJS.Timeout | null = null;
     private lastExecutionTime = 0;
-    private interval = 3 * 60 * 1_000; // 3 minutes
-    private previousNetworkHash = '';
+
+    // State machine
+    private state: MonitorState = 'idle';
+    private currentHash: string;
+    private verifyingTarget = '';
+    private verifyingCount = 0;
+    private alertTier: 1 | 2 | 3 = 1;
+    private alertTierStartTime = 0;
+
+    // Timing configuration
+    private readonly CONFIG = {
+        idle: { interval: 3 * 60 * 1_000 },
+        alert: {
+            1: { interval: 1_000, duration: 30_000 },
+            2: { interval: 5_000, duration: 30_000 },
+            3: { interval: 15_000, duration: 180_000 }
+        },
+        verifying: { interval: 1_000, requiredCount: 3 }
+    };
+
+    private systemSleepMonitor: SystemSleepMonitor;
 
     constructor(onNetworkChanged: () => void) {
         this.onNetworkChanged = onNetworkChanged;
-        // Take initial snapshot
-        this.previousNetworkHash = getNetworkHash();
+        // Take initial snapshot - this is the hash we've "broadcast" about
+        this.currentHash = getNetworkHash();
+
+        this.systemSleepMonitor = new SystemSleepMonitor(() => {
+            this.enterAlert();
+        });
     }
 
     public start(): void {
+        this.systemSleepMonitor.start();
         const now = Date.now();
-        if (now - this.lastExecutionTime > this.interval) {
+        if (now - this.lastExecutionTime > this.getCurrentInterval()) {
             this.executeTask();
         } else {
             this.setTimer();
@@ -50,6 +82,7 @@ export class NetworkChangeMonitor {
     }
 
     public stop(): void {
+        this.systemSleepMonitor.stop();
         if (this.timer) {
             clearTimeout(this.timer);
             this.timer = null;
@@ -62,24 +95,193 @@ export class NetworkChangeMonitor {
         this.setTimer();
     }
 
+    private getCurrentInterval(): number {
+        switch (this.state) {
+            case 'idle':
+                return this.CONFIG.idle.interval;
+            case 'alert':
+                return this.CONFIG.alert[this.alertTier].interval;
+            case 'verifying':
+                return this.CONFIG.verifying.interval;
+        }
+    }
+
     private setTimer() {
-        this.stop(); // Ensure no existing timer is running
+        if (this.timer) {
+            clearTimeout(this.timer);
+            this.timer = null;
+        }
+        const interval = this.getCurrentInterval();
+        const elapsed = Date.now() - this.lastExecutionTime;
+        const remaining = Math.max(0, interval - elapsed);
         this.timer = setTimeout(() => {
             this.executeTask();
-        }, this.interval - (Date.now() - this.lastExecutionTime));
+        }, remaining);
     }
 
     private doWork() {
-        const currentNetworkHash = getNetworkHash();
-        if (currentNetworkHash === this.previousNetworkHash) {
-            return; // No change detected
+        switch (this.state) {
+            case 'idle':
+                this.handleIdle();
+                break;
+            case 'alert':
+                this.handleAlert();
+                break;
+            case 'verifying':
+                this.handleVerifying();
+                break;
         }
-        this.onNetworkChanged();
-        this.previousNetworkHash = currentNetworkHash;
+    }
+
+    /**
+     * Idle: Normal polling mode
+     * - Network changed (hash ≠ currentHash, hash ≠ 'no-network') → broadcast, stay idle
+     * - Sleep detected → handled by SystemSleepMonitor callback
+     */
+    private handleIdle() {
+        const hash = getNetworkHash();
+        if (hash !== this.currentHash && hash !== 'no-network') {
+            this.currentHash = hash;
+            this.onNetworkChanged();
+        }
+        // Stay idle
+    }
+
+    /**
+     * Alert: Aggressive polling after wake
+     * - Network detected (hash ≠ 'no-network') → enter verifying (broadcast if hash changed)
+     * - Tier timeout → advance to next tier (or return to idle if tier 3 times out)
+     */
+    private handleAlert() {
+        const hash = getNetworkHash();
+        const now = Date.now();
+        const tierConfig = this.CONFIG.alert[this.alertTier];
+        const tierElapsed = now - this.alertTierStartTime;
+
+        // Check if we have a network
+        if (hash !== 'no-network') {
+            // Network detected - broadcast if it changed
+            if (hash !== this.currentHash) {
+                this.currentHash = hash;
+                this.onNetworkChanged();
+            }
+            // Enter verifying to validate the network is stable
+            this.enterVerifying(hash);
+            return;
+        }
+
+        // No network - check for tier timeout
+        if (tierElapsed >= tierConfig.duration) {
+            this.advanceAlertTier();
+        }
+    }
+
+    /**
+     * Verifying: Validates network is stable
+     * - 3 consecutive polls with same hash → stable, return to idle
+     * - Hash changed (unstable) → back to alert
+     * - 'no-network' detected → back to alert
+     */
+    private handleVerifying() {
+        const hash = getNetworkHash();
+
+        // Check for no-network or hash change (unstable)
+        if (hash === 'no-network' || hash !== this.verifyingTarget) {
+            // Network unstable - go back to alert
+            this.enterAlert();
+            return;
+        }
+
+        // Hash matches - increment verifying count
+        this.verifyingCount++;
+
+        const requiredCount = this.CONFIG.verifying.requiredCount;
+        if (this.verifyingCount >= requiredCount) {
+            // Stable! Return to idle
+            this.returnToIdle();
+        }
+    }
+
+    /**
+     * Enter alert state after sleep detected
+     */
+    private enterAlert(): void {
+        this.state = 'alert';
+        this.alertTier = 1;
+        this.alertTierStartTime = Date.now();
+        this.lastExecutionTime = 0; // Force immediate execution
+        this.setTimer();
+    }
+
+    /**
+     * Enter verifying state
+     */
+    private enterVerifying(targetHash: string): void {
+        this.state = 'verifying';
+        this.verifyingTarget = targetHash;
+        this.verifyingCount = 0;
+        this.lastExecutionTime = Date.now();
+        this.setTimer();
+    }
+
+    /**
+     * Return to idle state
+     */
+    private returnToIdle(): void {
+        this.state = 'idle';
+        this.verifyingTarget = '';
+        this.verifyingCount = 0;
+        this.lastExecutionTime = Date.now();
+        this.setTimer();
+    }
+
+    /**
+     * Advance to the next alert tier, or return to idle if tier 3 times out
+     */
+    private advanceAlertTier(): void {
+        if (this.alertTier < 3) {
+            this.alertTier = (this.alertTier + 1) as 1 | 2 | 3;
+            this.alertTierStartTime = Date.now();
+            this.lastExecutionTime = Date.now();
+            this.setTimer();
+        } else {
+            // Gave up - return to idle without broadcasting
+            this.returnToIdle();
+        }
+    }
+
+    /**
+     * Get the current state (for testing)
+     */
+    public getState(): MonitorState {
+        return this.state;
+    }
+
+    /**
+     * Get the current alert tier (for testing)
+     */
+    public getAlertTier(): number {
+        return this.alertTier;
+    }
+
+    /**
+     * Get the current hash (for testing)
+     */
+    public getCurrentHash(): string {
+        return this.currentHash;
+    }
+
+    /**
+     * Simulate sleep detection (for testing)
+     * @internal
+     */
+    public simulateSleep(): void {
+        this.enterAlert();
     }
 
     public dispose(): void {
         this.stop();
+        this.systemSleepMonitor?.dispose?.();
         delete this.onNetworkChanged;
     }
 }

--- a/src/deviceDiscovery/RokuFinder.ts
+++ b/src/deviceDiscovery/RokuFinder.ts
@@ -256,6 +256,8 @@ export class RokuFinder extends EventEmitter {
     public dispose() {
         this.stop();
 
+        this.removeAllListeners();
+
         // Clear all timers
         for (const timer of this.scanTimers) {
             clearTimeout(timer);


### PR DESCRIPTION
## Summary                          
  - Adds handlePotentialNetworkChange() method that both SystemSleepMonitor and NetworkChangeMonitor now use
  - Sleep/wake now properly checks for network changes instead of just marking scan needed                           
  - Includes retry logic for WiFi reconnection timing after wake                                                   
  - Focus-gained event also triggers network check as backup