### PR TITLE
Support setting a default device password

### DIFF
--- a/package.json
+++ b/package.json
@@ -324,6 +324,16 @@
                     "group": "navigation@3"
                 },
                 {
+                    "command": "extension.brightscript.setDefaultDevicePassword",
+                    "when": "view == devicesView",
+                    "group": "1_devices@1"
+                },
+                {
+                    "command": "extension.brightscript.clearDefaultDevicePassword",
+                    "when": "view == devicesView && brightscript.hasDefaultDevicePassword",
+                    "group": "1_devices@2"
+                },
+                {
                     "command": "extension.brightscript.rokuRegistry.refreshRegistry",
                     "when": "view == rokuRegistryView && brightscript.isOnDeviceComponentAvailable",
                     "group": "navigation@1"
@@ -2260,6 +2270,12 @@
                             }
                         },
                         "scope": "resource"
+                    },
+                    "brightscript.defaultDevicePassword": {
+                        "type": "string",
+                        "default": "",
+                        "description": "Default developer password applied to any device that does not have its own password configured. Leave empty to disable.",
+                        "scope": "resource"
                     }
                 }
             },
@@ -3427,6 +3443,17 @@
                 "title": "Refresh",
                 "category": "BrightScript",
                 "icon": "$(refresh)"
+            },
+            {
+                "command": "extension.brightscript.setDefaultDevicePassword",
+                "title": "Set Default Device Password",
+                "category": "BrightScript",
+                "icon": "$(key)"
+            },
+            {
+                "command": "extension.brightscript.clearDefaultDevicePassword",
+                "title": "Clear Default Device Password",
+                "category": "BrightScript"
             },
             {
                 "command": "extension.brightscript.enableDeviceDiscovery",

--- a/src/BrightScriptCommands.ts
+++ b/src/BrightScriptCommands.ts
@@ -502,6 +502,97 @@ export class BrightScriptCommands {
             void vscode.window.showInformationMessage(`Added "${displayName}" to workspace settings.`);
         });
 
+        this.registerCommand('clearDefaultDevicePassword', async () => {
+            // Clear the value from every scope where it's set, so "clear" really means clear.
+            const rootInspection = vscode.workspace.getConfiguration('brightscript').inspect<string>('defaultDevicePassword');
+
+            if (rootInspection?.globalValue !== undefined) {
+                await vscode.workspace.getConfiguration('brightscript')
+                    .update('defaultDevicePassword', undefined, vscode.ConfigurationTarget.Global);
+            }
+
+            if (rootInspection?.workspaceValue !== undefined) {
+                await vscode.workspace.getConfiguration('brightscript')
+                    .update('defaultDevicePassword', undefined, vscode.ConfigurationTarget.Workspace);
+            }
+
+            // Per-folder values need to be inspected with that folder's URI as scope
+            for (const folder of vscode.workspace.workspaceFolders ?? []) {
+                const folderConfig = vscode.workspace.getConfiguration('brightscript', folder.uri);
+                const folderInspection = folderConfig.inspect<string>('defaultDevicePassword');
+                if (folderInspection?.workspaceFolderValue !== undefined) {
+                    await folderConfig.update('defaultDevicePassword', undefined, vscode.ConfigurationTarget.WorkspaceFolder);
+                }
+            }
+
+            await vscode.window.showInformationMessage('Default device password cleared.');
+        });
+
+        this.registerCommand('setDefaultDevicePassword', async () => {
+            const currentValue = vscode.workspace.getConfiguration('brightscript').get<string>('defaultDevicePassword') ?? '';
+
+            const password = await vscode.window.showInputBox({
+                placeHolder: 'Enter the default developer password (applied to devices without their own password)',
+                password: true,
+                value: currentValue,
+                prompt: 'Set default device password'
+            });
+
+            if (password === undefined) {
+                return;
+            }
+
+            // Pick the right "workspace" target and scope resource:
+            // - A .code-workspace file: write to Workspace (no resource needed)
+            // - A plain folder: write to WorkspaceFolder and provide the folder URI as the config scope
+            let workspaceTarget: vscode.ConfigurationTarget;
+            let scopeUri: vscode.Uri | undefined;
+
+            if (vscode.workspace.workspaceFile) {
+                workspaceTarget = vscode.ConfigurationTarget.Workspace;
+            } else {
+                workspaceTarget = vscode.ConfigurationTarget.WorkspaceFolder;
+                const folders = vscode.workspace.workspaceFolders ?? [];
+                if (folders.length === 0) {
+                    void vscode.window.showErrorMessage('Cannot set workspace default password: no workspace is open.');
+                    return;
+                } else if (folders.length === 1) {
+                    scopeUri = folders[0].uri;
+                } else {
+                    const pickedFolder = await vscode.window.showWorkspaceFolderPick({
+                        placeHolder: 'Select which folder to save the default password to'
+                    });
+                    if (!pickedFolder) {
+                        return;
+                    }
+                    scopeUri = pickedFolder.uri;
+                }
+            }
+
+            const targetChoice = await vscode.window.showQuickPick(
+                [
+                    { label: 'User', description: 'Apply to all workspaces', target: vscode.ConfigurationTarget.Global },
+                    { label: 'Workspace', description: 'Apply to this workspace only', target: workspaceTarget }
+                ],
+                { placeHolder: 'Where should the default password be saved?' }
+            );
+
+            if (!targetChoice) {
+                return;
+            }
+
+            // For WorkspaceFolder writes, the configuration must be scoped to a folder URI
+            const updateScope = targetChoice.target === vscode.ConfigurationTarget.WorkspaceFolder ? scopeUri : undefined;
+            await vscode.workspace.getConfiguration('brightscript', updateScope)
+                .update('defaultDevicePassword', password || undefined, targetChoice.target);
+
+            if (password) {
+                await vscode.window.showInformationMessage('Default device password set.');
+            } else {
+                await vscode.window.showInformationMessage('Default device password cleared.');
+            }
+        });
+
         this.registerCommand('setDevicePassword', async (deviceIp: string) => {
             if (!deviceIp) {
                 throw new Error('Device IP is required to set password.');

--- a/src/deviceDiscovery/DeviceManager.spec.ts
+++ b/src/deviceDiscovery/DeviceManager.spec.ts
@@ -2436,4 +2436,117 @@ describe('DeviceManager', () => {
             });
         });
     });
