### PR TITLE
Document bs:disable / bs:enable block directives and suppression quick fixes

### DIFF
--- a/docs/Editing/error-handling.md
+++ b/docs/Editing/error-handling.md
@@ -28,13 +28,16 @@ sub DoSomething()
 end sub
 ```
 
-# Ignore errors and warnings for an entire file
-To suppress diagnostics across an entire file, place a `bs:disable-file` comment in the file's header (before any executable code). For XML components, place the comment between the `<?xml ?>` declaration and the root element.
- - `bs:disable-file`
- - `bs:disable-file: code1 code2 code3`
+# Ignore errors and warnings for a block of code or whole file
+Use `bs:disable` and `bs:enable` to suppress diagnostics for a span of code. A `bs:disable` opens a suppression block, and a matching `bs:enable` closes it. If no `bs:enable` follows, the block runs to the end of the file, so a bare `bs:disable` at the top of a file suppresses the whole file.
+
+ - `bs:disable`: suppress all diagnostics from this line until the next `bs:enable`
+ - `bs:disable: code1 code2 code3`: suppress only the listed codes
+ - `bs:enable`: close any open `bs:disable` block
+ - `bs:enable: code1 code2 code3`: re-enable specific codes from an open `bs:disable`
 
 ```vb
-' bs:disable-file: 1001 1002
+' bs:disable: 1001 1002
 
 sub Main()
     DoSomething()
@@ -43,16 +46,26 @@ end sub
 
 ```xml
 <?xml version="1.0" encoding="utf-8" ?>
-<!-- bs:disable-file: 1006 -->
+<!-- bs:disable: 1006 -->
 <component name="Foo">
 </component>
 ```
 
-A `bs:disable-file` comment placed below the first line of code is ignored.
+`bs:enable: <code>` after a bare `bs:disable` re-enables one diagnostic while keeping the rest suppressed:
+
+```vb
+' bs:disable
+'   1006 is still suppressed below, but 1001 reports normally
+' bs:enable: 1001
+
+sub Main()
+    DoSomething()
+end sub
+```
 
 # Quick fixes for disabling diagnostics
 Every diagnostic surfaced in the editor has two quick fixes for suppressing it without leaving the file:
- - **Disable {code} for this line: {message}** &mdash; appends the code to an existing `bs:disable-line` or `bs:disable-next-line` directive on/above the diagnostic line if there is one, otherwise inserts a new `bs:disable-next-line: {code}` directive above the diagnostic.
- - **Disable {code} for this file: {message}** &mdash; appends the code to an existing `bs:disable-file` directive in the file's header if there is one, otherwise inserts a new `bs:disable-file: {code}` directive at the top of the file.
+ - **Disable {code} for this line: {message}**: appends the code to an existing `bs:disable-line` or `bs:disable-next-line` directive on or above the diagnostic line if there is one, otherwise inserts a new `bs:disable-next-line: {code}` directive above the diagnostic.
+ - **Disable {code} for this file: {message}**: appends the code to an existing header-level `bs:disable` directive if there is one, otherwise inserts a new `bs:disable: {code}` directive at the top of the file.
 
 Open the quick-fix menu the same way you would for any other diagnostic (the lightbulb in the gutter, or `Ctrl+.` / `Cmd+.`).

--- a/docs/Editing/error-handling.md
+++ b/docs/Editing/error-handling.md
@@ -27,3 +27,32 @@ end sub
 sub DoSomething()
 end sub
 ```
+
+# Ignore errors and warnings for an entire file
+To suppress diagnostics across an entire file, place a `bs:disable-file` comment in the file's header (before any executable code). For XML components, place the comment between the `<?xml ?>` declaration and the root element.
+ - `bs:disable-file`
+ - `bs:disable-file: code1 code2 code3`
+
+```vb
+' bs:disable-file: 1001 1002
+
+sub Main()
+    DoSomething()
+end sub
+```
+
+```xml
+<?xml version="1.0" encoding="utf-8" ?>
+<!-- bs:disable-file: 1006 -->
+<component name="Foo">
+</component>
+```
+
+A `bs:disable-file` comment placed below the first line of code is ignored.
+
+# Quick fixes for disabling diagnostics
+Every diagnostic surfaced in the editor has two quick fixes for suppressing it without leaving the file:
+ - **Disable {code} for this line: {message}** &mdash; appends the code to an existing `bs:disable-line` or `bs:disable-next-line` directive on/above the diagnostic line if there is one, otherwise inserts a new `bs:disable-next-line: {code}` directive above the diagnostic.
+ - **Disable {code} for this file: {message}** &mdash; appends the code to an existing `bs:disable-file` directive in the file's header if there is one, otherwise inserts a new `bs:disable-file: {code}` directive at the top of the file.
+
+Open the quick-fix menu the same way you would for any other diagnostic (the lightbulb in the gutter, or `Ctrl+.` / `Cmd+.`).


### PR DESCRIPTION
## Summary

- Replace the `bs:disable-file` documentation with the ESLint-style `bs:disable` / `bs:enable` pair landed in brighterscript. A bare `bs:disable` at the top of a file still covers the whole file (the original use case), and `bs:enable: <code>` after a bare `bs:disable` re-enables a single diagnostic while keeping the rest suppressed.
- Update the per-diagnostic quick-fix descriptions: the file action now extends a header-level `bs:disable` (or inserts a new one) instead of a `bs:disable-file`.
- Drop em-dashes and clean up the prose to match the brighterscript docs.

Pairs with rokucommunity/brighterscript#1699, which adds the directive parsing, the state machine, and the code-action emission.

## Test plan
- [ ] Render the docs and confirm the new sections read correctly alongside the existing per-line guidance.
- [ ] Once #1699 ships in a brighterscript release used by this extension, smoke-test the quick fixes in VS Code (block disable, paired enable, carve-out, both quick fixes for line and file).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
