### PR TITLE
chore: install-local --projects list

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -67,7 +67,7 @@
                 "@types/sinon": "7.0.6",
                 "@types/vscode": "^1.81.0",
                 "@types/xml2js": "^0.4.14",
-                "@types/yargs": "^17.0.10",
+                "@types/yargs": "^15.0.5",
                 "@typescript-eslint/eslint-plugin": "^5.14.0",
                 "@typescript-eslint/parser": "^5.14.0",
                 "@vscode/vsce": "^2.22.0",
@@ -1544,9 +1544,9 @@
             }
         },
         "node_modules/@types/yargs": {
-            "version": "17.0.17",
-            "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-17.0.17.tgz",
-            "integrity": "sha512-72bWxFKTK6uwWJAVT+3rF6Jo6RTojiJ27FQo8Rf60AL+VZbzoVPnMFhKsUnbjR8A3BTCYQ7Mv3hnl8T0A+CX9g==",
+            "version": "15.0.20",
+            "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.20.tgz",
+            "integrity": "sha512-KIkX+/GgfFitlASYCGoSF+T4XRXhOubJLhkLVtSfsRTe9jWMmuM2g28zQ41BtPTG7TRBb2xHW+LCNVE9QR/vsg==",
             "dev": true,
             "dependencies": {
                 "@types/yargs-parser": "*"

--- a/package.json
+++ b/package.json
@@ -110,7 +110,7 @@
         "@types/sinon": "7.0.6",
         "@types/vscode": "^1.81.0",
         "@types/xml2js": "^0.4.14",
-        "@types/yargs": "^17.0.10",
+        "@types/yargs": "^15.0.5",
         "@typescript-eslint/eslint-plugin": "^5.14.0",
         "@typescript-eslint/parser": "^5.14.0",
         "@vscode/vsce": "^2.22.0",
@@ -540,7 +540,10 @@
             {
                 "label": "BrightScript Debug",
                 "type": "brightscript",
-                "languages": ["brightscript", "brighterscript"],
+                "languages": [
+                    "brightscript",
+                    "brighterscript"
+                ],
                 "program": "./dist/debugAdapter.js",
                 "runtime": "node",
                 "configurationAttributes": {

--- a/scripts/install-local.ts
+++ b/scripts/install-local.ts
@@ -6,16 +6,51 @@ import * as path from 'path';
 import * as childProcess from 'child_process';
 import * as fsExtra from 'fs-extra';
 import * as chalk from 'chalk';
+import * as yargs from 'yargs';
+
 //path to the parent folder where all of the rokucommunity projects reside (i.e. 1 level above vscode-brightscript-language
 const cwd = path.normalize(`${__dirname}/../../`);
 
-const pull = process.argv.includes('--pull');
-const enableVerboseLogging = process.argv.includes('--verbose');
+const args = yargs
+    .option('pull', {
+        type: 'boolean',
+        default: false,
+        description: 'Fetch and pull latest for each repo'
+    })
+    .option('verbose', {
+        type: 'boolean',
+        default: false,
+        description: 'Enable verbose logging'
+    })
+    .option('projects', {
+        type: 'array',
+        string: true,
+        description: 'Only install local versions of these projects (leave others at their published versions)'
+    })
+    .parseSync();
+
+const pull = args.pull;
+const enableVerboseLogging = args.verbose;
 
 class InstallLocalRunner {
 
+    private requestedProjects!: Set<string>;
+
     public run() {
-        for (const project of this.projects) {
+        this.requestedProjects = new Set(args.projects?.length
+            ? args.projects
+            : this.projects.map(p => p.name)
+        );
+        this.requestedProjects.add('vscode-brightscript-language');
+
+        const unknown = Array.from(this.requestedProjects).filter(n => !this.projects.find(p => p.name === n));
+        if (unknown.length > 0) {
+            console.error(`Unknown projects: ${unknown.join(', ')}`);
+            console.error(`Valid projects: ${this.projects.map(p => p.name).join(', ')}`);
+            process.exit(1);
+        }
+
+        for (const project of this.projects.filter(p => this.requestedProjects.has(p.name))) {
             this.installProject(project.name);
         }
         console.log('Done!');
@@ -100,6 +135,11 @@ class InstallLocalRunner {
 
         //ensure all dependencies are installed
         for (const dependency of project.dependencies) {
+            // if --projects was specified and this dependency isn't in the list, leave the published version intact
+            if (!this.requestedProjects.has(dependency)) {
+                continue;
+            }
+
             log('\n', `installing dependency ${chalk.blue(dependency)}`);
             this.installProject(dependency);
 

--- a/scripts/install-local.ts
+++ b/scripts/install-local.ts
@@ -27,7 +27,7 @@ const args = yargs
         string: true,
         description: 'Only install local versions of these projects (leave others at their published versions)'
     })
-    .parseSync();
+    .argv;
 
 const pull = args.pull;
 const enableVerboseLogging = args.verbose;


### PR DESCRIPTION
Update `install-local` to receive a `--projects` list to only install certain local projects. 

example:

```bash
npm run install-local -- --projects roku-debug
```