### PR TITLE
Suppress device-online notifications for routine Roku heartbeats

### DIFF
--- a/package.json
+++ b/package.json
@@ -2238,6 +2238,12 @@
                         "description": "If set to true, the extension will also include devices that do not have their developer mode enabled that are found on the network.",
                         "scope": "resource"
                     },
+                    "brightscript.deviceDiscovery.heartbeatLogging": {
+                        "type": "boolean",
+                        "default": false,
+                        "description": "Log every ssdp:alive heartbeat to the 'BrightScript Extension' output panel, including the serial number, time since last seen, and whether the device-online notification was suppressed or fired. Useful for verifying heartbeat suppression behavior. Leave disabled in normal use.",
+                        "scope": "resource"
+                    },
                     "brightscript.deviceDiscovery.concealDeviceInfo": {
                         "type": "boolean",
                         "default": false,

--- a/src/GlobalStateManager.ts
+++ b/src/GlobalStateManager.ts
@@ -305,7 +305,8 @@ export class GlobalStateManager {
 
     public setLastAliveTimestamp(key: string, timestamp: number): void {
         const map = this.context.globalState.get<Record<string, number>>(this.keys.lastAliveTimestamp) || {};
-        void this.context.globalState.update(this.keys.lastAliveTimestamp, { ...map, [key]: timestamp });
+        map[key] = timestamp;
+        void this.context.globalState.update(this.keys.lastAliveTimestamp, map);
     }
 
     /**

--- a/src/GlobalStateManager.ts
+++ b/src/GlobalStateManager.ts
@@ -305,8 +305,7 @@ export class GlobalStateManager {
 
     public setLastAliveTimestamp(key: string, timestamp: number): void {
         const map = this.context.globalState.get<Record<string, number>>(this.keys.lastAliveTimestamp) || {};
-        map[key] = timestamp;
-        void this.context.globalState.update(this.keys.lastAliveTimestamp, map);
+        void this.context.globalState.update(this.keys.lastAliveTimestamp, { ...map, [key]: timestamp });
     }
 
     /**

--- a/src/GlobalStateManager.ts
+++ b/src/GlobalStateManager.ts
@@ -17,7 +17,8 @@ export class GlobalStateManager {
         debugProtocolPopupSnoozeValue: 'debugProtocolPopupSnoozeValue',
         lastSeenDevicesByNetwork: 'lastSeenDevicesByNetwork',
         deviceCache: 'deviceCache',
-        serialNumberByIpForNetwork: 'serialNumberByIpForNetwork'
+        serialNumberByIpForNetwork: 'serialNumberByIpForNetwork',
+        lastAliveTimestamp: 'lastAliveTimestamp'
     };
     private remoteTextHistoryLimit: number;
     private remoteTextHistoryEnabled: boolean;
@@ -295,6 +296,17 @@ export class GlobalStateManager {
             }
         }
         return networks;
+    }
+
+    public getLastAliveTimestamp(key: string): number | undefined {
+        const map = this.context.globalState.get<Record<string, number>>(this.keys.lastAliveTimestamp) || {};
+        return map[key];
+    }
+
+    public setLastAliveTimestamp(key: string, timestamp: number): void {
+        const map = this.context.globalState.get<Record<string, number>>(this.keys.lastAliveTimestamp) || {};
+        map[key] = timestamp;
+        void this.context.globalState.update(this.keys.lastAliveTimestamp, map);
     }
 
     /**

--- a/src/deviceDiscovery/DeviceManager.ts
+++ b/src/deviceDiscovery/DeviceManager.ts
@@ -445,7 +445,7 @@ export class DeviceManager {
     private makeFinderLogger(): (msg: string) => void {
         return (msg: string) => {
             if (this.heartbeatLogging) {
-                this.extensionOutputChannel?.appendLine(`[DeviceDiscovery] ${msg}`);
+                this.extensionOutputChannel?.appendLine(`[heartbeat] ${msg}`);
             }
         };
     }
@@ -1150,6 +1150,8 @@ export class DeviceManager {
      */
     private async startRokuFinder() {
         await this.finder.start();
+        const ts = new Date().toLocaleTimeString();
+        this.makeFinderLogger()(`[${ts}] RokuFinder started — passive ssdp:alive monitoring active`);
     }
 
     private stopRokuFinder() {

--- a/src/deviceDiscovery/DeviceManager.ts
+++ b/src/deviceDiscovery/DeviceManager.ts
@@ -140,7 +140,7 @@ export class DeviceManager {
     private emitter = new EventEmitter();
     private systemSleepMonitor: SystemSleepMonitor;
     private networkChangeMonitor: NetworkChangeMonitor;
-    private finder = new RokuFinder();
+    private finder = new RokuFinder(this.globalStateManager);
 
     // Health check tracking and cooldowns
     private lastHealthCheckTime = new Map<string, number>();
@@ -1116,7 +1116,7 @@ export class DeviceManager {
         const oldFinder = this.finder;
 
         // Create new finder instance
-        this.finder = new RokuFinder();
+        this.finder = new RokuFinder(this.globalStateManager);
 
         // Re-attach event listeners
         this.setupFinderListeners();

--- a/src/deviceDiscovery/DeviceManager.ts
+++ b/src/deviceDiscovery/DeviceManager.ts
@@ -16,7 +16,8 @@ export class DeviceManager {
     // #region constructor
     constructor(
         private context: vscode.ExtensionContext,
-        private globalStateManager: GlobalStateManager
+        private globalStateManager: GlobalStateManager,
+        private extensionOutputChannel?: vscode.OutputChannel
     ) {
         this.networkId = getNetworkHash();
 
@@ -140,7 +141,7 @@ export class DeviceManager {
     private emitter = new EventEmitter();
     private systemSleepMonitor: SystemSleepMonitor;
     private networkChangeMonitor: NetworkChangeMonitor;
-    private finder = new RokuFinder(this.globalStateManager);
+    private finder = new RokuFinder(this.globalStateManager, this.makeFinderLogger());
 
     // Health check tracking and cooldowns
     private lastHealthCheckTime = new Map<string, number>();
@@ -435,6 +436,18 @@ export class DeviceManager {
      */
     private get showInfoMessages() {
         return util.getConfiguration('brightscript')?.deviceDiscovery?.showInfoMessages ?? true;
+    }
+
+    private get heartbeatLogging() {
+        return util.getConfiguration('brightscript')?.deviceDiscovery?.heartbeatLogging ?? false;
+    }
+
+    private makeFinderLogger(): (msg: string) => void {
+        return (msg: string) => {
+            if (this.heartbeatLogging) {
+                this.extensionOutputChannel?.appendLine(`[DeviceDiscovery] ${msg}`);
+            }
+        };
     }
 
     /**
@@ -1116,7 +1129,7 @@ export class DeviceManager {
         const oldFinder = this.finder;
 
         // Create new finder instance
-        this.finder = new RokuFinder(this.globalStateManager);
+        this.finder = new RokuFinder(this.globalStateManager, this.makeFinderLogger());
 
         // Re-attach event listeners
         this.setupFinderListeners();

--- a/src/deviceDiscovery/RokuFinder.spec.ts
+++ b/src/deviceDiscovery/RokuFinder.spec.ts
@@ -460,7 +460,7 @@ describe('RokuFinder', () => {
                 expect(deviceOnlineSpy.calledOnce).to.be.true;
 
                 // 3 days plus 10 minutes — off schedule, device rebooted
-                clock.tick(3 * 24 * 60 * 60 * 1_000 + 10 * 60 * 1_000);
+                clock.tick((3 * 24 * 60 * 60 * 1_000) + (10 * 60 * 1_000));
                 (finder['server'] as any).emit('advertise-alive', aliveMessage);
                 expect(deviceOnlineSpy.calledTwice).to.be.true;
             } finally {

--- a/src/deviceDiscovery/RokuFinder.spec.ts
+++ b/src/deviceDiscovery/RokuFinder.spec.ts
@@ -1,9 +1,19 @@
 import { expect } from 'chai';
 import * as sinon from 'sinon';
 import { RokuFinder } from './RokuFinder';
+import type { GlobalStateManager } from '../GlobalStateManager';
 
 describe('RokuFinder', () => {
     let finder: RokuFinder;
+    let mockGlobalStateManager: GlobalStateManager;
+
+    beforeEach(() => {
+        const timestampStore = new Map<string, number>();
+        mockGlobalStateManager = {
+            getLastAliveTimestamp: (key: string) => timestampStore.get(key),
+            setLastAliveTimestamp: (key: string, ts: number) => timestampStore.set(key, ts)
+        } as any;
+    });
 
     afterEach(() => {
         finder?.stop();
@@ -14,34 +24,34 @@ describe('RokuFinder', () => {
     describe('constructor', () => {
         it('creates without error', () => {
             expect(() => {
-                finder = new RokuFinder();
+                finder = new RokuFinder(mockGlobalStateManager);
             }).to.not.throw();
         });
     });
 
     describe('start/stop', () => {
         it('start sets running to true', async () => {
-            finder = new RokuFinder();
+            finder = new RokuFinder(mockGlobalStateManager);
             await finder.start();
             expect(finder['running']).to.be.true;
         });
 
         it('stop sets running to false', async () => {
-            finder = new RokuFinder();
+            finder = new RokuFinder(mockGlobalStateManager);
             await finder.start();
             finder.stop();
             expect(finder['running']).to.be.false;
         });
 
         it('start is idempotent', async () => {
-            finder = new RokuFinder();
+            finder = new RokuFinder(mockGlobalStateManager);
             await finder.start();
             await finder.start();
             expect(finder['running']).to.be.true;
         });
 
         it('stop is idempotent', async () => {
-            finder = new RokuFinder();
+            finder = new RokuFinder(mockGlobalStateManager);
             await finder.start();
             finder.stop();
             expect(() => finder.stop()).to.not.throw();
@@ -52,7 +62,7 @@ describe('RokuFinder', () => {
         it('sends multiple search requests', () => {
             const clock = sinon.useFakeTimers();
             try {
-                finder = new RokuFinder();
+                finder = new RokuFinder(mockGlobalStateManager);
                 const searchStub = sinon.stub(finder['client'], 'search');
 
                 finder.scan();
@@ -76,7 +86,7 @@ describe('RokuFinder', () => {
 
     describe('SSDP response handling', () => {
         it('emits "found" with IP string for Roku devices', () => {
-            finder = new RokuFinder();
+            finder = new RokuFinder(mockGlobalStateManager);
 
             const foundSpy = sinon.spy();
             finder.on('found', foundSpy);
@@ -96,7 +106,7 @@ describe('RokuFinder', () => {
         });
 
         it('extracts serial number from USN header', () => {
-            finder = new RokuFinder();
+            finder = new RokuFinder(mockGlobalStateManager);
 
             const foundSpy = sinon.spy();
             finder.on('found', foundSpy);
@@ -111,7 +121,7 @@ describe('RokuFinder', () => {
         });
 
         it('handles missing USN gracefully', () => {
-            finder = new RokuFinder();
+            finder = new RokuFinder(mockGlobalStateManager);
 
             const foundSpy = sinon.spy();
             finder.on('found', foundSpy);
@@ -127,7 +137,7 @@ describe('RokuFinder', () => {
         });
 
         it('ignores non-Roku devices', () => {
-            finder = new RokuFinder();
+            finder = new RokuFinder(mockGlobalStateManager);
 
             const foundSpy = sinon.spy();
             finder.on('found', foundSpy);
@@ -142,7 +152,7 @@ describe('RokuFinder', () => {
         });
 
         it('processes scan responses even when passive listener not started', () => {
-            finder = new RokuFinder();
+            finder = new RokuFinder(mockGlobalStateManager);
             // Don't call start() - passive listener is off, but scans should still work
 
             const foundSpy = sinon.spy();
@@ -161,7 +171,7 @@ describe('RokuFinder', () => {
 
     describe('SSDP notify handling', () => {
         it('emits "found" with IP string and serial number on ssdp:alive', async () => {
-            finder = new RokuFinder();
+            finder = new RokuFinder(mockGlobalStateManager);
             await finder.start();
 
             const foundSpy = sinon.spy();
@@ -182,7 +192,7 @@ describe('RokuFinder', () => {
         });
 
         it('emits "device-online" with IP and serial number the first time a device is seen', async () => {
-            finder = new RokuFinder();
+            finder = new RokuFinder(mockGlobalStateManager);
             await finder.start();
 
             const deviceOnlineSpy = sinon.spy();
@@ -203,7 +213,7 @@ describe('RokuFinder', () => {
         it('suppresses "device-online" for a routine ~20-minute heartbeat', () => {
             const clock = sinon.useFakeTimers();
             try {
-                finder = new RokuFinder();
+                finder = new RokuFinder(mockGlobalStateManager);
                 finder['running'] = true;
 
                 const deviceOnlineSpy = sinon.spy();
@@ -232,7 +242,7 @@ describe('RokuFinder', () => {
         it('suppresses "device-online" when alive arrives within ±5s of 20-minute schedule', () => {
             const clock = sinon.useFakeTimers();
             try {
-                finder = new RokuFinder();
+                finder = new RokuFinder(mockGlobalStateManager);
                 finder['running'] = true;
 
                 const deviceOnlineSpy = sinon.spy();
@@ -266,7 +276,7 @@ describe('RokuFinder', () => {
         it('emits "device-online" again when alive arrives off the 20-minute schedule (e.g. reboot)', () => {
             const clock = sinon.useFakeTimers();
             try {
-                finder = new RokuFinder();
+                finder = new RokuFinder(mockGlobalStateManager);
                 finder['running'] = true;
 
                 const deviceOnlineSpy = sinon.spy();
@@ -295,7 +305,7 @@ describe('RokuFinder', () => {
         it('resets the heartbeat clock on wake so the next 20-minute heartbeat is suppressed', () => {
             const clock = sinon.useFakeTimers();
             try {
-                finder = new RokuFinder();
+                finder = new RokuFinder(mockGlobalStateManager);
                 finder['running'] = true;
 
                 const deviceOnlineSpy = sinon.spy();
@@ -329,7 +339,7 @@ describe('RokuFinder', () => {
         it('emits "device-online" again after a missed heartbeat (host was asleep)', () => {
             const clock = sinon.useFakeTimers();
             try {
-                finder = new RokuFinder();
+                finder = new RokuFinder(mockGlobalStateManager);
                 finder['running'] = true;
 
                 const deviceOnlineSpy = sinon.spy();
@@ -363,7 +373,7 @@ describe('RokuFinder', () => {
         it('uses serial number (not IP) as the heartbeat key so IP changes do not reset the clock', () => {
             const clock = sinon.useFakeTimers();
             try {
-                finder = new RokuFinder();
+                finder = new RokuFinder(mockGlobalStateManager);
                 finder['running'] = true;
 
                 const deviceOnlineSpy = sinon.spy();
@@ -398,7 +408,7 @@ describe('RokuFinder', () => {
         it('tracks heartbeat independently per device', () => {
             const clock = sinon.useFakeTimers();
             try {
-                finder = new RokuFinder();
+                finder = new RokuFinder(mockGlobalStateManager);
                 finder['running'] = true;
 
                 const deviceOnlineSpy = sinon.spy();
@@ -433,7 +443,7 @@ describe('RokuFinder', () => {
         });
 
         it('emits "lost" on ssdp:byebye', async () => {
-            finder = new RokuFinder();
+            finder = new RokuFinder(mockGlobalStateManager);
             await finder.start();
 
             const lostSpy = sinon.spy();
@@ -451,7 +461,7 @@ describe('RokuFinder', () => {
         });
 
         it('ignores non-Roku notifications', async () => {
-            finder = new RokuFinder();
+            finder = new RokuFinder(mockGlobalStateManager);
             await finder.start();
 
             const foundSpy = sinon.spy();
@@ -471,7 +481,7 @@ describe('RokuFinder', () => {
         });
 
         it('debounces rapid ssdp:alive messages from same IP', async () => {
-            finder = new RokuFinder();
+            finder = new RokuFinder(mockGlobalStateManager);
             await finder.start();
 
             const foundSpy = sinon.spy();
@@ -496,7 +506,7 @@ describe('RokuFinder', () => {
         it('allows ssdp:alive after debounce period expires', async () => {
             const clock = sinon.useFakeTimers();
             try {
-                finder = new RokuFinder();
+                finder = new RokuFinder(mockGlobalStateManager);
                 await finder.start();
 
                 const foundSpy = sinon.spy();
@@ -525,7 +535,7 @@ describe('RokuFinder', () => {
         });
 
         it('debounces independently per IP address', async () => {
-            finder = new RokuFinder();
+            finder = new RokuFinder(mockGlobalStateManager);
             await finder.start();
 
             const foundSpy = sinon.spy();
@@ -560,7 +570,7 @@ describe('RokuFinder', () => {
         it('cleans up stale debounce entries after 5 minutes', async () => {
             const clock = sinon.useFakeTimers();
             try {
-                finder = new RokuFinder();
+                finder = new RokuFinder(mockGlobalStateManager);
                 await finder.start();
 
                 const aliveMessage = {
@@ -592,7 +602,7 @@ describe('RokuFinder', () => {
 
     describe('scan orchestration', () => {
         it('emits scan-started when scan begins', () => {
-            finder = new RokuFinder();
+            finder = new RokuFinder(mockGlobalStateManager);
 
             const scanStartedSpy = sinon.spy();
             finder.on('scan-started', scanStartedSpy);
@@ -605,7 +615,7 @@ describe('RokuFinder', () => {
         it('emits scan-ended after min duration and settle time', () => {
             const clock = sinon.useFakeTimers();
             try {
-                finder = new RokuFinder();
+                finder = new RokuFinder(mockGlobalStateManager);
 
                 const scanEndedSpy = sinon.spy();
                 finder.on('scan-ended', scanEndedSpy);
@@ -627,7 +637,7 @@ describe('RokuFinder', () => {
         it('waits for settle timer even after min duration', () => {
             const clock = sinon.useFakeTimers();
             try {
-                finder = new RokuFinder();
+                finder = new RokuFinder(mockGlobalStateManager);
 
                 const scanEndedSpy = sinon.spy();
                 finder.on('scan-ended', scanEndedSpy);
@@ -657,7 +667,7 @@ describe('RokuFinder', () => {
         it('does not start new scan if already scanning', () => {
             const clock = sinon.useFakeTimers();
             try {
-                finder = new RokuFinder();
+                finder = new RokuFinder(mockGlobalStateManager);
 
                 const scanStartedSpy = sinon.spy();
                 finder.on('scan-started', scanStartedSpy);
@@ -683,7 +693,7 @@ describe('RokuFinder', () => {
         it('resets settle timer when device found via ssdp:alive', () => {
             const clock = sinon.useFakeTimers();
             try {
-                finder = new RokuFinder();
+                finder = new RokuFinder(mockGlobalStateManager);
                 finder['running'] = true; // Simulate started
 
                 const scanEndedSpy = sinon.spy();

--- a/src/deviceDiscovery/RokuFinder.spec.ts
+++ b/src/deviceDiscovery/RokuFinder.spec.ts
@@ -170,6 +170,13 @@ describe('RokuFinder', () => {
     });
 
     describe('SSDP notify handling', () => {
+        let HEARTBEAT_INTERVAL_MS: number;
+        before(() => {
+            const tmp = new RokuFinder({ getLastAliveTimestamp: () => undefined, setLastAliveTimestamp: () => {} } as any);
+            HEARTBEAT_INTERVAL_MS = tmp['HEARTBEAT_INTERVAL_MS'];
+            tmp.dispose();
+        });
+
         it('emits "found" with IP string and serial number on ssdp:alive', async () => {
             finder = new RokuFinder(mockGlobalStateManager);
             await finder.start();
@@ -231,7 +238,7 @@ describe('RokuFinder', () => {
                 expect(deviceOnlineSpy.calledOnce).to.be.true;
 
                 // Exactly 20 minutes later — routine heartbeat, suppressed
-                clock.tick(20 * 60 * 1_000);
+                clock.tick(HEARTBEAT_INTERVAL_MS);
                 (finder['server'] as any).emit('advertise-alive', aliveMessage);
                 expect(deviceOnlineSpy.calledOnce).to.be.true;
             } finally {
@@ -239,7 +246,7 @@ describe('RokuFinder', () => {
             }
         });
 
-        it('suppresses "device-online" when alive arrives within ±5s of 20-minute schedule', () => {
+        it('suppresses "device-online" when alive arrives within ±10s of 20-minute schedule', () => {
             const clock = sinon.useFakeTimers();
             try {
                 finder = new RokuFinder(mockGlobalStateManager);
@@ -259,19 +266,122 @@ describe('RokuFinder', () => {
                 (finder['server'] as any).emit('advertise-alive', aliveMessage);
                 expect(deviceOnlineSpy.calledOnce).to.be.true;
 
-                // 4 seconds early (within ±5s tolerance) — suppressed
-                clock.tick((20 * 60 * 1_000) - 4_000);
+                // 9 seconds early (within ±10s tolerance) — suppressed
+                clock.tick((HEARTBEAT_INTERVAL_MS) - 9_000);
                 (finder['server'] as any).emit('advertise-alive', aliveMessage);
                 expect(deviceOnlineSpy.calledOnce).to.be.true;
 
-                // 4 seconds late from that timestamp (within ±5s tolerance) — suppressed
-                clock.tick((20 * 60 * 1_000) + 4_000);
+                // 9 seconds late from that timestamp (within ±10s tolerance) — suppressed
+                clock.tick((HEARTBEAT_INTERVAL_MS) + 9_000);
                 (finder['server'] as any).emit('advertise-alive', aliveMessage);
                 expect(deviceOnlineSpy.calledOnce).to.be.true;
             } finally {
                 clock.restore();
             }
         });
+
+        it('suppresses "device-online" when alive arrives at an exact multiple of 20 minutes (e.g. skipped heartbeat)', () => {
+            const clock = sinon.useFakeTimers();
+            try {
+                finder = new RokuFinder(mockGlobalStateManager);
+                finder['running'] = true;
+
+                const deviceOnlineSpy = sinon.spy();
+                finder.on('device-online', deviceOnlineSpy);
+
+                const aliveMessage = {
+                    NT: 'roku:ecp',
+                    NTS: 'ssdp:alive',
+                    LOCATION: 'http://192.168.1.100:8060',
+                    USN: 'uuid:roku:ecp:ABC123'
+                };
+
+                // First alive
+                (finder['server'] as any).emit('advertise-alive', aliveMessage);
+                expect(deviceOnlineSpy.calledOnce).to.be.true;
+
+                // 2× interval later — host missed one heartbeat, but this is still on-schedule
+                clock.tick(2 * HEARTBEAT_INTERVAL_MS);
+                (finder['server'] as any).emit('advertise-alive', aliveMessage);
+                expect(deviceOnlineSpy.calledOnce).to.be.true; // suppressed
+
+                // 3× interval from that timestamp — still on-schedule
+                clock.tick(3 * HEARTBEAT_INTERVAL_MS);
+                (finder['server'] as any).emit('advertise-alive', aliveMessage);
+                expect(deviceOnlineSpy.calledOnce).to.be.true; // suppressed
+            } finally {
+                clock.restore();
+            }
+        });
+
+        it('suppresses after waking from 12-hour sleep (36 missed heartbeats)', () => {
+            const clock = sinon.useFakeTimers();
+            try {
+                finder = new RokuFinder(mockGlobalStateManager);
+                finder['running'] = true;
+
+                const deviceOnlineSpy = sinon.spy();
+                finder.on('device-online', deviceOnlineSpy);
+
+                const aliveMessage = {
+                    NT: 'roku:ecp',
+                    NTS: 'ssdp:alive',
+                    LOCATION: 'http://192.168.1.100:8060',
+                    USN: 'uuid:roku:ecp:ABC123'
+                };
+
+                (finder['server'] as any).emit('advertise-alive', aliveMessage);
+                expect(deviceOnlineSpy.calledOnce).to.be.true;
+
+                // 12 hours later — 36 missed heartbeats, device fires on schedule
+                clock.tick(36 * HEARTBEAT_INTERVAL_MS);
+                (finder['server'] as any).emit('advertise-alive', aliveMessage);
+                expect(deviceOnlineSpy.calledOnce).to.be.true; // suppressed
+            } finally {
+                clock.restore();
+            }
+        });
+
+        // Real-world data points from observed logs (elapsed values that must be suppressed)
+        const realWorldElapsedMs = [
+            1198.8,   // 1× — standard heartbeat
+            2397.7,   // 2× — one missed
+            3596.5,   // 3× — two missed
+            4795.6,   // 4× — three missed
+            5994.5,   // 5× — four missed
+            7193.4,   // 6× — five missed
+            8392.1,   // 7× — six missed
+            9591.1,   // 8× — seven missed (max within ±10s at 1198.86 cadence)
+        ].map(s => s * 1_000);
+
+        for (const elapsedMs of realWorldElapsedMs) {
+            it(`suppresses at real-world elapsed ${(elapsedMs / 1000).toFixed(1)}s (${(elapsedMs / (1198.86 * 1000)).toFixed(0)}× interval)`, () => {
+                const clock = sinon.useFakeTimers();
+                try {
+                    finder = new RokuFinder(mockGlobalStateManager);
+                    finder['running'] = true;
+
+                    const deviceOnlineSpy = sinon.spy();
+                    finder.on('device-online', deviceOnlineSpy);
+
+                    const aliveMessage = {
+                        NT: 'roku:ecp',
+                        NTS: 'ssdp:alive',
+                        LOCATION: 'http://192.168.1.100:8060',
+                        USN: 'uuid:roku:ecp:ABC123'
+                    };
+
+                    (finder['server'] as any).emit('advertise-alive', aliveMessage);
+                    expect(deviceOnlineSpy.calledOnce).to.be.true;
+
+                    clock.tick(elapsedMs);
+                    (finder['server'] as any).emit('advertise-alive', aliveMessage);
+                    expect(deviceOnlineSpy.calledOnce).to.be.true; // suppressed
+                } finally {
+                    clock.restore();
+                }
+            });
+        }
 
         it('emits "device-online" again when alive arrives off the 20-minute schedule (e.g. reboot)', () => {
             const clock = sinon.useFakeTimers();
@@ -328,7 +438,7 @@ describe('RokuFinder', () => {
                 expect(deviceOnlineSpy.calledTwice).to.be.true;
 
                 // 20 minutes after the reboot — routine heartbeat, clock was reset from wake time
-                clock.tick(20 * 60 * 1_000);
+                clock.tick(HEARTBEAT_INTERVAL_MS);
                 (finder['server'] as any).emit('advertise-alive', aliveMessage);
                 expect(deviceOnlineSpy.calledTwice).to.be.true; // suppressed
             } finally {
@@ -336,7 +446,7 @@ describe('RokuFinder', () => {
             }
         });
 
-        it('emits "device-online" again after a missed heartbeat (host was asleep)', () => {
+        it('emits "device-online" again when alive arrives at an off-schedule time (e.g. reboot mid-cycle)', () => {
             const clock = sinon.useFakeTimers();
             try {
                 finder = new RokuFinder(mockGlobalStateManager);
@@ -357,12 +467,12 @@ describe('RokuFinder', () => {
                 expect(deviceOnlineSpy.calledOnce).to.be.true;
 
                 // Routine 20-minute heartbeat — suppressed
-                clock.tick(20 * 60 * 1_000);
+                clock.tick(HEARTBEAT_INTERVAL_MS);
                 (finder['server'] as any).emit('advertise-alive', aliveMessage);
                 expect(deviceOnlineSpy.calledOnce).to.be.true;
 
-                // Host was asleep for 3 days — next alive is way off schedule, fires again
-                clock.tick(3 * 24 * 60 * 60 * 1_000);
+                // 7 minutes later (not on 20-min schedule) — fires again (device rebooted)
+                clock.tick(7 * 60 * 1_000);
                 (finder['server'] as any).emit('advertise-alive', aliveMessage);
                 expect(deviceOnlineSpy.calledTwice).to.be.true;
             } finally {
@@ -397,7 +507,7 @@ describe('RokuFinder', () => {
                 expect(deviceOnlineSpy.calledOnce).to.be.true;
 
                 // Routine heartbeat on new IP — same serial, should still be suppressed
-                clock.tick(20 * 60 * 1_000);
+                clock.tick(HEARTBEAT_INTERVAL_MS);
                 (finder['server'] as any).emit('advertise-alive', aliveNewIp);
                 expect(deviceOnlineSpy.calledOnce).to.be.true;
             } finally {
@@ -433,7 +543,7 @@ describe('RokuFinder', () => {
                 expect(deviceOnlineSpy.calledTwice).to.be.true;
 
                 // Both send routine 20-min heartbeat — both suppressed
-                clock.tick(20 * 60 * 1_000);
+                clock.tick(HEARTBEAT_INTERVAL_MS);
                 (finder['server'] as any).emit('advertise-alive', alive1);
                 (finder['server'] as any).emit('advertise-alive', alive2);
                 expect(deviceOnlineSpy.calledTwice).to.be.true;

--- a/src/deviceDiscovery/RokuFinder.spec.ts
+++ b/src/deviceDiscovery/RokuFinder.spec.ts
@@ -181,7 +181,7 @@ describe('RokuFinder', () => {
             expect(options.serialNumber).to.equal('ABC123');
         });
 
-        it('emits "device-online" with IP and serial number on ssdp:alive', async () => {
+        it('emits "device-online" with IP and serial number the first time a device is seen', async () => {
             finder = new RokuFinder();
             await finder.start();
 
@@ -198,6 +198,238 @@ describe('RokuFinder', () => {
             expect(deviceOnlineSpy.calledOnce).to.be.true;
             expect(deviceOnlineSpy.firstCall.args[0]).to.equal('192.168.1.100');
             expect(deviceOnlineSpy.firstCall.args[1]).to.equal('ABC123');
+        });
+
+        it('suppresses "device-online" for a routine ~20-minute heartbeat', () => {
+            const clock = sinon.useFakeTimers();
+            try {
+                finder = new RokuFinder();
+                finder['running'] = true;
+
+                const deviceOnlineSpy = sinon.spy();
+                finder.on('device-online', deviceOnlineSpy);
+
+                const aliveMessage = {
+                    NT: 'roku:ecp',
+                    NTS: 'ssdp:alive',
+                    LOCATION: 'http://192.168.1.100:8060',
+                    USN: 'uuid:roku:ecp:ABC123'
+                };
+
+                // First alive — fires (first time seen)
+                (finder['server'] as any).emit('advertise-alive', aliveMessage);
+                expect(deviceOnlineSpy.calledOnce).to.be.true;
+
+                // Exactly 20 minutes later — routine heartbeat, suppressed
+                clock.tick(20 * 60 * 1_000);
+                (finder['server'] as any).emit('advertise-alive', aliveMessage);
+                expect(deviceOnlineSpy.calledOnce).to.be.true;
+            } finally {
+                clock.restore();
+            }
+        });
+
+        it('suppresses "device-online" when alive arrives within ±5s of 20-minute schedule', () => {
+            const clock = sinon.useFakeTimers();
+            try {
+                finder = new RokuFinder();
+                finder['running'] = true;
+
+                const deviceOnlineSpy = sinon.spy();
+                finder.on('device-online', deviceOnlineSpy);
+
+                const aliveMessage = {
+                    NT: 'roku:ecp',
+                    NTS: 'ssdp:alive',
+                    LOCATION: 'http://192.168.1.100:8060',
+                    USN: 'uuid:roku:ecp:ABC123'
+                };
+
+                // First alive
+                (finder['server'] as any).emit('advertise-alive', aliveMessage);
+                expect(deviceOnlineSpy.calledOnce).to.be.true;
+
+                // 4 seconds early (within ±5s tolerance) — suppressed
+                clock.tick(20 * 60 * 1_000 - 4_000);
+                (finder['server'] as any).emit('advertise-alive', aliveMessage);
+                expect(deviceOnlineSpy.calledOnce).to.be.true;
+
+                // 4 seconds late from that timestamp (within ±5s tolerance) — suppressed
+                clock.tick(20 * 60 * 1_000 + 4_000);
+                (finder['server'] as any).emit('advertise-alive', aliveMessage);
+                expect(deviceOnlineSpy.calledOnce).to.be.true;
+            } finally {
+                clock.restore();
+            }
+        });
+
+        it('emits "device-online" again when alive arrives off the 20-minute schedule (e.g. reboot)', () => {
+            const clock = sinon.useFakeTimers();
+            try {
+                finder = new RokuFinder();
+                finder['running'] = true;
+
+                const deviceOnlineSpy = sinon.spy();
+                finder.on('device-online', deviceOnlineSpy);
+
+                const aliveMessage = {
+                    NT: 'roku:ecp',
+                    NTS: 'ssdp:alive',
+                    LOCATION: 'http://192.168.1.100:8060',
+                    USN: 'uuid:roku:ecp:ABC123'
+                };
+
+                // First alive — fires
+                (finder['server'] as any).emit('advertise-alive', aliveMessage);
+                expect(deviceOnlineSpy.calledOnce).to.be.true;
+
+                // 10 seconds later — not on 20-min schedule, fires again (reboot scenario)
+                clock.tick(10_000);
+                (finder['server'] as any).emit('advertise-alive', aliveMessage);
+                expect(deviceOnlineSpy.calledTwice).to.be.true;
+            } finally {
+                clock.restore();
+            }
+        });
+
+        it('resets the heartbeat clock on wake so the next 20-minute heartbeat is suppressed', () => {
+            const clock = sinon.useFakeTimers();
+            try {
+                finder = new RokuFinder();
+                finder['running'] = true;
+
+                const deviceOnlineSpy = sinon.spy();
+                finder.on('device-online', deviceOnlineSpy);
+
+                const aliveMessage = {
+                    NT: 'roku:ecp',
+                    NTS: 'ssdp:alive',
+                    LOCATION: 'http://192.168.1.100:8060',
+                    USN: 'uuid:roku:ecp:ABC123'
+                };
+
+                // First heartbeat
+                (finder['server'] as any).emit('advertise-alive', aliveMessage);
+                expect(deviceOnlineSpy.calledOnce).to.be.true;
+
+                // Device reboots 10 minutes into the cycle — fires device-online
+                clock.tick(10 * 60 * 1_000);
+                (finder['server'] as any).emit('advertise-alive', aliveMessage);
+                expect(deviceOnlineSpy.calledTwice).to.be.true;
+
+                // 20 minutes after the reboot — routine heartbeat, clock was reset from wake time
+                clock.tick(20 * 60 * 1_000);
+                (finder['server'] as any).emit('advertise-alive', aliveMessage);
+                expect(deviceOnlineSpy.calledTwice).to.be.true; // suppressed
+            } finally {
+                clock.restore();
+            }
+        });
+
+        it('emits "device-online" again after a missed heartbeat (host was asleep)', () => {
+            const clock = sinon.useFakeTimers();
+            try {
+                finder = new RokuFinder();
+                finder['running'] = true;
+
+                const deviceOnlineSpy = sinon.spy();
+                finder.on('device-online', deviceOnlineSpy);
+
+                const aliveMessage = {
+                    NT: 'roku:ecp',
+                    NTS: 'ssdp:alive',
+                    LOCATION: 'http://192.168.1.100:8060',
+                    USN: 'uuid:roku:ecp:ABC123'
+                };
+
+                // First alive
+                (finder['server'] as any).emit('advertise-alive', aliveMessage);
+                expect(deviceOnlineSpy.calledOnce).to.be.true;
+
+                // Routine 20-minute heartbeat — suppressed
+                clock.tick(20 * 60 * 1_000);
+                (finder['server'] as any).emit('advertise-alive', aliveMessage);
+                expect(deviceOnlineSpy.calledOnce).to.be.true;
+
+                // Host was asleep for 3 days — next alive is way off schedule, fires again
+                clock.tick(3 * 24 * 60 * 60 * 1_000);
+                (finder['server'] as any).emit('advertise-alive', aliveMessage);
+                expect(deviceOnlineSpy.calledTwice).to.be.true;
+            } finally {
+                clock.restore();
+            }
+        });
+
+        it('uses serial number (not IP) as the heartbeat key so IP changes do not reset the clock', () => {
+            const clock = sinon.useFakeTimers();
+            try {
+                finder = new RokuFinder();
+                finder['running'] = true;
+
+                const deviceOnlineSpy = sinon.spy();
+                finder.on('device-online', deviceOnlineSpy);
+
+                const aliveOldIp = {
+                    NT: 'roku:ecp',
+                    NTS: 'ssdp:alive',
+                    LOCATION: 'http://192.168.1.100:8060',
+                    USN: 'uuid:roku:ecp:ABC123'
+                };
+                const aliveNewIp = {
+                    NT: 'roku:ecp',
+                    NTS: 'ssdp:alive',
+                    LOCATION: 'http://192.168.1.200:8060',
+                    USN: 'uuid:roku:ecp:ABC123'
+                };
+
+                // First alive on old IP
+                (finder['server'] as any).emit('advertise-alive', aliveOldIp);
+                expect(deviceOnlineSpy.calledOnce).to.be.true;
+
+                // Routine heartbeat on new IP — same serial, should still be suppressed
+                clock.tick(20 * 60 * 1_000);
+                (finder['server'] as any).emit('advertise-alive', aliveNewIp);
+                expect(deviceOnlineSpy.calledOnce).to.be.true;
+            } finally {
+                clock.restore();
+            }
+        });
+
+        it('tracks heartbeat independently per device', () => {
+            const clock = sinon.useFakeTimers();
+            try {
+                finder = new RokuFinder();
+                finder['running'] = true;
+
+                const deviceOnlineSpy = sinon.spy();
+                finder.on('device-online', deviceOnlineSpy);
+
+                const alive1 = {
+                    NT: 'roku:ecp',
+                    NTS: 'ssdp:alive',
+                    LOCATION: 'http://192.168.1.100:8060',
+                    USN: 'uuid:roku:ecp:ABC123'
+                };
+                const alive2 = {
+                    NT: 'roku:ecp',
+                    NTS: 'ssdp:alive',
+                    LOCATION: 'http://192.168.1.101:8060',
+                    USN: 'uuid:roku:ecp:DEF456'
+                };
+
+                // Both devices seen for the first time
+                (finder['server'] as any).emit('advertise-alive', alive1);
+                (finder['server'] as any).emit('advertise-alive', alive2);
+                expect(deviceOnlineSpy.calledTwice).to.be.true;
+
+                // Both send routine 20-min heartbeat — both suppressed
+                clock.tick(20 * 60 * 1_000);
+                (finder['server'] as any).emit('advertise-alive', alive1);
+                (finder['server'] as any).emit('advertise-alive', alive2);
+                expect(deviceOnlineSpy.calledTwice).to.be.true;
+            } finally {
+                clock.restore();
+            }
         });
 
         it('emits "lost" on ssdp:byebye', async () => {

--- a/src/deviceDiscovery/RokuFinder.spec.ts
+++ b/src/deviceDiscovery/RokuFinder.spec.ts
@@ -344,25 +344,25 @@ describe('RokuFinder', () => {
 
         // Real-world data points from observed logs (elapsed values that must be suppressed)
         const realWorldElapsedMs = [
-            1198.8,   // 1× — standard heartbeat
-            2397.7,   // 2× — one missed
-            3596.5,   // 3× — two missed
-            4795.6,   // 4× — three missed
-            5994.5,   // 5× — four missed
-            7193.4,   // 6× — five missed
-            8392.1,   // 7× — six missed
-            9591.1,   // 8× — seven missed (max within ±10s at 1198.86 cadence)
+            1198.8, // 1× — standard heartbeat
+            2397.7, // 2× — one missed
+            3596.5, // 3× — two missed
+            4795.6, // 4× — three missed
+            5994.5, // 5× — four missed
+            7193.4, // 6× — five missed
+            8392.1, // 7× — six missed
+            9591.1 // 8× — seven missed (max within ±10s at 1198.86 cadence)
         ].map(s => s * 1_000);
 
-        for (const elapsedMs of realWorldElapsedMs) {
+        realWorldElapsedMs.forEach((elapsedMs) => {
             it(`suppresses at real-world elapsed ${(elapsedMs / 1000).toFixed(1)}s (${(elapsedMs / (1198.86 * 1000)).toFixed(0)}× interval)`, () => {
+                const localFinder = new RokuFinder(mockGlobalStateManager);
                 const clock = sinon.useFakeTimers();
                 try {
-                    finder = new RokuFinder(mockGlobalStateManager);
-                    finder['running'] = true;
+                    localFinder['running'] = true;
 
                     const deviceOnlineSpy = sinon.spy();
-                    finder.on('device-online', deviceOnlineSpy);
+                    localFinder.on('device-online', deviceOnlineSpy);
 
                     const aliveMessage = {
                         NT: 'roku:ecp',
@@ -371,17 +371,17 @@ describe('RokuFinder', () => {
                         USN: 'uuid:roku:ecp:ABC123'
                     };
 
-                    (finder['server'] as any).emit('advertise-alive', aliveMessage);
+                    (localFinder['server'] as any).emit('advertise-alive', aliveMessage);
                     expect(deviceOnlineSpy.calledOnce).to.be.true;
 
                     clock.tick(elapsedMs);
-                    (finder['server'] as any).emit('advertise-alive', aliveMessage);
+                    (localFinder['server'] as any).emit('advertise-alive', aliveMessage);
                     expect(deviceOnlineSpy.calledOnce).to.be.true; // suppressed
                 } finally {
                     clock.restore();
                 }
             });
-        }
+        });
 
         it('emits "device-online" again when alive arrives off the 20-minute schedule (e.g. reboot)', () => {
             const clock = sinon.useFakeTimers();
@@ -412,7 +412,63 @@ describe('RokuFinder', () => {
             }
         });
 
-        it('resets the heartbeat clock on wake so the next 20-minute heartbeat is suppressed', () => {
+        it('suppresses after a 3-day gap if the Roku fires on its regular schedule (host slept, Roku did not reboot)', () => {
+            const clock = sinon.useFakeTimers();
+            try {
+                finder = new RokuFinder(mockGlobalStateManager);
+                finder['running'] = true;
+
+                const deviceOnlineSpy = sinon.spy();
+                finder.on('device-online', deviceOnlineSpy);
+
+                const aliveMessage = {
+                    NT: 'roku:ecp',
+                    NTS: 'ssdp:alive',
+                    LOCATION: 'http://192.168.1.100:8060',
+                    USN: 'uuid:roku:ecp:ABC123'
+                };
+
+                (finder['server'] as any).emit('advertise-alive', aliveMessage);
+                expect(deviceOnlineSpy.calledOnce).to.be.true;
+
+                // 3 days = 216 heartbeat intervals — device stayed up, host was asleep
+                clock.tick(216 * HEARTBEAT_INTERVAL_MS);
+                (finder['server'] as any).emit('advertise-alive', aliveMessage);
+                expect(deviceOnlineSpy.calledOnce).to.be.true; // suppressed — on schedule
+            } finally {
+                clock.restore();
+            }
+        });
+
+        it('fires device-online after a 3-day gap if the Roku rebooted (alive arrives off schedule)', () => {
+            const clock = sinon.useFakeTimers();
+            try {
+                finder = new RokuFinder(mockGlobalStateManager);
+                finder['running'] = true;
+
+                const deviceOnlineSpy = sinon.spy();
+                finder.on('device-online', deviceOnlineSpy);
+
+                const aliveMessage = {
+                    NT: 'roku:ecp',
+                    NTS: 'ssdp:alive',
+                    LOCATION: 'http://192.168.1.100:8060',
+                    USN: 'uuid:roku:ecp:ABC123'
+                };
+
+                (finder['server'] as any).emit('advertise-alive', aliveMessage);
+                expect(deviceOnlineSpy.calledOnce).to.be.true;
+
+                // 3 days plus 10 minutes — off schedule, device rebooted
+                clock.tick(3 * 24 * 60 * 60 * 1_000 + 10 * 60 * 1_000);
+                (finder['server'] as any).emit('advertise-alive', aliveMessage);
+                expect(deviceOnlineSpy.calledTwice).to.be.true;
+            } finally {
+                clock.restore();
+            }
+        });
+
+        it('suppresses the next routine heartbeat after a reboot (clock resets from the reboot alive)', () => {
             const clock = sinon.useFakeTimers();
             try {
                 finder = new RokuFinder(mockGlobalStateManager);
@@ -437,7 +493,7 @@ describe('RokuFinder', () => {
                 (finder['server'] as any).emit('advertise-alive', aliveMessage);
                 expect(deviceOnlineSpy.calledTwice).to.be.true;
 
-                // 20 minutes after the reboot — routine heartbeat, clock was reset from wake time
+                // 20 minutes after the reboot — routine heartbeat, clock was reset from the reboot alive
                 clock.tick(HEARTBEAT_INTERVAL_MS);
                 (finder['server'] as any).emit('advertise-alive', aliveMessage);
                 expect(deviceOnlineSpy.calledTwice).to.be.true; // suppressed

--- a/src/deviceDiscovery/RokuFinder.spec.ts
+++ b/src/deviceDiscovery/RokuFinder.spec.ts
@@ -260,12 +260,12 @@ describe('RokuFinder', () => {
                 expect(deviceOnlineSpy.calledOnce).to.be.true;
 
                 // 4 seconds early (within ±5s tolerance) — suppressed
-                clock.tick(20 * 60 * 1_000 - 4_000);
+                clock.tick((20 * 60 * 1_000) - 4_000);
                 (finder['server'] as any).emit('advertise-alive', aliveMessage);
                 expect(deviceOnlineSpy.calledOnce).to.be.true;
 
                 // 4 seconds late from that timestamp (within ±5s tolerance) — suppressed
-                clock.tick(20 * 60 * 1_000 + 4_000);
+                clock.tick((20 * 60 * 1_000) + 4_000);
                 (finder['server'] as any).emit('advertise-alive', aliveMessage);
                 expect(deviceOnlineSpy.calledOnce).to.be.true;
             } finally {

--- a/src/deviceDiscovery/RokuFinder.ts
+++ b/src/deviceDiscovery/RokuFinder.ts
@@ -38,13 +38,20 @@ export class RokuFinder extends EventEmitter {
     private lastCleanupTime = 0;
     private readonly CLEANUP_INTERVAL_MS = 5 * 60 * 1000;
 
-    // Heartbeat suppression: Roku devices send ssdp:alive on a ~20-minute schedule.
-    // We emit device-online only when the alive does NOT arrive on schedule — meaning
-    // the device just woke up, rebooted, or the host missed heartbeats while asleep.
-    // Timestamps are persisted via GlobalStateManager so the clock survives restarts.
-    // Keyed by serial number so a DHCP IP change doesn't reset the clock.
-    private readonly HEARTBEAT_INTERVAL_MS = 20 * 60 * 1_000;
-    private readonly HEARTBEAT_TOLERANCE_MS = 5_000;
+    /**
+     * Heartbeat suppression: Roku devices send ssdp:alive on a ~20-minute schedule.
+     * We emit device-online only when the alive does NOT arrive on schedule — meaning
+     * the device just woke up or rebooted
+     * Timestamps are persisted via GlobalStateManager so the clock survives restarts.
+     * Keyed by serial number so a DHCP IP change doesn't reset the clock.
+     *
+     * Roku devices actually fire slightly less than 20minute interval. So use that value to help avoid overnight clock drift
+     */
+    private readonly HEARTBEAT_INTERVAL_MS = 1198.86 * 1_000;
+    /**
+     * Give some tolerance to the heartbeat interval to account for clock drift and Roku's non-exact timing, while still reliably suppressing regular heartbeats. 10 seconds should be more than enough.
+     */
+    private readonly HEARTBEAT_TOLERANCE_MS = 10_000;
 
     private readonly SCAN_MIN_DURATION_MS = 3_000;
     private readonly SCAN_SETTLE_MS = 1_500;
@@ -258,8 +265,10 @@ export class RokuFinder extends EventEmitter {
         const elapsed = lastTs !== undefined ? now - lastTs : undefined;
         this.globalStateManager.setLastAliveTimestamp(key, now);
 
+        const nearestMultiple = elapsed !== undefined ? Math.round(elapsed / this.HEARTBEAT_INTERVAL_MS) : 0;
         const isRoutineHeartbeat = elapsed !== undefined &&
-            Math.abs(elapsed - this.HEARTBEAT_INTERVAL_MS) <= this.HEARTBEAT_TOLERANCE_MS;
+            nearestMultiple >= 1 &&
+            Math.abs(elapsed - (nearestMultiple * this.HEARTBEAT_INTERVAL_MS)) <= this.HEARTBEAT_TOLERANCE_MS;
 
         const elapsedStr = elapsed !== undefined ? `${(elapsed / 1000).toFixed(1)}s ago` : 'first time seen';
         const decision = isRoutineHeartbeat ? '🔇 suppressed' : '🔔 device-online';

--- a/src/deviceDiscovery/RokuFinder.ts
+++ b/src/deviceDiscovery/RokuFinder.ts
@@ -4,7 +4,10 @@ import { Client, Server } from 'node-ssdp';
 import type { GlobalStateManager } from '../GlobalStateManager';
 
 export class RokuFinder extends EventEmitter {
-    constructor(private globalStateManager: GlobalStateManager) {
+    constructor(
+        private globalStateManager: GlobalStateManager,
+        private log: (msg: string) => void = () => { }
+    ) {
         super();
 
         this.client = new Client({
@@ -257,6 +260,9 @@ export class RokuFinder extends EventEmitter {
 
         const isRoutineHeartbeat = elapsed !== undefined &&
             Math.abs(elapsed - this.HEARTBEAT_INTERVAL_MS) <= this.HEARTBEAT_TOLERANCE_MS;
+
+        const elapsedStr = elapsed !== undefined ? `${(elapsed / 1000).toFixed(1)}s ago` : 'first time seen';
+        this.log(`ssdp:alive ip=${ip} serial=${serialNumber ?? 'unknown'} lastSeen=${elapsedStr} decision=${isRoutineHeartbeat ? 'suppressed (routine heartbeat)' : 'device-online'}`);
 
         if (!isRoutineHeartbeat) {
             this.emit('device-online', ip, serialNumber);

--- a/src/deviceDiscovery/RokuFinder.ts
+++ b/src/deviceDiscovery/RokuFinder.ts
@@ -1,9 +1,10 @@
 import { EventEmitter } from 'eventemitter3';
 import type { SsdpHeaders } from 'node-ssdp';
 import { Client, Server } from 'node-ssdp';
+import type { GlobalStateManager } from '../GlobalStateManager';
 
 export class RokuFinder extends EventEmitter {
-    constructor() {
+    constructor(private globalStateManager: GlobalStateManager) {
         super();
 
         this.client = new Client({
@@ -37,8 +38,8 @@ export class RokuFinder extends EventEmitter {
     // Heartbeat suppression: Roku devices send ssdp:alive on a ~20-minute schedule.
     // We emit device-online only when the alive does NOT arrive on schedule — meaning
     // the device just woke up, rebooted, or the host missed heartbeats while asleep.
+    // Timestamps are persisted via GlobalStateManager so the clock survives restarts.
     // Keyed by serial number so a DHCP IP change doesn't reset the clock.
-    private lastAliveTimestampMap = new Map<string, number>();
     private readonly HEARTBEAT_INTERVAL_MS = 20 * 60 * 1_000;
     private readonly HEARTBEAT_TOLERANCE_MS = 5_000;
 
@@ -250,9 +251,9 @@ export class RokuFinder extends EventEmitter {
      */
     private maybeEmitDeviceOnline(ip: string, serialNumber: string | undefined, now: number): void {
         const key = serialNumber ?? ip;
-        const lastTs = this.lastAliveTimestampMap.get(key);
+        const lastTs = this.globalStateManager.getLastAliveTimestamp(key);
         const elapsed = lastTs !== undefined ? now - lastTs : undefined;
-        this.lastAliveTimestampMap.set(key, now);
+        this.globalStateManager.setLastAliveTimestamp(key, now);
 
         const isRoutineHeartbeat = elapsed !== undefined &&
             Math.abs(elapsed - this.HEARTBEAT_INTERVAL_MS) <= this.HEARTBEAT_TOLERANCE_MS;
@@ -293,7 +294,6 @@ export class RokuFinder extends EventEmitter {
         this.scanTimers = [];
         this.clearScanTimers();
         this.aliveDebounceMap.clear();
-        this.lastAliveTimestampMap.clear();
 
         this.client.removeAllListeners();
         this.client.stop();

--- a/src/deviceDiscovery/RokuFinder.ts
+++ b/src/deviceDiscovery/RokuFinder.ts
@@ -263,7 +263,8 @@ export class RokuFinder extends EventEmitter {
 
         const elapsedStr = elapsed !== undefined ? `${(elapsed / 1000).toFixed(1)}s ago` : 'first time seen';
         const decision = isRoutineHeartbeat ? '🔇 suppressed' : '🔔 device-online';
-        this.log(`ssdp:alive  |  ${decision}  |  ip: ${ip}  |  serial: ${serialNumber ?? 'unknown'}  |  last seen: ${elapsedStr}`);
+        const ts = new Date().toLocaleTimeString();
+        this.log(`[${ts}] ssdp:alive  |  ${decision}  |  ip: ${ip}  |  serial: ${serialNumber ?? 'unknown'}  |  last seen: ${elapsedStr}`);
 
         if (!isRoutineHeartbeat) {
             this.emit('device-online', ip, serialNumber);

--- a/src/deviceDiscovery/RokuFinder.ts
+++ b/src/deviceDiscovery/RokuFinder.ts
@@ -262,7 +262,8 @@ export class RokuFinder extends EventEmitter {
             Math.abs(elapsed - this.HEARTBEAT_INTERVAL_MS) <= this.HEARTBEAT_TOLERANCE_MS;
 
         const elapsedStr = elapsed !== undefined ? `${(elapsed / 1000).toFixed(1)}s ago` : 'first time seen';
-        this.log(`ssdp:alive ip=${ip} serial=${serialNumber ?? 'unknown'} lastSeen=${elapsedStr} decision=${isRoutineHeartbeat ? 'suppressed (routine heartbeat)' : 'device-online'}`);
+        const decision = isRoutineHeartbeat ? '🔇 suppressed' : '🔔 device-online';
+        this.log(`ssdp:alive  |  ${decision}  |  ip: ${ip}  |  serial: ${serialNumber ?? 'unknown'}  |  last seen: ${elapsedStr}`);
 
         if (!isRoutineHeartbeat) {
             this.emit('device-online', ip, serialNumber);

--- a/src/deviceDiscovery/RokuFinder.ts
+++ b/src/deviceDiscovery/RokuFinder.ts
@@ -34,6 +34,14 @@ export class RokuFinder extends EventEmitter {
     private lastCleanupTime = 0;
     private readonly CLEANUP_INTERVAL_MS = 5 * 60 * 1000;
 
+    // Heartbeat suppression: Roku devices send ssdp:alive on a ~20-minute schedule.
+    // We emit device-online only when the alive does NOT arrive on schedule — meaning
+    // the device just woke up, rebooted, or the host missed heartbeats while asleep.
+    // Keyed by serial number so a DHCP IP change doesn't reset the clock.
+    private lastAliveTimestampMap = new Map<string, number>();
+    private readonly HEARTBEAT_INTERVAL_MS = 20 * 60 * 1_000;
+    private readonly HEARTBEAT_TOLERANCE_MS = 5_000;
+
     private readonly SCAN_MIN_DURATION_MS = 3_000;
     private readonly SCAN_SETTLE_MS = 1_500;
     private scanMinTimer: ReturnType<typeof setTimeout> | null = null;
@@ -221,7 +229,7 @@ export class RokuFinder extends EventEmitter {
                     this.aliveDebounceMap.set(ip, now);
                     const serialNumber = this.extractSerialFromUsn(usn);
                     this.emit('found', ip, { serialNumber: serialNumber });
-                    this.emit('device-online', ip, serialNumber);
+                    this.maybeEmitDeviceOnline(ip, serialNumber, now);
 
                     // Reset settle timer when device found during active scan
                     if (this.isScanning) {
@@ -231,6 +239,26 @@ export class RokuFinder extends EventEmitter {
             } catch {
                 // Invalid URL, ignore
             }
+        }
+    }
+
+    /**
+     * Emit 'device-online' unless this alive arrived right on the ~20-minute heartbeat
+     * schedule. Suppressing on-schedule heartbeats means we only notify when the device
+     * actually just came online: first time seen, after a reboot, or after the host was
+     * asleep long enough to miss the regular cadence.
+     */
+    private maybeEmitDeviceOnline(ip: string, serialNumber: string | undefined, now: number): void {
+        const key = serialNumber ?? ip;
+        const lastTs = this.lastAliveTimestampMap.get(key);
+        const elapsed = lastTs !== undefined ? now - lastTs : undefined;
+        this.lastAliveTimestampMap.set(key, now);
+
+        const isRoutineHeartbeat = elapsed !== undefined &&
+            Math.abs(elapsed - this.HEARTBEAT_INTERVAL_MS) <= this.HEARTBEAT_TOLERANCE_MS;
+
+        if (!isRoutineHeartbeat) {
+            this.emit('device-online', ip, serialNumber);
         }
     }
 
@@ -265,6 +293,7 @@ export class RokuFinder extends EventEmitter {
         this.scanTimers = [];
         this.clearScanTimers();
         this.aliveDebounceMap.clear();
+        this.lastAliveTimestampMap.clear();
 
         this.client.removeAllListeners();
         this.client.stop();

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -80,7 +80,9 @@ export class Extension {
         );
 
         this.telemetryManager.sendStartupEvent();
-        this.deviceManager = new DeviceManager(context, this.globalStateManager);
+        this.extensionOutputChannel = util.createOutputChannel('BrightScript Extension', this.writeExtensionLog.bind(this));
+        this.extensionOutputChannel.appendLine('Extension startup');
+        this.deviceManager = new DeviceManager(context, this.globalStateManager, this.extensionOutputChannel);
         let userInputManager = new UserInputManager(
             this.deviceManager
         );
@@ -113,8 +115,6 @@ export class Extension {
         //create channels
         this.outputChannel = vscode.window.createOutputChannel('BrightScript Log');
         this.sceneGraphDebugChannel = vscode.window.createOutputChannel('SceneGraph Debug Commands');
-        this.extensionOutputChannel = util.createOutputChannel('BrightScript Extension', this.writeExtensionLog.bind(this));
-        this.extensionOutputChannel.appendLine('Extension startup');
 
         let docLinkProvider = new LogDocumentLinkProvider();
 


### PR DESCRIPTION
## Summary

- Roku devices broadcast `ssdp:alive` on a ~20-minute schedule, causing repeated "Device Online" popups for devices that were never offline
- Added `maybeEmitDeviceOnline()` which tracks the last-seen alive timestamp per serial number and suppresses `device-online` when an alive arrives within ±10s of the 20-minute interval (or a multiple of that, sometimes we miss a few).
- First time a device is seen or after a reboot — correctly fires the notification
- If the host slept and missed heartbeats, the next on-schedule alive is still suppressed (multiple-of-interval math handles it, no wake-event handling needed)
- A device that rebooted while the host was asleep fires `device-online` because its first alive after reboot lands off-schedule
- Keyed by serial number (not IP) so DHCP lease changes don't reset the clock

## Test plan

- [x] First alive fires `device-online`
- [x] Alive at exactly 20 min is suppressed
- [x] Alive within ±5s of 20 min is suppressed
- [x] Alive off-schedule (e.g. 10s after last) fires `device-online` (reboot)
- [x] After a reboot, the next routine 20-min heartbeat is suppressed
- [x] Alive after 3-day gap on schedule (host slept, Roku did not reboot) is suppressed
- [x] Alive after 3-day gap off schedule (Roku rebooted while host was asleep) fires `device-online`
- [x] Serial number used as key; IP change doesn't reset clock
- [x] Heartbeat tracked independently per device

This seems to work! See this log:
```
[heartbeat] [7:06:50 AM] ssdp:alive  |  🔔 device-online  |  ip: 192.168.1.32  |  serial: AAA  |  last seen: 210.9s ago
[heartbeat] [7:07:09 AM] ssdp:alive  |  🔇 suppressed     |  ip: 192.168.1.33  |  serial: BBB |  last seen: 1198.9s ago
[heartbeat] [7:07:31 AM] ssdp:alive  |  🔔 device-online  |  ip: 192.168.1.31  |  serial: CCC |  last seen: 1307.1s ago
[heartbeat] [7:07:33 AM] ssdp:alive  |  🔔 device-online  |  ip: 192.168.1.32  |  serial: AAA |  last seen: 43.2s ago
[heartbeat] [7:08:10 AM] ssdp:alive  |  🔇 suppressed     |  ip: 192.168.1.251  |  serial: DDD |  last seen: 1198.8s ago
[heartbeat] [7:08:14 AM] ssdp:alive  |  🔔 device-online  |  ip: 192.168.1.32  |  serial: AAA |  last seen: 40.4s ago
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)