### PR TITLE
Prefer active device for ${promptForHost}, fall back to picker

### DIFF
--- a/docs/variable-substitutions.md
+++ b/docs/variable-substitutions.md
@@ -10,24 +10,32 @@ Variable substitutions allow you to avoid hardcoding values in your launch confi
 
 | Variable | Description | Behavior |
 |----------|-------------|----------|
-| `${promptForHost}` | Prompts you to enter or select a host IP address | Shows input dialog or device picker when debugging starts |
+| `${promptForHost}` | Resolves to the active device when set and reachable; otherwise opens the device picker | Uses the active device after a successful health check, or shows the picker when no active device is set or the health check fails |
 | `${promptForPassword}` | Prompts you to enter the device password | Shows password input dialog when debugging starts |
-| `${activeHost}` | Uses the currently active device | Automatically uses pre-configured device, or prompts if none set |
+| `${activeHost}` | **Deprecated.** Alias for `${promptForHost}` | Same behavior as `${promptForHost}` |
 | `${activeHostPassword}` | Uses the password for the currently active device | Automatically uses device-specific password, or falls back to global password |
 | `${host}` | References the resolved host value | Can be used in other fields like `deepLinkUrl` |
 
-## `${promptForHost}` - Interactive Host Selection
+## `${promptForHost}` - Smart Host Selection
 
-The most common variable substitution. When used, VS Code will:
-- Show a list of discovered Roku devices (if device discovery is enabled)
-- Allow manual IP entry
-- Remember the last used device
+The most common variable substitution. Resolution order:
+
+1. If an **active device** is set (e.g. via the Roku Devices view or the `Set Active Device` command) and it passes a health check, it is used automatically — no prompt.
+2. Otherwise, VS Code shows the device picker, which:
+   - Lists discovered Roku devices (if device discovery is enabled)
+   - Allows manual IP entry
+   - Remembers the last used device
 
 ```json
 {
     "host": "${promptForHost}"
 }
 ```
+
+To set an active device:
+
+- Open the Command Palette and run **BrightScript: Set Active Device**
+- Or, in the Roku Devices view, expand a device and click **⭐ Set as Active Device**
 
 ## `${promptForPassword}` - Interactive Password Entry
 