+
+    describe('defaultPassword', () => {
+        function stubConfig(defaultDevicePassword: string | undefined) {
+            (vscode.workspace.getConfiguration as sinon.SinonStub).returns({
+                get: () => undefined,
+                inspect: () => ({ workspaceValue: [], globalValue: [] }),
+                deviceDiscovery: {
+                    enabled: false,
+                    showInfoMessages: false
+                },
+                defaultDevicePassword: defaultDevicePassword
+            } as any);
+        }
+
+        it('returns undefined when setting is missing', () => {
+            stubConfig(undefined);
+            manager = new DeviceManager(vscode.context, mockGlobalStateManager);
+            expect(manager.defaultPassword).to.be.undefined;
+        });
+
+        it('returns undefined when setting is an empty string', () => {
+            stubConfig('');
+            manager = new DeviceManager(vscode.context, mockGlobalStateManager);
+            expect(manager.defaultPassword).to.be.undefined;
+        });
+
+        it('returns the configured value when setting is a non-empty string', () => {
+            stubConfig('hunter2');
+            manager = new DeviceManager(vscode.context, mockGlobalStateManager);
+            expect(manager.defaultPassword).to.equal('hunter2');
+        });
+
+        describe('getDevice fallback', () => {
+            it('applies defaultPassword to a device missing configuredPassword', () => {
+                stubConfig('hunter2');
+                manager = new DeviceManager(vscode.context, mockGlobalStateManager);
+
+                manager['devices'].push(createMockDevice({
+                    serialNumber: 'abc',
+                    ip: '10.0.0.5'
+                    // no configuredPassword
+                }));
+
+                const device = manager.getDevice({ ip: '10.0.0.5' });
+                expect(device?.configuredPassword).to.equal('hunter2');
+            });
+
+            it('preserves a device-specific configuredPassword over defaultPassword', () => {
+                stubConfig('hunter2');
+                manager = new DeviceManager(vscode.context, mockGlobalStateManager);
+
+                manager['devices'].push(createMockDevice({
+                    serialNumber: 'abc',
+                    ip: '10.0.0.5',
+                    configuredPassword: 'specific'
+                }));
+
+                const device = manager.getDevice({ ip: '10.0.0.5' });
+                expect(device?.configuredPassword).to.equal('specific');
+            });
+
+            it('leaves configuredPassword undefined when no default and no per-device password', () => {
+                stubConfig(undefined);
+                manager = new DeviceManager(vscode.context, mockGlobalStateManager);
+
+                manager['devices'].push(createMockDevice({
+                    serialNumber: 'abc',
+                    ip: '10.0.0.5'
+                }));
+
+                const device = manager.getDevice({ ip: '10.0.0.5' });
+                expect(device?.configuredPassword).to.be.undefined;
+            });
+        });
+
+        describe('getAllDevices fallback', () => {
+            it('applies defaultPassword to every device missing a per-device password', () => {
+                stubConfig('hunter2');
+                manager = new DeviceManager(vscode.context, mockGlobalStateManager);
+
+                manager['devices'].push(createMockDevice({
+                    serialNumber: 'no-pw',
+                    ip: '10.0.0.5'
+                }));
+                manager['devices'].push(createMockDevice({
+                    serialNumber: 'has-pw',
+                    ip: '10.0.0.6',
+                    configuredPassword: 'specific'
+                }));
+
+                const devices = manager.getAllDevices();
+                const withoutPw = devices.find(d => d.serialNumber === 'no-pw');
+                const withPw = devices.find(d => d.serialNumber === 'has-pw');
+                expect(withoutPw?.configuredPassword).to.equal('hunter2');
+                expect(withPw?.configuredPassword).to.equal('specific');
+            });
+
+            it('does not mutate the underlying device entry when applying the fallback', () => {
+                stubConfig('hunter2');
+                manager = new DeviceManager(vscode.context, mockGlobalStateManager);
+
+                manager['devices'].push(createMockDevice({
+                    serialNumber: 'abc',
+                    ip: '10.0.0.5'
+                }));
+
+                manager.getAllDevices();
+
+                // Internal entry should still have no configuredPassword stored on it
+                expect(manager['devices'][0].configuredPassword).to.be.undefined;
+            });
+        });
+    });
 });

