### PR TITLE
Detect device-online via SSDP alive burst

### DIFF
--- a/src/deviceDiscovery/DeviceManager.ts
+++ b/src/deviceDiscovery/DeviceManager.ts
@@ -10,7 +10,6 @@ import { NetworkChangeMonitor, getNetworkHash } from './NetworkChangeMonitor';
 import { SystemSleepMonitor } from './SystemSleepMonitor';
 import { util } from '../util';
 import { vscodeContextManager } from '../managers/VscodeContextManager';
-import { debounce } from 'lodash';
 
 export class DeviceManager {
     // #region constructor
@@ -168,7 +167,6 @@ export class DeviceManager {
 
     // Notifications and event debouncing
     private readonly DEVICES_CHANGED_DEBOUNCE_MS = 50;
-    private deviceOnlineNotifiers = new Map<string, ReturnType<typeof debounce>>();
 
     // Scan state management
     private readonly STALE_SCAN_THRESHOLD_MS = 30 * 60 * 1_000; // 30 minutes
@@ -1033,15 +1031,8 @@ export class DeviceManager {
         // Get display name from cache
         const fallbackName = actualSerial ? `${ip} (${actualSerial})` : ip;
         const displayName = cachedDevice?.deviceInfo?.['default-device-name'] ?? fallbackName;
-        const notifierId = actualSerial ?? ip;
 
-        if (!this.deviceOnlineNotifiers.has(notifierId)) {
-            this.deviceOnlineNotifiers.set(notifierId, debounce((name: string) => {
-                this.deviceOnlineNotifiers.delete(notifierId);
-                void util.showTimedNotification(`Device Online: ${name}`);
-            }, 500));
-        }
-        this.deviceOnlineNotifiers.get(notifierId)(displayName);
+        void util.showTimedNotification(`Device Online: ${displayName}`);
     }
 
     private async activateMonitoring() {

--- a/src/deviceDiscovery/RokuFinder.spec.ts
+++ b/src/deviceDiscovery/RokuFinder.spec.ts
@@ -181,7 +181,29 @@ describe('RokuFinder', () => {
             expect(options.serialNumber).to.equal('ABC123');
         });
 
-        it('emits "device-online" with IP and serial number on ssdp:alive', async () => {
+        it('emits "device-online" with IP and serial number when a burst of ssdp:alive is seen', async () => {
+            finder = new RokuFinder();
+            await finder.start();
+
+            const deviceOnlineSpy = sinon.spy();
+            finder.on('device-online', deviceOnlineSpy);
+
+            const aliveMessage = {
+                NT: 'roku:ecp',
+                NTS: 'ssdp:alive',
+                LOCATION: 'http://192.168.1.100:8060',
+                USN: 'uuid:roku:ecp:ABC123'
+            };
+
+            (finder['server'] as any).emit('advertise-alive', aliveMessage);
+            (finder['server'] as any).emit('advertise-alive', aliveMessage);
+
+            expect(deviceOnlineSpy.calledOnce).to.be.true;
+            expect(deviceOnlineSpy.firstCall.args[0]).to.equal('192.168.1.100');
+            expect(deviceOnlineSpy.firstCall.args[1]).to.equal('ABC123');
+        });
+
+        it('does not emit "device-online" for a single ssdp:alive', async () => {
             finder = new RokuFinder();
             await finder.start();
 
@@ -195,9 +217,120 @@ describe('RokuFinder', () => {
                 USN: 'uuid:roku:ecp:ABC123'
             });
 
+            expect(deviceOnlineSpy.called).to.be.false;
+        });
+
+        it('emits "device-online" only once per burst regardless of how many alives arrive', async () => {
+            finder = new RokuFinder();
+            await finder.start();
+
+            const deviceOnlineSpy = sinon.spy();
+            finder.on('device-online', deviceOnlineSpy);
+
+            const aliveMessage = {
+                NT: 'roku:ecp',
+                NTS: 'ssdp:alive',
+                LOCATION: 'http://192.168.1.100:8060',
+                USN: 'uuid:roku:ecp:ABC123'
+            };
+
+            (finder['server'] as any).emit('advertise-alive', aliveMessage);
+            (finder['server'] as any).emit('advertise-alive', aliveMessage);
+            (finder['server'] as any).emit('advertise-alive', aliveMessage);
+            (finder['server'] as any).emit('advertise-alive', aliveMessage);
+
             expect(deviceOnlineSpy.calledOnce).to.be.true;
+        });
+
+        it('does not emit "device-online" for periodic heartbeats spaced beyond the burst window', () => {
+            const clock = sinon.useFakeTimers();
+            try {
+                finder = new RokuFinder();
+                finder['running'] = true;
+
+                const deviceOnlineSpy = sinon.spy();
+                finder.on('device-online', deviceOnlineSpy);
+
+                const aliveMessage = {
+                    NT: 'roku:ecp',
+                    NTS: 'ssdp:alive',
+                    LOCATION: 'http://192.168.1.100:8060',
+                    USN: 'uuid:roku:ecp:ABC123'
+                };
+
+                (finder['server'] as any).emit('advertise-alive', aliveMessage);
+                clock.tick(10_000);
+                (finder['server'] as any).emit('advertise-alive', aliveMessage);
+                clock.tick(10_000);
+                (finder['server'] as any).emit('advertise-alive', aliveMessage);
+
+                expect(deviceOnlineSpy.called).to.be.false;
+            } finally {
+                clock.restore();
+            }
+        });
+
+        it('emits "device-online" again on a new burst after a quiet period', () => {
+            const clock = sinon.useFakeTimers();
+            try {
+                finder = new RokuFinder();
+                finder['running'] = true;
+
+                const deviceOnlineSpy = sinon.spy();
+                finder.on('device-online', deviceOnlineSpy);
+
+                const aliveMessage = {
+                    NT: 'roku:ecp',
+                    NTS: 'ssdp:alive',
+                    LOCATION: 'http://192.168.1.100:8060',
+                    USN: 'uuid:roku:ecp:ABC123'
+                };
+
+                (finder['server'] as any).emit('advertise-alive', aliveMessage);
+                (finder['server'] as any).emit('advertise-alive', aliveMessage);
+                expect(deviceOnlineSpy.calledOnce).to.be.true;
+
+                clock.tick(10_000);
+
+                (finder['server'] as any).emit('advertise-alive', aliveMessage);
+                (finder['server'] as any).emit('advertise-alive', aliveMessage);
+                expect(deviceOnlineSpy.calledTwice).to.be.true;
+            } finally {
+                clock.restore();
+            }
+        });
+
+        it('tracks bursts independently per IP', async () => {
+            finder = new RokuFinder();
+            await finder.start();
+
+            const deviceOnlineSpy = sinon.spy();
+            finder.on('device-online', deviceOnlineSpy);
+
+            const alive1 = {
+                NT: 'roku:ecp',
+                NTS: 'ssdp:alive',
+                LOCATION: 'http://192.168.1.100:8060',
+                USN: 'uuid:roku:ecp:ABC123'
+            };
+            const alive2 = {
+                NT: 'roku:ecp',
+                NTS: 'ssdp:alive',
+                LOCATION: 'http://192.168.1.101:8060',
+                USN: 'uuid:roku:ecp:DEF456'
+            };
+
+            // One alive from each IP - neither alone forms a burst
+            (finder['server'] as any).emit('advertise-alive', alive1);
+            (finder['server'] as any).emit('advertise-alive', alive2);
+            expect(deviceOnlineSpy.called).to.be.false;
+
+            // Second alive from each IP - now each forms a burst
+            (finder['server'] as any).emit('advertise-alive', alive1);
+            (finder['server'] as any).emit('advertise-alive', alive2);
+            expect(deviceOnlineSpy.calledTwice).to.be.true;
             expect(deviceOnlineSpy.firstCall.args[0]).to.equal('192.168.1.100');
-            expect(deviceOnlineSpy.firstCall.args[1]).to.equal('ABC123');
+            expect(deviceOnlineSpy.secondCall.args[0]).to.equal('192.168.1.101');
         });
 
         it('emits "lost" on ssdp:byebye', async () => {
@@ -325,11 +458,11 @@ describe('RokuFinder', () => {
             expect(foundSpy.secondCall.args[0]).to.equal('192.168.1.101');
         });
 
-        it('cleans up stale debounce entries after 5 minutes', async () => {
+        it('auto-cleans debounce entries once the debounce window elapses', () => {
             const clock = sinon.useFakeTimers();
             try {
                 finder = new RokuFinder();
-                await finder.start();
+                finder['running'] = true;
 
                 const aliveMessage = {
                     NT: 'roku:ecp',
@@ -338,20 +471,35 @@ describe('RokuFinder', () => {
                     USN: 'uuid:roku:ecp:ABC123'
                 };
 
-                // First message - adds entry to map
                 (finder['server'] as any).emit('advertise-alive', aliveMessage);
                 expect(finder['aliveDebounceMap'].size).to.equal(1);
 
-                // Advance past cleanup interval (5 minutes)
-                clock.tick((5 * 60 * 1000) + 1);
+                // After the debounce window, the entry removes itself without waiting for another alive
+                clock.tick(500);
+                expect(finder['aliveDebounceMap'].size).to.equal(0);
+            } finally {
+                clock.restore();
+            }
+        });
 
-                // Next message triggers cleanup and removes stale entry, then adds fresh one
+        it('auto-cleans burst tracker entries once the burst window elapses', () => {
+            const clock = sinon.useFakeTimers();
+            try {
+                finder = new RokuFinder();
+                finder['running'] = true;
+
+                const aliveMessage = {
+                    NT: 'roku:ecp',
+                    NTS: 'ssdp:alive',
+                    LOCATION: 'http://192.168.1.100:8060',
+                    USN: 'uuid:roku:ecp:ABC123'
+                };
+
                 (finder['server'] as any).emit('advertise-alive', aliveMessage);
-                expect(finder['aliveDebounceMap'].size).to.equal(1);
+                expect(finder['aliveBurstMap'].size).to.equal(1);
 
-                // Verify the entry is fresh (timestamp should be current time)
-                const timestamp = finder['aliveDebounceMap'].get('192.168.1.100');
-                expect(timestamp).to.equal(Date.now());
+                clock.tick(5_000);
+                expect(finder['aliveBurstMap'].size).to.equal(0);
             } finally {
                 clock.restore();
             }

--- a/src/deviceDiscovery/RokuFinder.ts
+++ b/src/deviceDiscovery/RokuFinder.ts
@@ -29,10 +29,18 @@ export class RokuFinder extends EventEmitter {
     private server: Server;
     private running = false;
     private scanTimers: ReturnType<typeof setTimeout>[] = [];
-    private aliveDebounceMap = new Map<string, number>();
+    // Suppresses duplicate `found` emits within the debounce window; entries self-clean
+    // when their timer fires, so there's no long-lived state for devices that go away.
+    private aliveDebounceMap = new Map<string, ReturnType<typeof setTimeout>>();
     private readonly ALIVE_DEBOUNCE_MS = 500;
-    private lastCleanupTime = 0;
-    private readonly CLEANUP_INTERVAL_MS = 5 * 60 * 1000;
+
+    // Burst detection: Roku devices send multiple ssdp:alive packets in quick succession
+    // when they first come online; steady-state heartbeats are spaced minutes apart. We
+    // infer "just came online" from the burst pattern rather than any single alive.
+    // Entries self-clean when their timer fires after the window goes quiet.
+    private aliveBurstMap = new Map<string, { timestamps: number[]; emitted: boolean; cleanupTimer: ReturnType<typeof setTimeout> }>();
+    private readonly ALIVE_BURST_WINDOW_MS = 5_000;
+    private readonly ALIVE_BURST_MIN_COUNT = 2;
 
     private readonly SCAN_MIN_DURATION_MS = 3_000;
     private readonly SCAN_SETTLE_MS = 1_500;
@@ -204,34 +212,67 @@ export class RokuFinder extends EventEmitter {
             try {
                 const url = new URL(location);
                 const ip = url.hostname;
-                const now = Date.now();
+                const serialNumber = this.extractSerialFromUsn(usn);
 
-                // Periodic cleanup of stale entries
-                if (now - this.lastCleanupTime > this.CLEANUP_INTERVAL_MS) {
-                    this.lastCleanupTime = now;
-                    for (const [cachedIp, timestamp] of this.aliveDebounceMap) {
-                        if (now - timestamp > this.CLEANUP_INTERVAL_MS) {
-                            this.aliveDebounceMap.delete(cachedIp);
-                        }
-                    }
-                }
-
-                const lastEmit = this.aliveDebounceMap.get(ip);
-                if (lastEmit === undefined || now - lastEmit >= this.ALIVE_DEBOUNCE_MS) {
-                    this.aliveDebounceMap.set(ip, now);
-                    const serialNumber = this.extractSerialFromUsn(usn);
+                // Always run the `found` path first, independent of burst detection — every
+                // alive needs to feed discovery, even if the burst tracker decides not to fire
+                // `device-online` or something downstream of it throws.
+                if (!this.aliveDebounceMap.has(ip)) {
+                    this.aliveDebounceMap.set(
+                        ip,
+                        setTimeout(() => this.aliveDebounceMap.delete(ip), this.ALIVE_DEBOUNCE_MS)
+                    );
                     this.emit('found', ip, { serialNumber: serialNumber });
-                    this.emit('device-online', ip, serialNumber);
 
                     // Reset settle timer when device found during active scan
                     if (this.isScanning) {
                         this.resetSettleTimer();
                     }
                 }
+
+                // Then track every alive for burst detection (may emit `device-online`)
+                this.detectDeviceOnlineBurst(ip, serialNumber, Date.now());
             } catch {
                 // Invalid URL, ignore
             }
         }
+    }
+
+    /**
+     * Detect a burst of ssdp:alive packets from the same IP, which implies the
+     * device just came online (Rokus send several alives in quick succession on
+     * boot/join; steady-state heartbeats are far apart and won't accumulate).
+     * Emits 'device-online' once per burst, then clears the window so lingering
+     * alives in the same burst don't trigger additional emits.
+     */
+    private detectDeviceOnlineBurst(ip: string, serialNumber: string | undefined, now: number): void {
+        const existing = this.aliveBurstMap.get(ip);
+        if (existing) {
+            clearTimeout(existing.cleanupTimer);
+        }
+        const recent = existing
+            ? existing.timestamps.filter(time => now - time <= this.ALIVE_BURST_WINDOW_MS)
+            : [];
+
+        // Re-arm once the burst window goes quiet, so a future burst can fire again.
+        let emitted = existing?.emitted ?? false;
+        if (emitted && recent.length === 0) {
+            emitted = false;
+        }
+
+        recent.push(now);
+
+        if (!emitted && recent.length >= this.ALIVE_BURST_MIN_COUNT) {
+            emitted = true;
+            this.emit('device-online', ip, serialNumber);
+        }
+
+        // Entry self-cleans once the burst window elapses with no new alives
+        this.aliveBurstMap.set(ip, {
+            timestamps: recent,
+            emitted: emitted,
+            cleanupTimer: setTimeout(() => this.aliveBurstMap.delete(ip), this.ALIVE_BURST_WINDOW_MS)
+        });
     }
 
     /**
@@ -262,7 +303,14 @@ export class RokuFinder extends EventEmitter {
         }
         this.scanTimers = [];
         this.clearScanTimers();
+        for (const timer of this.aliveDebounceMap.values()) {
+            clearTimeout(timer);
+        }
         this.aliveDebounceMap.clear();
+        for (const tracker of this.aliveBurstMap.values()) {
+            clearTimeout(tracker.cleanupTimer);
+        }
+        this.aliveBurstMap.clear();
 
         this.client.removeAllListeners();
         this.client.stop();


### PR DESCRIPTION
## Summary

- `RokuFinder` previously emitted `device-online` on every debounced `ssdp:alive`, so a Roku already on the network would re-trigger "Device Online" notifications on every periodic heartbeat.
- Now `device-online` is inferred from a **burst** of alives (≥2 within a 5s window, per-IP). Devices send a tight burst when they first join the network; steady-state heartbeats are spaced minutes apart and never accumulate.
- The burst tracker re-arms once the window goes quiet so a future reboot fires again, and both the burst map and the `found` debounce map are now self-cleaning via `setTimeout` (removing the old 5-minute periodic sweep).
- `found` is emitted before burst detection runs so discovery is never skipped if the tracker throws.
- With burst detection at the source, the redundant 500ms per-device notification debounce in `DeviceManager.handleDeviceOnline` is removed (the `deviceOnlineNotifiers` map and the lodash `debounce` import go with it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)