### PR TITLE
Auto-update imports when files are renamed

### DIFF
--- a/src/LanguageServerManager.ts
+++ b/src/LanguageServerManager.ts
@@ -221,6 +221,29 @@ export class LanguageServerManager {
             synchronize: {
                 // Notify the server about file changes to every filetype it cares about
                 fileEvents: workspace.createFileSystemWatcher('**/*')
+            },
+            middleware: {
+                workspace: {
+                    //apply willRenameFiles edits silently (matches the TypeScript extension's behavior).
+                    //Default vscode-languageclient routes the edit through VS Code's onWillRenameFiles -> bulkEditService,
+                    //which shows a "wants to make refactoring changes" modal. Apply manually with no metadata to skip it,
+                    //then save the affected documents so they don't end up dirty.
+                    willRenameFiles: async (event, next) => {
+                        const edit = await next(event);
+                        if (!edit || (!edit.entries || edit.entries().length === 0)) {
+                            return undefined;
+                        }
+                        await vscode.workspace.applyEdit(edit);
+                        const affectedUris = edit.entries().map(([uri]) => uri.toString());
+                        await Promise.all(
+                            vscode.workspace.textDocuments
+                                .filter(doc => doc.isDirty && affectedUris.includes(doc.uri.toString()))
+                                .map(doc => doc.save())
+                        );
+                        //return undefined so vscode-languageclient doesn't ask VS Code to apply the edit a second time via the modal
+                        return undefined;
+                    }
+                }
             }
         };
 


### PR DESCRIPTION
## Summary
- Adds `willRenameFiles` middleware to the language client so the import-rewrite edits returned by the brighterscript LSP server apply silently and the rewritten files do not end up dirty.
- Without this middleware, vscode-languageclient routes the `WorkspaceEdit` through VS Code's `bulkEditService`, which prompts "Extension wants to make refactoring changes with this file move" on every rename and leaves the modified files in an unsaved state.
- Mirrors how `typescript-language-features` handles update-imports-on-file-move (it owns the `onWillRenameFiles` event directly and applies edits without metadata, bypassing the refactor-confirmation modal).

## How it works
The middleware:
1. Calls `next(event)` to fetch the `WorkspaceEdit` from the LSP server (unchanged plumbing).
2. Applies it via `vscode.workspace.applyEdit(edit)` with no metadata — VS Code's modal only fires when the edit carries a `WorkspaceEditMetadata` payload.
3. Awaits `doc.save()` for any documents that became dirty so they don't sit unsaved.
4. Returns `undefined` so vscode-languageclient's `event.waitUntil` resolves with no edit, preventing VS Code from applying it a second time via the modal flow.

## Paired brighterscript PR
Companion server-side change that produces the `WorkspaceEdit`: rokucommunity/brighterscript#1688

## Test plan
- [ ] Rename a `.bs` file that is imported elsewhere → no popup, imports updated, files saved
- [ ] Rename a `.brs` file referenced by an XML `<script uri>` tag → no popup, XML updated, file saved
- [ ] Rename a file that nothing imports → no popup, no edits
- [ ] Rename a file across folders (e.g. `source/lib.bs` → `utils/lib.bs`) → relative imports recomputed correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)