### PR TITLE
defaultDevicePassword scoped only to global settings

### DIFF
--- a/package.json
+++ b/package.json
@@ -2278,7 +2278,7 @@
                         "type": "string",
                         "default": "",
                         "description": "Default developer password applied to any device that does not have its own password configured. Leave empty to disable.",
-                        "scope": "resource"
+                        "scope": "application"
                     }
                 }
             },

--- a/src/BrightScriptCommands.spec.ts
+++ b/src/BrightScriptCommands.spec.ts
@@ -103,7 +103,7 @@ describe('BrightScriptFileUtils ', () => {
         beforeEach(() => {
             localCommands = new BrightScriptCommands({} as any, {} as any, vscode.context, {} as any, {} as any, {} as any);
             capturedCommands = {};
-            sinon.stub(vscode.commands, 'registerCommand').callsFake((name: string, cb: (...args: any[]) => any) => {
+            sinon.stub(vscode.commands as any, 'registerCommand').callsFake((name: any, cb: any) => {
                 capturedCommands[name] = cb;
             });
             updateStub = sinon.stub().resolves();
@@ -157,7 +157,7 @@ describe('BrightScriptFileUtils ', () => {
         beforeEach(() => {
             localCommands = new BrightScriptCommands({} as any, {} as any, vscode.context, {} as any, {} as any, {} as any);
             capturedCommands = {};
-            sinon.stub(vscode.commands, 'registerCommand').callsFake((name: string, cb: (...args: any[]) => any) => {
+            sinon.stub(vscode.commands as any, 'registerCommand').callsFake((name: any, cb: any) => {
                 capturedCommands[name] = cb;
             });
             updateStub = sinon.stub().resolves();

--- a/src/BrightScriptCommands.spec.ts
+++ b/src/BrightScriptCommands.spec.ts
@@ -16,6 +16,7 @@ Module.prototype.require = function hijacked(file) {
 };
 
 import { BrightScriptCommands } from './BrightScriptCommands';
+import { util } from './util';
 
 describe('BrightScriptFileUtils ', () => {
     let commands: BrightScriptCommands;
@@ -90,6 +91,102 @@ describe('BrightScriptFileUtils ', () => {
 
             commandsMock.verify();
             (vscode.commands.executeCommand as any).restore();
+        });
+    });
+
+    describe('setDefaultDevicePassword', () => {
+        let localCommands: BrightScriptCommands;
+        let capturedCommands: Record<string, (...args: any[]) => any>;
+        let updateStub: sinon.SinonStub;
+        let showTimedNotificationStub: sinon.SinonStub;
+
+        beforeEach(() => {
+            localCommands = new BrightScriptCommands({} as any, {} as any, vscode.context, {} as any, {} as any, {} as any);
+            capturedCommands = {};
+            sinon.stub(vscode.commands, 'registerCommand').callsFake((name: string, cb: (...args: any[]) => any) => {
+                capturedCommands[name] = cb;
+            });
+            updateStub = sinon.stub().resolves();
+            sinon.stub(vscode.workspace, 'getConfiguration').returns({
+                get: sinon.stub().returns(''),
+                update: updateStub
+            } as any);
+            showTimedNotificationStub = sinon.stub(Object.getPrototypeOf(util), 'showTimedNotification').resolves();
+            localCommands.registerCommands();
+        });
+
+        afterEach(() => {
+            (vscode.commands.registerCommand as any).restore();
+            (vscode.workspace.getConfiguration as any).restore();
+            showTimedNotificationStub.restore();
+        });
+
+        it('saves the password to Global configuration target only', async () => {
+            sinon.stub(vscode.window, 'showInputBox').resolves('mypassword');
+            await capturedCommands['extension.brightscript.setDefaultDevicePassword']();
+            assert.isTrue(updateStub.calledOnce);
+            assert.equal(updateStub.firstCall.args[0], 'defaultDevicePassword');
+            assert.equal(updateStub.firstCall.args[1], 'mypassword');
+            assert.equal(updateStub.firstCall.args[2], vscode.ConfigurationTarget.Global);
+            (vscode.window.showInputBox as any).restore();
+        });
+
+        it('does not save when user cancels the input box', async () => {
+            sinon.stub(vscode.window, 'showInputBox').resolves(undefined);
+            await capturedCommands['extension.brightscript.setDefaultDevicePassword']();
+            assert.isTrue(updateStub.notCalled);
+            (vscode.window.showInputBox as any).restore();
+        });
+
+        it('saves empty string when user clears the password', async () => {
+            sinon.stub(vscode.window, 'showInputBox').resolves('');
+            await capturedCommands['extension.brightscript.setDefaultDevicePassword']();
+            assert.isTrue(updateStub.calledOnce);
+            assert.equal(updateStub.firstCall.args[1], '');
+            assert.equal(updateStub.firstCall.args[2], vscode.ConfigurationTarget.Global);
+            (vscode.window.showInputBox as any).restore();
+        });
+    });
+
+    describe('clearDefaultDevicePassword', () => {
+        let localCommands: BrightScriptCommands;
+        let capturedCommands: Record<string, (...args: any[]) => any>;
+        let updateStub: sinon.SinonStub;
+        let showTimedNotificationStub: sinon.SinonStub;
+
+        beforeEach(() => {
+            localCommands = new BrightScriptCommands({} as any, {} as any, vscode.context, {} as any, {} as any, {} as any);
+            capturedCommands = {};
+            sinon.stub(vscode.commands, 'registerCommand').callsFake((name: string, cb: (...args: any[]) => any) => {
+                capturedCommands[name] = cb;
+            });
+            updateStub = sinon.stub().resolves();
+            sinon.stub(vscode.workspace, 'getConfiguration').returns({
+                get: sinon.stub().returns(''),
+                update: updateStub
+            } as any);
+            showTimedNotificationStub = sinon.stub(Object.getPrototypeOf(util), 'showTimedNotification').resolves();
+            localCommands.registerCommands();
+        });
+
+        afterEach(() => {
+            (vscode.commands.registerCommand as any).restore();
+            (vscode.workspace.getConfiguration as any).restore();
+            showTimedNotificationStub.restore();
+        });
+
+        it('clears the password in Global configuration target only', async () => {
+            await capturedCommands['extension.brightscript.clearDefaultDevicePassword']();
+            assert.isTrue(updateStub.calledOnce);
+            assert.equal(updateStub.firstCall.args[0], 'defaultDevicePassword');
+            assert.equal(updateStub.firstCall.args[1], undefined);
+            assert.equal(updateStub.firstCall.args[2], vscode.ConfigurationTarget.Global);
+        });
+
+        it('shows a confirmation notification after clearing', async () => {
+            await capturedCommands['extension.brightscript.clearDefaultDevicePassword']();
+            assert.isTrue(showTimedNotificationStub.calledOnce);
+            assert.equal(showTimedNotificationStub.firstCall.args[0], 'Default device password cleared.');
         });
     });
 

--- a/src/BrightScriptCommands.ts
+++ b/src/BrightScriptCommands.ts
@@ -505,29 +505,8 @@ export class BrightScriptCommands {
         });
 
         this.registerCommand('clearDefaultDevicePassword', async () => {
-            // Clear the value from every scope where it's set, so "clear" really means clear.
-            const rootInspection = vscode.workspace.getConfiguration('brightscript').inspect<string>('defaultDevicePassword');
-
-            if (rootInspection?.globalValue !== undefined) {
-                await vscode.workspace.getConfiguration('brightscript')
-                    .update('defaultDevicePassword', undefined, vscode.ConfigurationTarget.Global);
-            }
-
-            if (rootInspection?.workspaceValue !== undefined) {
-                await vscode.workspace.getConfiguration('brightscript')
-                    .update('defaultDevicePassword', undefined, vscode.ConfigurationTarget.Workspace);
-            }
-
-            // Per-folder values need to be inspected with that folder's URI as scope
-            for (const folder of vscode.workspace.workspaceFolders ?? []) {
-                const folderConfig = vscode.workspace.getConfiguration('brightscript', folder.uri);
-                const folderInspection = folderConfig.inspect<string>('defaultDevicePassword');
-                if (folderInspection?.workspaceFolderValue !== undefined) {
-                    await folderConfig.update('defaultDevicePassword', undefined, vscode.ConfigurationTarget.WorkspaceFolder);
-                }
-            }
-
-            await vscode.window.showInformationMessage('Default device password cleared.');
+            await vscode.workspace.getConfiguration('brightscript').update('defaultDevicePassword', undefined, vscode.ConfigurationTarget.Global);
+            await util.showTimedNotification('Default device password cleared.');
         });
 
         this.registerCommand('setDefaultDevicePassword', async () => {
@@ -544,55 +523,8 @@ export class BrightScriptCommands {
                 return;
             }
 
-            // Pick the right "workspace" target and scope resource:
-            // - A .code-workspace file: write to Workspace (no resource needed)
-            // - A plain folder: write to WorkspaceFolder and provide the folder URI as the config scope
-            let workspaceTarget: vscode.ConfigurationTarget;
-            let scopeUri: vscode.Uri | undefined;
-
-            if (vscode.workspace.workspaceFile) {
-                workspaceTarget = vscode.ConfigurationTarget.Workspace;
-            } else {
-                workspaceTarget = vscode.ConfigurationTarget.WorkspaceFolder;
-                const folders = vscode.workspace.workspaceFolders ?? [];
-                if (folders.length === 0) {
-                    void vscode.window.showErrorMessage('Cannot set workspace default password: no workspace is open.');
-                    return;
-                } else if (folders.length === 1) {
-                    scopeUri = folders[0].uri;
-                } else {
-                    const pickedFolder = await vscode.window.showWorkspaceFolderPick({
-                        placeHolder: 'Select which folder to save the default password to'
-                    });
-                    if (!pickedFolder) {
-                        return;
-                    }
-                    scopeUri = pickedFolder.uri;
-                }
-            }
-
-            const targetChoice = await vscode.window.showQuickPick(
-                [
-                    { label: 'User', description: 'Apply to all workspaces', target: vscode.ConfigurationTarget.Global },
-                    { label: 'Workspace', description: 'Apply to this workspace only', target: workspaceTarget }
-                ],
-                { placeHolder: 'Where should the default password be saved?' }
-            );
-
-            if (!targetChoice) {
-                return;
-            }
-
-            // For WorkspaceFolder writes, the configuration must be scoped to a folder URI
-            const updateScope = targetChoice.target === vscode.ConfigurationTarget.WorkspaceFolder ? scopeUri : undefined;
-            await vscode.workspace.getConfiguration('brightscript', updateScope)
-                .update('defaultDevicePassword', password || undefined, targetChoice.target);
-
-            if (password) {
-                await vscode.window.showInformationMessage('Default device password set.');
-            } else {
-                await vscode.window.showInformationMessage('Default device password cleared.');
-            }
+            //this value is only supported at the global level, so just always write it there
+            await vscode.workspace.getConfiguration('brightscript').update('defaultDevicePassword', password, vscode.ConfigurationTarget.Global);
         });
 
         this.registerCommand('setDevicePassword', async (deviceIp: string) => {

--- a/src/DebugConfigurationProvider.spec.ts
+++ b/src/DebugConfigurationProvider.spec.ts
@@ -58,7 +58,8 @@ describe('BrightScriptConfigurationProvider', () => {
             null,
             vscode.window.createOutputChannel('Extension'),
             userInputManager,
-            null // BrightScriptCommands is not used in this test
+            null, // BrightScriptCommands is not used in this test
+            deviceManager
         );
     });
 
@@ -130,7 +131,7 @@ describe('BrightScriptConfigurationProvider', () => {
                 });
                 assert.fail('Should have thrown exception');
             } catch (e) {
-                expect(e.message).to.contain('Cannot find .env');
+                expect((e as Error)?.message).to.contain('Cannot find .env');
             }
         });
 

--- a/src/DebugConfigurationProvider.ts
+++ b/src/DebugConfigurationProvider.ts
@@ -22,6 +22,7 @@ import type { DeviceInfo } from 'roku-deploy';
 import type { UserInputManager } from './managers/UserInputManager';
 import type { BrightScriptCommands } from './BrightScriptCommands';
 import type { RokuProjectManager } from './managers/RokuProject/RokuProjectManager';
+import type { DeviceManager } from './deviceDiscovery/DeviceManager';
 
 
 export class BrightScriptDebugConfigurationProvider implements DebugConfigurationProvider {
@@ -32,6 +33,7 @@ export class BrightScriptDebugConfigurationProvider implements DebugConfiguratio
         private extensionOutputChannel: vscode.OutputChannel,
         private userInputManager: UserInputManager,
         private brightScriptCommands: BrightScriptCommands,
+        private deviceManager: DeviceManager,
         private rokuProjectDiscovery?: RokuProjectManager
     ) {
         this.context = context;
@@ -481,9 +483,14 @@ export class BrightScriptDebugConfigurationProvider implements DebugConfiguratio
      * Validates the password parameter in the config and opens an input ui if set to ${promptForPassword}
      * @param config  current config object
      */
-    private async processPasswordParameter(config: BrightScriptLaunchConfiguration) {
+    private async processPasswordParameter(config: BrightScriptLaunchConfiguration): Promise<BrightScriptLaunchConfiguration> {
+        const defaultPassword = this.deviceManager.getDefaultPassword();
         //prompt for password if not hardcoded
         if (config.password.trim() === '${promptForPassword}') {
+            if (defaultPassword) {
+                config.password = defaultPassword;
+                return config;
+            }
             config.password = await this.openInputBox('The developer account password for your Roku device.');
             if (!config.password) {
                 throw new Error('Debug session terminated: password is required.');
@@ -494,6 +501,10 @@ export class BrightScriptDebugConfigurationProvider implements DebugConfiguratio
             // Get the password for the current active device
             config.password = await this.brightScriptCommands.getActiveHostPassword();
             if (!config.password) {
+                if (defaultPassword) {
+                    config.password = defaultPassword;
+                    return config;
+                }
                 throw new Error('Debug session terminated: no password set for active device.');
             }
         }

--- a/src/deviceDiscovery/DeviceManager.spec.ts
+++ b/src/deviceDiscovery/DeviceManager.spec.ts
@@ -2555,19 +2555,19 @@ describe('DeviceManager', () => {
         it('returns undefined when setting is missing', () => {
             stubConfig(undefined);
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
-            expect(manager.defaultPassword).to.be.undefined;
+            expect(manager.getDefaultPassword()).to.be.undefined;
         });
 
         it('returns undefined when setting is an empty string', () => {
             stubConfig('');
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
-            expect(manager.defaultPassword).to.be.undefined;
+            expect(manager.getDefaultPassword()).to.be.undefined;
         });
 
         it('returns the configured value when setting is a non-empty string', () => {
             stubConfig('hunter2');
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
-            expect(manager.defaultPassword).to.equal('hunter2');
+            expect(manager.getDefaultPassword()).to.equal('hunter2');
         });
 
         describe('getDevice fallback', () => {

--- a/src/deviceDiscovery/DeviceManager.ts
+++ b/src/deviceDiscovery/DeviceManager.ts
@@ -32,7 +32,7 @@ export class DeviceManager {
             let config: any = util.getConfiguration('brightscript') || {};
 
             void vscodeContextManager.set('brightscript.deviceDiscovery.enabled', config.deviceDiscovery?.enabled);
-            void vscodeContextManager.set('brightscript.hasDefaultDevicePassword', !!this.defaultPassword);
+            void vscodeContextManager.set('brightscript.hasDefaultDevicePassword', !!this.getDefaultPassword());
 
             //if the `deviceDiscovery.enabled` setting was changed, start or stop monitoring
             if (event?.affectsConfiguration('brightscript.deviceDiscovery.enabled')) {
@@ -227,7 +227,7 @@ export class DeviceManager {
         const cached = serial ? this.globalStateManager.getCachedDevice(serial) : undefined;
 
         // Fall back to the extension-wide default password when this device has none configured
-        const configuredPassword = device.configuredPassword ?? this.defaultPassword;
+        const configuredPassword = device.configuredPassword ?? this.getDefaultPassword();
 
         return {
             ...device,
@@ -420,7 +420,7 @@ export class DeviceManager {
      * Default password applied to any device that does not have its own configured password.
      * Returns undefined when the setting is empty so callers can fall through to their own logic.
      */
-    public get defaultPassword(): string | undefined {
+    public getDefaultPassword(): string | undefined {
         const value = util.getConfiguration('brightscript')?.defaultDevicePassword;
         return typeof value === 'string' && value.length > 0 ? value : undefined;
     }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -173,7 +173,7 @@ export class Extension {
         );
 
         //register the debug configuration provider
-        let configProvider = new BrightScriptDebugConfigurationProvider(context, this.telemetryManager, this.extensionOutputChannel, userInputManager, this.brightScriptCommands, rokuProjectProvider);
+        let configProvider = new BrightScriptDebugConfigurationProvider(context, this.telemetryManager, this.extensionOutputChannel, userInputManager, this.brightScriptCommands, this.deviceManager, rokuProjectProvider);
         context.subscriptions.push(
             // Initial: resolveDebugConfiguration — handles launch.json configs and F5 with no launch.json
             vscode.debug.registerDebugConfigurationProvider('brightscript', configProvider, vscode.DebugConfigurationProviderTriggerKind.Initial),
@@ -422,8 +422,8 @@ export class Extension {
             await session.customRequest(ClientToServerCustomEventName.customRequestEventResponse, {
                 requestId: event.body.requestId,
                 error: {
-                    message: error?.message,
-                    stack: error?.stack
+                    message: (error as Error)?.message,
+                    stack: (error as Error)?.stack
                 }
             });
         }


### PR DESCRIPTION
It doesn't make sense to allow setting defaultDevicePassword on a per-workspace basis, these are very much user-specific settings. So this PR changes the scope of that setting to be only global (i.e. user) settings. 

Also removes the "where do you want to save it" picker because there's only one location now. 

Fixes a bug where `defaultDevicePassword` wasn't being loaded during launch prior to `${promptForHost}`