--- a/src/deviceDiscovery/DeviceManager.ts
+++ b/src/deviceDiscovery/DeviceManager.ts
@@ -32,6 +32,7 @@ export class DeviceManager {
             let config: any = util.getConfiguration('brightscript') || {};
 
             void vscodeContextManager.set('brightscript.deviceDiscovery.enabled', config.deviceDiscovery?.enabled);
+            void vscodeContextManager.set('brightscript.hasDefaultDevicePassword', !!this.defaultPassword);
 
             //if the `deviceDiscovery.enabled` setting was changed, start or stop monitoring
             if (event?.affectsConfiguration('brightscript.deviceDiscovery.enabled')) {
@@ -56,6 +57,11 @@ export class DeviceManager {
                 this.loadConfiguredDevices().then(() => {
                     this.emitDevicesChanged();
                 }).catch(() => { });
+            }
+
+            //if the `defaultDevicePassword` setting was changed, refresh any device views that rely on it
+            if (event?.affectsConfiguration('brightscript.defaultDevicePassword')) {
+                this.emitDevicesChanged();
             }
         };
         this.context.subscriptions.push(
@@ -242,8 +248,12 @@ export class DeviceManager {
         const serial = this.getSerial(device);
         const cached = serial ? this.globalStateManager.getCachedDevice(serial) : undefined;
 
+        // Fall back to the extension-wide default password when this device has none configured
+        const configuredPassword = device.configuredPassword ?? this.defaultPassword;
+
         return {
             ...device,
+            configuredPassword: configuredPassword,
             deviceInfo: cached?.deviceInfo ?? {}
         };
     }
@@ -426,6 +436,15 @@ export class DeviceManager {
      */
     private get showInfoMessages() {
         return util.getConfiguration('brightscript')?.deviceDiscovery?.showInfoMessages ?? true;
+    }
+
+    /**
+     * Default password applied to any device that does not have its own configured password.
+     * Returns undefined when the setting is empty so callers can fall through to their own logic.
+     */
+    public get defaultPassword(): string | undefined {
+        const value = util.getConfiguration('brightscript')?.defaultDevicePassword;
+        return typeof value === 'string' && value.length > 0 ? value : undefined;
     }
 
     /**

--- a/src/mockVscode.spec.ts
+++ b/src/mockVscode.spec.ts
@@ -540,6 +540,11 @@ export let vscode = {
     DebugConfigurationProviderTriggerKind: {
         Initial: 1,
         Dynamic: 2
+    },
+    ConfigurationTarget: {
+        Global: 1,
+        Workspace: 2,
+        WorkspaceFolder: 3
     }
 };
 


### PR DESCRIPTION
Adds support for saving a default device password (i.e. a password used anytime you don't have a password set for a specific device). 

- Adds a new prop called `brightscript.defaultDevicePassword`. 
- prompts the user for where they want to save the password  <img width="1381" height="229" alt="image" src="https://github.com/user-attachments/assets/4295454e-0e87-4b1c-aecc-4a02b38aa2f0" />

- lets you save and clear from the devices panel  <img width="1084" height="472" alt="image" src="https://github.com/user-attachments/assets/8b78a6f3-98d2-465e-8584-2b47dffd84e8" />  <img width="1067" height="577" alt="image" src="https://github.com/user-attachments/assets/2433c8e2-cf70-48c5-9476-9bad9fcd5030" />
- adds new command to run these directly from the command pallet  <img width="1319" height="187" alt="image" src="https://github.com/user-attachments/assets/574e11ce-65d0-4688-a400-9e7ac4d40728" />