@@ -39,56 +47,9 @@ Prompts for the developer password when debugging starts:
 }
 ```
 
-## `${activeHost}` - Smart Device Selection
+## `${activeHost}` - Deprecated
 
-**New!** Uses the currently active device without prompting, but gracefully falls back to prompting if no device is set. This provides the best of both worlds: convenience when you have a preferred device, flexibility when you don't.
-
-### Basic Usage
-
-```json
-{
-    "version": "0.2.0",
-    "configurations": [
-        {
-            "type": "brightscript",
-            "name": "Launch with Current Device",
-            "request": "launch",
-            "host": "${activeHost}",
-            "password": "${promptForPassword}",
-            "rootDir": "${workspaceFolder}",
-            "files": [
-                "manifest",
-                "source/**/*.*",
-                "components/**/*.*",
-                "images/**/*.*"
-            ]
-        }
-    ]
-}
-```
-
-### Requirements
-
-To use `${activeHost}` optimally, you should set an active device using one of these methods:
-
-1. **Via Command Palette:**
-   - Open Command Palette (`Ctrl+Shift+P` / `Cmd+Shift+P`)
-   - Type "BrightScript: Set Active Device"
-   - Enter the IP address of your Roku device
-
-2. **Via Device List:**
-   - Use the Roku Devices view in the sidebar to select a device (if device discovery is enabled)
-
-3. **Via Debugging Session:**
-   - The active device is automatically set when you start a debugging session with `${promptForHost}`
-
-### Fallback Handling
-
-If you use `${activeHost}` but no active device is set, it will automatically fallback to prompting for host selection (same behavior as `${promptForHost}`).
-
-This provides a seamless experience:
-- **When active device is set**: Uses it automatically without prompting
-- **When no active device**: Falls back to the device picker/input dialog
+**Deprecated.** `${activeHost}` is now an alias for [`${promptForHost}`](#promptforhost---smart-host-selection) and is kept only for backwards compatibility. New configurations should prefer `${promptForHost}`, which now uses the active device automatically when set and reachable.
 
 ## `${activeHostPassword}` - Device-Specific Password
 
@@ -104,7 +65,7 @@ Uses the password stored for the currently active device. This allows different 
             "name": "Launch",
             "type": "brightscript",
             "request": "launch",
-            "host": "${activeHost}",
+            "host": "${promptForHost}",
             "password": "${activeHostPassword}"
         }
     ]

--- a/package.json
+++ b/package.json
@@ -3145,7 +3145,7 @@
             },
             {
                 "command": "extension.brightscript.custom8080Command",
-                "title": "custom - Enter any command string to be run on port 8080'",
+                "title": "custom - Enter any command string to be run on port 8080",
                 "category": "Brightscript Debug"
             },
             {

--- a/src/BrightScriptCommands.ts
+++ b/src/BrightScriptCommands.ts
@@ -17,6 +17,7 @@ import type { UserInputManager } from './managers/UserInputManager';
 import { clearNpmPackageCacheCommand } from './commands/ClearNpmPackageCacheCommand';
 import type { LocalPackageManager } from './managers/LocalPackageManager';
 import { profilingCommands } from './commands/ProfilingCommands';
+import { vscodeContextManager } from './managers/VscodeContextManager';
 
 export class BrightScriptCommands {
 
@@ -434,7 +435,8 @@ export class BrightScriptCommands {
                 throw new Error('Tried to set active device but failed.');
             } else {
                 await this.context.workspaceState.update('remoteHost', ip);
-                await vscode.window.showInformationMessage(`BrightScript Language extension active device set to: ${ip}`);
+                await vscodeContextManager.set('activeHost', ip);
+                await util.showTimedNotification(`'${ip}' set as active device`);
             }
         });
 
@@ -525,7 +527,8 @@ export class BrightScriptCommands {
 
         this.registerCommand('clearActiveDevice', async () => {
             await this.context.workspaceState.update('remoteHost', '');
-            await vscode.window.showInformationMessage('BrightScript Language extension active device cleared');
+            await vscodeContextManager.set('activeHost', '');
+            await util.showTimedNotification('Active device cleared');
         });
 
         this.registerCommand('showReleaseNotes', () => {
@@ -786,6 +789,18 @@ export class BrightScriptCommands {
         }
         // Fallback to global password
         return this.getRemotePassword(false);
+    }
+
+    /**
+     * Return the active host IP if one is set and passes a health check; otherwise undefined.
+     */
+    public async getHealthyActiveHost(): Promise<string | undefined> {
+        const activeHost = vscodeContextManager.get<string>('activeHost');
+        if (!activeHost) {
+            return undefined;
+        }
+        const isHealthy = await this.deviceManager.checkDeviceHealth({ ip: activeHost }, true, false);
+        return isHealthy ? activeHost : undefined;
     }
 
     /**

--- a/src/DebugConfigurationProvider.ts
+++ b/src/DebugConfigurationProvider.ts
@@ -445,15 +445,26 @@ export class BrightScriptDebugConfigurationProvider implements DebugConfiguratio
     }
 
     /**
-     * Validates the host parameter in the config and opens an input ui if set to ${promptForHost}
+     * Validates the host parameter in the config and opens an input ui if set to ${promptForHost}.
+     * ${activeHost} is a deprecated alias for ${promptForHost}.
+     * Both use the active device when it's set and passes a health check, otherwise fall back to the device picker.
      * @param config  current config object
      */
     private async processHostParameter(config: BrightScriptLaunchConfiguration): Promise<BrightScriptLaunchConfiguration> {
-        if (config.host.trim() === '${promptForHost}' || (config?.deepLinkUrl?.includes('${promptForHost}'))) {
-            config.host = await this.userInputManager.promptForHost();
-        } else if (config.host.trim() === '${activeHost}') {
-            // Get the current remote host from workspace state (it will prompt for host as a fallback)
-            config.host = await this.brightScriptCommands.getRemoteHost();
+        const trimmedHost = config.host.trim();
+        const needsHostPrompt =
+            trimmedHost === '' ||
+            trimmedHost === '${promptForHost}' ||
+            trimmedHost === '${activeHost}' ||
+            config?.deepLinkUrl?.includes('${promptForHost}');
+
+        if (needsHostPrompt) {
+            const healthyActiveHost = await this.brightScriptCommands.getHealthyActiveHost();
+            if (healthyActiveHost) {
+                config.host = healthyActiveHost;
+            } else {
+                config.host = await this.userInputManager.promptForHost();
+            }
         }
 
         //check the host and throw error if not provided or update the workspace to set last host


### PR DESCRIPTION
## Summary

- `setActiveDevice` / `clearActiveDevice` now also write the active host IP to an in-memory `activeHost` context via `VscodeContextManager` (non-persistent across window reloads). `workspaceState.remoteHost` continues to be written as a persistent shadow of the active value.
- `${promptForHost}` resolution now prefers the active host: if one is set and passes a `deviceManager.checkDeviceHealth` check, it is used silently; otherwise the existing device picker is shown. No error message is displayed on health-check failure — the picker just opens.
- `${activeHost}` is retained as a deprecated alias for `${promptForHost}` (same new behavior).
- Docs updated to reflect the new `${promptForHost}` semantics and the `${activeHost}` deprecation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)