### PR TITLE
Add ManifestProjectProvider for Roku channel detection

### DIFF
--- a/src/DebugConfigurationProvider.ts
+++ b/src/DebugConfigurationProvider.ts
@@ -2,7 +2,6 @@ import { util as bslangUtil } from 'brighterscript';
 import * as dotenv from 'dotenv';
 import * as path from 'path';
 import * as fsExtra from 'fs-extra';
-import { DefaultFiles } from 'roku-deploy';
 import * as rta from 'roku-test-automation';
 import type {
     CancellationToken,
@@ -27,6 +26,29 @@ import type { CredentialStore } from './managers/CredentialStore';
 
 
 export class BrightScriptDebugConfigurationProvider implements DebugConfigurationProvider {
+
+    /**
+     * Canonical default `files` glob list for a Roku channel launch configuration.
+     * Other providers (e.g. ManifestProjectProvider) reference this so the project's
+     * notion of "what to deploy" stays in one place.
+     *
+     * Backed by Roku's documented channel package layout:
+     *   - manifest, source/, components/, images/ — listed as standard folders in
+     *     https://developer.roku.com/dev/docs/hello-world
+     *   - locale/ — auto-loaded for translations and localized images per
+     *     https://developer.roku.com/dev/docs/localization
+     *   - fonts/ — TrueType/OpenType files loaded via roFontRegistry
+     *   - componentLibraries/ — output dir for component-library builds bundled with the channel
+     */
+    public static readonly defaultFiles: ReadonlyArray<string> = [
+        'source/**/*.*',
+        'componentLibraries/**/*.*',
+        'components/**/*.*',
+        'images/**/*.*',
+        'locale/**/*',
+        'fonts/**/*',
+        'manifest'
+    ];
 
     public constructor(
         private context: ExtensionContext,
@@ -67,7 +89,7 @@ export class BrightScriptDebugConfigurationProvider implements DebugConfiguratio
         enableDebuggerAutoRecovery: false,
         stopDebuggerOnAppExit: false,
         autoRunSgDebugCommands: [],
-        files: [...DefaultFiles],
+        files: [...BrightScriptDebugConfigurationProvider.defaultFiles],
         enableSourceMaps: true,
         rewriteDevicePathsInLogs: true,
         packagePort: 80,
@@ -254,7 +276,7 @@ export class BrightScriptDebugConfigurationProvider implements DebugConfiguratio
 
             for (let library of config.componentLibraries as any) {
                 library.rootDir = this.util.ensureTrailingSlash(library.rootDir);
-                library.files = library.files ? library.files : [...DefaultFiles];
+                library.files = library.files ? library.files : [...BrightScriptDebugConfigurationProvider.defaultFiles];
             }
         } else {
             //create an empty array so it's easier to reason with downstream

--- a/src/managers/RokuProject/ManifestProjectProvider.spec.ts
+++ b/src/managers/RokuProject/ManifestProjectProvider.spec.ts
@@ -1,0 +1,264 @@
+import { expect } from 'chai';
+import { createSandbox } from 'sinon';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import { vscode } from '../../mockVscode.spec';
+
+let Module = require('module');
+const { require: oldRequire } = Module.prototype;
+Module.prototype.require = function hijacked(file) {
+    if (file === 'vscode') {
+        return vscode;
+    }
+    return oldRequire.apply(this, arguments);
+};
+
+import { ManifestProjectProvider } from './ManifestProjectProvider';
+import { BrightScriptDebugConfigurationProvider } from '../../DebugConfigurationProvider';
+
+const sinon = createSandbox();
+
+function makeUri(fsPath: string) {
+    return vscode.Uri.file(fsPath);
+}
+
+describe('ManifestProjectProvider', () => {
+    let provider: ManifestProjectProvider;
+    let tempDir: string;
+
+    beforeEach(() => {
+        sinon.restore();
+        provider = new ManifestProjectProvider();
+        tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'manifest-spec-'));
+    });
+
+    afterEach(() => {
+        sinon.restore();
+        try {
+            fs.rmSync(tempDir, { recursive: true, force: true });
+        } catch {
+            // best-effort cleanup
+        }
+    });
+
+    /** Lay out a Roku-shaped project at projectDir, returning the manifest URI. */
+    function makeRokuProject(projectDir: string, opts: { source?: boolean; components?: boolean } = { source: true }): ReturnType<typeof makeUri> {
+        fs.mkdirSync(projectDir, { recursive: true });
+        if (opts.source) {
+            fs.mkdirSync(path.join(projectDir, 'source'), { recursive: true });
+        }
+        if (opts.components) {
+            fs.mkdirSync(path.join(projectDir, 'components'), { recursive: true });
+        }
+        const manifestPath = path.join(projectDir, 'manifest');
+        fs.writeFileSync(manifestPath, '');
+        return makeUri(manifestPath);
+    }
+
+    describe('ownsConfig', () => {
+        it('returns true for a manifest with an adjacent source/ dir', () => {
+            const uri = makeRokuProject(tempDir, { source: true });
+            expect(provider.ownsConfig(uri)).to.be.true;
+        });
+
+        it('returns true for a manifest with an adjacent components/ dir', () => {
+            const uri = makeRokuProject(tempDir, { components: true });
+            expect(provider.ownsConfig(uri)).to.be.true;
+        });
+
+        it('returns true for a manifest with both source/ and components/', () => {
+            const uri = makeRokuProject(tempDir, { source: true, components: true });
+            expect(provider.ownsConfig(uri)).to.be.true;
+        });
+
+        it('returns false for a manifest with neither source/ nor components/', () => {
+            fs.writeFileSync(path.join(tempDir, 'manifest'), '');
+            expect(provider.ownsConfig(makeUri(path.join(tempDir, 'manifest')))).to.be.false;
+        });
+
+        it('returns false for a non-manifest filename even with source/ adjacent', () => {
+            fs.mkdirSync(path.join(tempDir, 'source'), { recursive: true });
+            fs.writeFileSync(path.join(tempDir, 'package.json'), '');
+            expect(provider.ownsConfig(makeUri(path.join(tempDir, 'package.json')))).to.be.false;
+        });
+    });
+
+
+    describe('findProjectConfigs', () => {
+        it('returns Roku-shaped manifests and filters out non-Roku ones', async () => {
+            const rokuDir = path.join(tempDir, 'rokuApp');
+            const nonRokuDir = path.join(tempDir, 'nonRoku');
+            const rokuUri = makeRokuProject(rokuDir, { source: true });
+            fs.mkdirSync(nonRokuDir, { recursive: true });
+            fs.writeFileSync(path.join(nonRokuDir, 'manifest'), '');
+            const nonRokuUri = makeUri(path.join(nonRokuDir, 'manifest'));
+
+            sinon.stub(vscode.workspace, 'findFiles').resolves([rokuUri, nonRokuUri]);
+
+            const results = await provider.findProjectConfigs();
+
+            expect(results).to.have.length(1);
+            expect(results[0].fsPath).to.equal(rokuUri.fsPath);
+        });
+
+        it('returns an empty array when no manifests are found', async () => {
+            sinon.stub(vscode.workspace, 'findFiles').resolves([]);
+
+            const results = await provider.findProjectConfigs();
+            expect(results).to.have.length(0);
+        });
+    });
+
+
+    describe('findProjectConfigFromFile', () => {
+        it('returns an empty array when no projects are registered', async () => {
+            const result = await provider.findProjectConfigFromFile(makeUri(path.join(tempDir, 'foo.brs')));
+            expect(result).to.have.length(0);
+        });
+
+        it('returns the matching config when a file lives under a registered project', async () => {
+            const configUri = makeRokuProject(tempDir, { source: true });
+            provider.afterConfigRegistered(configUri);
+
+            const result = await provider.findProjectConfigFromFile(makeUri(path.join(tempDir, 'source', 'main.brs')));
+            expect(result).to.have.length(1);
+            expect(result[0].fsPath).to.equal(configUri.fsPath);
+        });
+
+        it('returns the matching config when the file IS the manifest', async () => {
+            const configUri = makeRokuProject(tempDir, { source: true });
+            provider.afterConfigRegistered(configUri);
+
+            const result = await provider.findProjectConfigFromFile(configUri);
+            expect(result).to.have.length(1);
+            expect(result[0].fsPath).to.equal(configUri.fsPath);
+        });
+
+        it('returns an empty array when the file is outside all registered projects', async () => {
+            const projectDir = path.join(tempDir, 'app');
+            const configUri = makeRokuProject(projectDir, { source: true });
+            provider.afterConfigRegistered(configUri);
+
+            const otherFile = path.join(tempDir, 'other', 'main.brs');
+            const result = await provider.findProjectConfigFromFile(makeUri(otherFile));
+            expect(result).to.have.length(0);
+        });
+
+        it('returns an empty array for a file inside the project dir that does not match any default pattern', async () => {
+            const configUri = makeRokuProject(tempDir, { source: true });
+            provider.afterConfigRegistered(configUri);
+
+            // .git/HEAD lives under the project but isn't covered by any of the default file globs
+            const result = await provider.findProjectConfigFromFile(makeUri(path.join(tempDir, '.git', 'HEAD')));
+            expect(result).to.have.length(0);
+        });
+
+        it('returns the matching config for a locale file (matched by locale/**/*)', async () => {
+            const configUri = makeRokuProject(tempDir, { source: true });
+            provider.afterConfigRegistered(configUri);
+
+            const result = await provider.findProjectConfigFromFile(makeUri(path.join(tempDir, 'locale', 'en_US', 'translations.xml')));
+            expect(result).to.have.length(1);
+            expect(result[0].fsPath).to.equal(configUri.fsPath);
+        });
+    });
+
+
+    describe('afterConfigRegistered', () => {
+        it('adds the project dir to the index', () => {
+            const configUri = makeRokuProject(tempDir, { source: true });
+            provider.afterConfigRegistered(configUri);
+
+            const index = (provider as any).configByProjectDir as Map<string, ReturnType<typeof makeUri>>;
+            expect(index.has(tempDir)).to.be.true;
+            expect(index.get(tempDir)?.fsPath).to.equal(configUri.fsPath);
+        });
+    });
+
+
+    describe('afterConfigUnregistered', () => {
+        it('removes the project dir from the index', () => {
+            const configUri = makeRokuProject(tempDir, { source: true });
+            provider.afterConfigRegistered(configUri);
+            expect((provider as any).configByProjectDir.has(tempDir)).to.be.true;
+
+            provider.afterConfigUnregistered(configUri);
+            expect((provider as any).configByProjectDir.has(tempDir)).to.be.false;
+        });
+
+        it('does not throw when called for an unregistered URI', () => {
+            const configUri = makeUri(path.join(tempDir, 'manifest'));
+            expect(() => provider.afterConfigUnregistered(configUri)).to.not.throw();
+        });
+    });
+
+
+    describe('createProject', () => {
+        it('produces project metadata with the correct projectDir and projectName', () => {
+            const projectDir = path.join(tempDir, 'myApp');
+            const configUri = makeRokuProject(projectDir, { source: true });
+
+            const result = provider.createProject(configUri);
+
+            expect(result.project.projectDir).to.equal(projectDir);
+            expect(result.project.projectName).to.equal('myApp');
+            expect(result.project.configUri.fsPath).to.equal(configUri.fsPath);
+        });
+
+        it('produces a debug config with type brightscript and request launch', () => {
+            const configUri = makeRokuProject(tempDir, { source: true });
+            const result = provider.createProject(configUri);
+
+            expect(result.debugConfig.type).to.equal('brightscript');
+            expect(result.debugConfig.request).to.equal('launch');
+        });
+
+        it('uses "Debug <projectName>" as the debug config name', () => {
+            const projectDir = path.join(tempDir, 'myCoolApp');
+            const configUri = makeRokuProject(projectDir, { source: true });
+            const result = provider.createProject(configUri);
+
+            expect(result.debugConfig.name).to.equal('Debug myCoolApp');
+        });
+
+        it('sets rootDir to the manifest directory', () => {
+            const configUri = makeRokuProject(tempDir, { source: true });
+            const result = provider.createProject(configUri);
+
+            expect(result.debugConfig.rootDir).to.equal(tempDir);
+        });
+
+        it('uses promptForHost and promptForPassword placeholders', () => {
+            const configUri = makeRokuProject(tempDir, { source: true });
+            const result = provider.createProject(configUri);
+
+            expect(result.debugConfig.host).to.equal('${promptForHost}');
+            expect(result.debugConfig.password).to.equal('${promptForPassword}');
+        });
+
+        it('does not include a taskName or taskConfig', () => {
+            const configUri = makeRokuProject(tempDir, { source: true });
+            const result = provider.createProject(configUri);
+
+            expect(result.taskName).to.be.undefined;
+            expect(result.taskConfig).to.be.undefined;
+        });
+
+        it('uses BrightScriptDebugConfigurationProvider.defaultFiles for every project', () => {
+            const configUri = makeRokuProject(tempDir, { source: true });
+            const result = provider.createProject(configUri);
+
+            expect(result.debugConfig.files).to.deep.equal([...BrightScriptDebugConfigurationProvider.defaultFiles]);
+        });
+
+        it('returns a fresh files array each call so callers can mutate it without affecting later calls', () => {
+            const configUri = makeRokuProject(tempDir, { source: true });
+            const first = provider.createProject(configUri);
+            first.debugConfig.files.push('extra/**/*');
+
+            const second = provider.createProject(configUri);
+            expect(second.debugConfig.files).to.not.include('extra/**/*');
+        });
+    });
+});

--- a/src/managers/RokuProject/ManifestProjectProvider.ts
+++ b/src/managers/RokuProject/ManifestProjectProvider.ts
@@ -1,0 +1,88 @@
+import * as fs from 'fs';
+import * as path from 'path';
+import * as vscode from 'vscode';
+import { util as bsUtil } from 'brighterscript';
+import { rokuDeploy } from 'roku-deploy';
+import { util } from '../../util';
+import { BrightScriptDebugConfigurationProvider } from '../../DebugConfigurationProvider';
+import type { DiscoveredRokuProject, ProjectBuildResult, ProjectConfigProvider } from './RokuProjectManager';
+
+export class ManifestProjectProvider implements ProjectConfigProvider {
+
+    public readonly configFileSelector: vscode.DocumentFilter[] = [
+        { pattern: '**/manifest', scheme: 'file' }
+    ];
+
+    public readonly excludePatterns = ['**/node_modules/**'];
+
+    /** Tracks registered project dirs so findProjectConfigFromFile can answer ownership without FS walks. */
+    private readonly configByProjectDir = new Map<string, vscode.Uri>();
+
+    public ownsConfig(uri: vscode.Uri): boolean {
+        return path.basename(uri.fsPath) === 'manifest' && this.looksLikeRokuProject(uri);
+    }
+
+    public async findProjectConfigs(): Promise<vscode.Uri[]> {
+        const exclude = util.buildExcludeGlob(this.excludePatterns);
+        const results = await Promise.all(
+            this.configFileSelector
+                .filter(selector => selector.pattern)
+                .map(selector => vscode.workspace.findFiles(selector.pattern as string, exclude))
+        );
+        return results.flat().filter(uri => this.looksLikeRokuProject(uri));
+    }
+
+    public findProjectConfigFromFile(fileUri: vscode.Uri): Promise<vscode.Uri[]> {
+        const filePath = bsUtil.driveLetterToLower(fileUri.fsPath);
+        const files = [...BrightScriptDebugConfigurationProvider.defaultFiles];
+        const matches: vscode.Uri[] = [];
+        for (const [projectDir, configUri] of this.configByProjectDir) {
+            if (rokuDeploy.getDestPath(filePath, files, projectDir)) {
+                matches.push(configUri);
+            }
+        }
+        return Promise.resolve(matches);
+    }
+
+    public afterConfigRegistered(configUri: vscode.Uri): void {
+        this.configByProjectDir.set(path.dirname(configUri.fsPath), configUri);
+    }
+
+    public afterConfigUnregistered(configUri: vscode.Uri): void {
+        this.configByProjectDir.delete(path.dirname(configUri.fsPath));
+    }
+
+    public createProject(configUri: vscode.Uri): ProjectBuildResult {
+        const project = this.toProject(configUri);
+        const { projectDir, projectName } = project;
+        const debugConfig: vscode.DebugConfiguration = {
+            type: 'brightscript',
+            request: 'launch',
+            name: `Debug ${projectName}`,
+            rootDir: projectDir,
+            files: [...BrightScriptDebugConfigurationProvider.defaultFiles],
+            host: '${promptForHost}',
+            password: '${promptForPassword}'
+        };
+        return { project: project, debugConfig: debugConfig };
+    }
+
+    /**
+     * A bare `manifest` file is too generic to be a Roku-project signal on its own
+     * (npm, webpack, browser-extensions, etc. also use that name), so we require an
+     * adjacent `source/` or `components/` dir before treating it as a Roku project.
+     */
+    private looksLikeRokuProject(manifestUri: vscode.Uri): boolean {
+        const dir = path.dirname(manifestUri.fsPath);
+        return fs.existsSync(path.join(dir, 'source')) || fs.existsSync(path.join(dir, 'components'));
+    }
+
+    private toProject(configUri: vscode.Uri): DiscoveredRokuProject {
+        const projectDir = path.dirname(configUri.fsPath);
+        return {
+            configUri: configUri,
+            projectDir: projectDir,
+            projectName: path.basename(projectDir)
+        };
+    }
+}

--- a/src/managers/RokuProject/ManifestProjectProvider.ts
+++ b/src/managers/RokuProject/ManifestProjectProvider.ts
@@ -46,7 +46,9 @@ export class ManifestProjectProvider implements ProjectConfigProvider {
         const files = [...BrightScriptDebugConfigurationProvider.defaultFiles];
         const matches: vscode.Uri[] = [];
         for (const [projectDir, configUri] of this.configByProjectDir) {
-            if (rokuDeploy.getDestPath(filePath, files, projectDir)) {
+            // Drive letters must be normalized on both sides — getDestPath does a case-sensitive
+            // comparison and Windows uri.fsPath casing isn't always consistent with path.dirname output.
+            if (rokuDeploy.getDestPath(filePath, files, bsUtil.driveLetterToLower(projectDir))) {
                 matches.push(configUri);
             }
         }

--- a/src/managers/RokuProject/ManifestProjectProvider.ts
+++ b/src/managers/RokuProject/ManifestProjectProvider.ts
@@ -13,7 +13,16 @@ export class ManifestProjectProvider implements ProjectConfigProvider {
         { pattern: '**/manifest', scheme: 'file' }
     ];
 
-    public readonly excludePatterns = ['**/node_modules/**'];
+    // Roku build output trees often contain a staged copy of manifest + source/ + components/,
+    // which trips the looksLikeRokuProject signal and surfaces a phantom duplicate project.
+    // Excluding the common output dirs keeps discovery focused on the real source tree.
+    public readonly excludePatterns = [
+        '**/node_modules/**',
+        '**/out/**',
+        '**/.roku-deploy-staging/**',
+        '**/dist/**',
+        '**/build/**'
+    ];
 
     /** Tracks registered project dirs so findProjectConfigFromFile can answer ownership without FS walks. */
     private readonly configByProjectDir = new Map<string, vscode.Uri>();

--- a/src/managers/RokuProject/RokuProjectManager.spec.ts
+++ b/src/managers/RokuProject/RokuProjectManager.spec.ts
@@ -101,54 +101,54 @@ describe('RokuProjectManager', () => {
 
 
     describe('registerProject', () => {
-        it('registers a task and project when a provider owns the URI', () => {
+        it('registers a task and project when a provider owns the URI', async () => {
             const uri = makeUri('/workspace/project/bsconfig.json');
             const result = makeBuildResult('/workspace/project', uri);
 
             (mockProvider.ownsConfig as sinon.SinonStub).returns(true);
             (mockProvider.createProject as sinon.SinonStub).returns(result);
 
-            (manager as any).registerProject(uri);
+            await (manager as any).registerProject(uri);
 
             expect(taskRegistry.registerTask.calledOnceWith(result.taskName, result.taskConfig)).to.be.true;
             expect(viewProvider.setProjects.calledOnce).to.be.true;
         });
 
-        it('stores the project in discoveredProjects', () => {
+        it('stores the project in discoveredProjects', async () => {
             const uri = makeUri('/workspace/project/bsconfig.json');
             const result = makeBuildResult('/workspace/project', uri);
 
             (mockProvider.ownsConfig as sinon.SinonStub).returns(true);
             (mockProvider.createProject as sinon.SinonStub).returns(result);
 
-            (manager as any).registerProject(uri);
+            await (manager as any).registerProject(uri);
 
             expect((manager as any).discoveredProjects.has('/workspace/project')).to.be.true;
         });
 
-        it('calls afterConfigRegistered on the owning provider', () => {
+        it('calls afterConfigRegistered on the owning provider', async () => {
             const uri = makeUri('/workspace/project/bsconfig.json');
             const result = makeBuildResult('/workspace/project', uri);
 
             (mockProvider.ownsConfig as sinon.SinonStub).returns(true);
             (mockProvider.createProject as sinon.SinonStub).returns(result);
 
-            (manager as any).registerProject(uri);
+            await (manager as any).registerProject(uri);
 
             expect((mockProvider.afterConfigRegistered as sinon.SinonStub).calledOnceWith(uri)).to.be.true;
         });
 
-        it('does nothing when no provider owns the URI', () => {
+        it('does nothing when no provider owns the URI', async () => {
             const uri = makeUri('/workspace/project/unknown.json');
             (mockProvider.ownsConfig as sinon.SinonStub).returns(false);
 
-            (manager as any).registerProject(uri);
+            await (manager as any).registerProject(uri);
 
             expect(taskRegistry.registerTask.called).to.be.false;
             expect(viewProvider.setProjects.called).to.be.false;
         });
 
-        it('skips when a higher-priority provider already owns an ancestor directory', () => {
+        it('skips when a higher-priority provider already owns an ancestor directory', async () => {
             const highPri = makeMockProvider();
             const lowPri = makeMockProvider();
             (manager as any).providers = [highPri, lowPri];
@@ -159,7 +159,7 @@ describe('RokuProjectManager', () => {
             (highPri.ownsConfig as sinon.SinonStub).returns(true);
             (highPri.createProject as sinon.SinonStub).returns(highPriBuild);
             (highPri.afterConfigRegistered as sinon.SinonStub);
-            (manager as any).registerProject(highPriUri);
+            await (manager as any).registerProject(highPriUri);
 
             // Now try to register a project in a subdirectory via the low-priority provider
             // '/workspace/sub'.startsWith('/workspace/') → true → should be skipped
@@ -170,13 +170,43 @@ describe('RokuProjectManager', () => {
             (lowPri.createProject as sinon.SinonStub).returns(lowPriBuild);
 
             const callsBefore = taskRegistry.registerTask.callCount;
-            (manager as any).registerProject(lowPriUri);
+            await (manager as any).registerProject(lowPriUri);
 
             expect(taskRegistry.registerTask.callCount).to.equal(callsBefore);
             expect((lowPri.afterConfigRegistered as sinon.SinonStub).called).to.be.false;
         });
 
-        it('allows registering two projects in different directories', () => {
+        it('skips when a higher-priority provider claims the new config URI as one of its files', async () => {
+            const bsConfig = makeMockProvider();
+            const brsConfig = makeMockProvider();
+            (manager as any).providers = [bsConfig, brsConfig];
+
+            // Register bsconfig.json at /workspace via the high-priority provider
+            const bsConfigUri = makeUri('/workspace/bsconfig.json');
+            const bsConfigBuild = makeBuildResult('/workspace', bsConfigUri);
+            (bsConfig.ownsConfig as sinon.SinonStub).withArgs(bsConfigUri).returns(true);
+            (bsConfig.createProject as sinon.SinonStub).returns(bsConfigBuild);
+            await (manager as any).registerProject(bsConfigUri);
+
+            // Now try to register brsconfig.json in the same folder. The dir-overlap check
+            // won't catch this (same dir is not a strict subdirectory), but bsConfig's
+            // findProjectConfigFromFile reports that the brsconfig file is part of its project.
+            const brsConfigUri = makeUri('/workspace/brsconfig.json');
+            const brsConfigBuild = makeBuildResult('/workspace', brsConfigUri);
+            (brsConfig.ownsConfig as sinon.SinonStub).withArgs(brsConfigUri).returns(true);
+            (brsConfig.createProject as sinon.SinonStub).returns(brsConfigBuild);
+            (bsConfig.findProjectConfigFromFile as sinon.SinonStub).withArgs(brsConfigUri).resolves([bsConfigUri]);
+
+            const callsBefore = taskRegistry.registerTask.callCount;
+            await (manager as any).registerProject(brsConfigUri);
+
+            expect(taskRegistry.registerTask.callCount).to.equal(callsBefore);
+            expect((brsConfig.afterConfigRegistered as sinon.SinonStub).called).to.be.false;
+            expect((manager as any).discoveredProjects.has('/workspace')).to.be.true;
+            expect((manager as any).providerIndexByProjectDir.get('/workspace')).to.equal(0);
+        });
+
+        it('allows registering two projects in different directories', async () => {
             const uri1 = makeUri('/workspace/project-a/bsconfig.json');
             const uri2 = makeUri('/workspace/project-b/bsconfig.json');
             const result1 = makeBuildResult('/workspace/project-a', uri1);
@@ -187,8 +217,8 @@ describe('RokuProjectManager', () => {
                 .onFirstCall().returns(result1)
                 .onSecondCall().returns(result2);
 
-            (manager as any).registerProject(uri1);
-            (manager as any).registerProject(uri2);
+            await (manager as any).registerProject(uri1);
+            await (manager as any).registerProject(uri2);
 
             expect((manager as any).discoveredProjects.size).to.equal(2);
             expect(taskRegistry.registerTask.callCount).to.equal(2);
@@ -197,14 +227,14 @@ describe('RokuProjectManager', () => {
 
 
     describe('unregisterProject', () => {
-        it('unregisters the task and removes the project', () => {
+        it('unregisters the task and removes the project', async () => {
             const uri = makeUri('/workspace/project/bsconfig.json');
             const result = makeBuildResult('/workspace/project', uri);
 
             (mockProvider.ownsConfig as sinon.SinonStub).returns(true);
             (mockProvider.createProject as sinon.SinonStub).returns(result);
 
-            (manager as any).registerProject(uri);
+            await (manager as any).registerProject(uri);
             expect((manager as any).discoveredProjects.size).to.equal(1);
 
             (manager as any).unregisterProject(uri);
@@ -214,14 +244,14 @@ describe('RokuProjectManager', () => {
             expect(viewProvider.setProjects.callCount).to.equal(2); // once for register, once for unregister
         });
 
-        it('calls afterConfigUnregistered on the owning provider', () => {
+        it('calls afterConfigUnregistered on the owning provider', async () => {
             const uri = makeUri('/workspace/project/bsconfig.json');
             const result = makeBuildResult('/workspace/project', uri);
 
             (mockProvider.ownsConfig as sinon.SinonStub).returns(true);
             (mockProvider.createProject as sinon.SinonStub).returns(result);
 
-            (manager as any).registerProject(uri);
+            await (manager as any).registerProject(uri);
             (manager as any).unregisterProject(uri);
 
             expect((mockProvider.afterConfigUnregistered as sinon.SinonStub).calledOnceWith(uri)).to.be.true;
@@ -236,14 +266,14 @@ describe('RokuProjectManager', () => {
             expect(taskRegistry.unregisterTask.called).to.be.false;
         });
 
-        it('removes the provider-index entry so the dir can be reclaimed later', () => {
+        it('removes the provider-index entry so the dir can be reclaimed later', async () => {
             const uri = makeUri('/workspace/project/bsconfig.json');
             const result = makeBuildResult('/workspace/project', uri);
 
             (mockProvider.ownsConfig as sinon.SinonStub).returns(true);
             (mockProvider.createProject as sinon.SinonStub).returns(result);
 
-            (manager as any).registerProject(uri);
+            await (manager as any).registerProject(uri);
             (manager as any).unregisterProject(uri);
 
             expect((manager as any).providerIndexByProjectDir.has('/workspace/project')).to.be.false;
@@ -292,7 +322,7 @@ describe('RokuProjectManager', () => {
 
 
     describe('syncStatusBar', () => {
-        it('shows the item when at least one project is registered', () => {
+        it('shows the item when at least one project is registered', async () => {
             const item = { show: sinon.stub(), hide: sinon.stub() };
             (manager as any).statusBarItem = item;
 
@@ -300,7 +330,7 @@ describe('RokuProjectManager', () => {
             const result = makeBuildResult('/workspace/project', uri);
             (mockProvider.ownsConfig as sinon.SinonStub).returns(true);
             (mockProvider.createProject as sinon.SinonStub).returns(result);
-            (manager as any).registerProject(uri);
+            await (manager as any).registerProject(uri);
 
             expect(item.show.calledOnce).to.be.true;
             expect(item.hide.called).to.be.false;
@@ -319,13 +349,13 @@ describe('RokuProjectManager', () => {
             expect(() => (manager as any).syncStatusBar()).to.not.throw();
         });
 
-        it('sets brightscript.hasRokuProjects context to true when projects exist', () => {
+        it('sets brightscript.hasRokuProjects context to true when projects exist', async () => {
             const uri = makeUri('/workspace/project/bsconfig.json');
             const result = makeBuildResult('/workspace/project', uri);
 
             (mockProvider.ownsConfig as sinon.SinonStub).returns(true);
             (mockProvider.createProject as sinon.SinonStub).returns(result);
-            (manager as any).registerProject(uri);
+            await (manager as any).registerProject(uri);
 
             const executeCommand = vscode.commands.executeCommand as sinon.SinonStub;
             const hasProjectsCall = executeCommand.getCalls().find(c => c.args[1] === 'brightscript.hasRokuProjects');
@@ -378,7 +408,7 @@ describe('RokuProjectManager', () => {
 
             (mockProvider.ownsConfig as sinon.SinonStub).returns(true);
             (mockProvider.createProject as sinon.SinonStub).returns(result);
-            (manager as any).registerProject(uri);
+            await (manager as any).registerProject(uri);
 
             const configs = await manager.provideDebugConfigurations();
 
@@ -397,7 +427,7 @@ describe('RokuProjectManager', () => {
 
             (mockProvider.ownsConfig as sinon.SinonStub).returns(true);
             (mockProvider.createProject as sinon.SinonStub).returns(result);
-            (manager as any).registerProject(uri);
+            await (manager as any).registerProject(uri);
 
             const otherFolder = { uri: { fsPath: '/other' } } as any;
             expect(await manager.provideDebugConfigurations(otherFolder)).to.have.length(0);
@@ -477,6 +507,39 @@ describe('RokuProjectManager', () => {
 
             expect((vscode.window.showQuickPick as sinon.SinonStub).calledOnce).to.be.true;
             expect(config).to.deep.equal(result1.debugConfig);
+        });
+
+        it('drops a match when a higher-priority provider claims its config URI', async () => {
+            const bsConfig = makeMockProvider();
+            const brsConfig = makeMockProvider();
+            (manager as any).providers = [bsConfig, brsConfig];
+
+            const bsConfigUri = makeUri('/workspace/bsconfig.json');
+            const brsConfigUri = makeUri('/workspace/brsconfig.json');
+            const bsBuild = makeBuildResult('/workspace', bsConfigUri);
+            const brsBuild = makeBuildResult('/workspace', brsConfigUri);
+
+            (bsConfig.ownsConfig as sinon.SinonStub).withArgs(bsConfigUri).returns(true);
+            (brsConfig.ownsConfig as sinon.SinonStub).withArgs(brsConfigUri).returns(true);
+            (bsConfig.createProject as sinon.SinonStub).withArgs(bsConfigUri).returns(bsBuild);
+            (brsConfig.createProject as sinon.SinonStub).withArgs(brsConfigUri).returns(brsBuild);
+
+            // Both providers claim the active file
+            const activeFileUri = makeUri('/workspace/main.brs');
+            (vscode.window as any).activeTextEditor = {
+                document: { uri: activeFileUri }
+            };
+            (bsConfig.findProjectConfigFromFile as sinon.SinonStub).withArgs(activeFileUri).resolves([bsConfigUri]);
+            (brsConfig.findProjectConfigFromFile as sinon.SinonStub).withArgs(activeFileUri).resolves([brsConfigUri]);
+            // bsConfig also claims the brsconfig file itself, so the brsconfig match should be filtered out
+            (bsConfig.findProjectConfigFromFile as sinon.SinonStub).withArgs(brsConfigUri).resolves([bsConfigUri]);
+
+            const showQuickPickStub = sinon.stub(vscode.window, 'showQuickPick');
+
+            const config = await manager.resolveDebugConfigFromActiveFile();
+
+            expect(showQuickPickStub.called).to.be.false;
+            expect(config).to.deep.equal(bsBuild.debugConfig);
         });
 
         it('returns undefined when the quick pick is dismissed', async () => {

--- a/src/managers/RokuProject/RokuProjectManager.spec.ts
+++ b/src/managers/RokuProject/RokuProjectManager.spec.ts
@@ -281,6 +281,87 @@ describe('RokuProjectManager', () => {
     });
 
 
+    describe('scheduleResync + idempotency', () => {
+        it('re-registers a previously-suppressed manifest once the higher-priority project is unregistered and a sync runs', async () => {
+            const bsConfig = makeMockProvider();
+            const manifest = makeMockProvider();
+            (manager as any).providers = [bsConfig, manifest];
+
+            const bsConfigUri = makeUri('/workspace/bsconfig.json');
+            const manifestUri = makeUri('/workspace/manifest');
+            const bsConfigBuild = makeBuildResult('/workspace', bsConfigUri);
+            const manifestBuild = makeBuildResult('/workspace', manifestUri);
+
+            // Toggle the bsConfig "alive" state from the test so the same stubs respond differently
+            // before vs. after unregistration.
+            let bsConfigPresent = true;
+
+            (bsConfig.ownsConfig as sinon.SinonStub).callsFake((uri: any) => uri === bsConfigUri);
+            (bsConfig.createProject as sinon.SinonStub).returns(bsConfigBuild);
+            (bsConfig.findProjectConfigs as sinon.SinonStub).callsFake(() => Promise.resolve(bsConfigPresent ? [bsConfigUri] : []));
+            (bsConfig.findProjectConfigFromFile as sinon.SinonStub).callsFake((uri: any) => {
+                return Promise.resolve(bsConfigPresent && uri === manifestUri ? [bsConfigUri] : []);
+            });
+
+            (manifest.ownsConfig as sinon.SinonStub).callsFake((uri: any) => uri === manifestUri);
+            (manifest.createProject as sinon.SinonStub).returns(manifestBuild);
+            (manifest.findProjectConfigs as sinon.SinonStub).resolves([manifestUri]);
+
+            await (manager as any).syncProjects();
+
+            // Sanity: only bsConfig is registered, manifest got suppressed.
+            expect((manager as any).providerIndexByProjectDir.get('/workspace')).to.equal(0);
+            expect((manifest.afterConfigRegistered as sinon.SinonStub).called).to.be.false;
+
+            // Now bsConfig disappears (e.g. user renames brsconfig.json off-pattern).
+            (manager as any).unregisterProject(bsConfigUri);
+            bsConfigPresent = false;
+
+            // Resync (what scheduleResync ends up running on debounce timeout).
+            await (manager as any).syncProjects();
+
+            // The manifest should now be registered.
+            expect((manager as any).providerIndexByProjectDir.get('/workspace')).to.equal(1);
+            expect((manifest.afterConfigRegistered as sinon.SinonStub).calledOnceWith(manifestUri)).to.be.true;
+        });
+
+        it('registerProject is idempotent: a second register for the same project dir is a no-op', async () => {
+            const uri = makeUri('/workspace/project/bsconfig.json');
+            const result = makeBuildResult('/workspace/project', uri);
+
+            (mockProvider.ownsConfig as sinon.SinonStub).returns(true);
+            (mockProvider.createProject as sinon.SinonStub).returns(result);
+
+            await (manager as any).registerProject(uri);
+            const tasksBefore = taskRegistry.registerTask.callCount;
+            const afterRegisteredBefore = (mockProvider.afterConfigRegistered as sinon.SinonStub).callCount;
+
+            await (manager as any).registerProject(uri);
+
+            expect(taskRegistry.registerTask.callCount).to.equal(tasksBefore);
+            expect((mockProvider.afterConfigRegistered as sinon.SinonStub).callCount).to.equal(afterRegisteredBefore);
+        });
+
+        it('scheduleResync coalesces rapid calls into a single syncProjects after the debounce window', () => {
+            const clock = sinon.useFakeTimers();
+            const syncStub = sinon.stub(manager as any, 'syncProjects').resolves();
+
+            (manager as any).scheduleResync();
+            (manager as any).scheduleResync();
+            (manager as any).scheduleResync();
+
+            // Before the debounce expires, no sync has run yet.
+            expect(syncStub.called).to.be.false;
+
+            // Advance past the debounce window (resyncDebounceMs is 250).
+            clock.tick(300);
+
+            expect(syncStub.calledOnce).to.be.true;
+            clock.restore();
+        });
+    });
+
+
     describe('syncProjects', () => {
         it('calls findProjectConfigs on every provider and registers each URI', async () => {
             const uri1 = makeUri('/workspace/a/bsconfig.json');

--- a/src/managers/RokuProject/RokuProjectManager.ts
+++ b/src/managers/RokuProject/RokuProjectManager.ts
@@ -57,6 +57,10 @@ export class RokuProjectManager {
                     watcher.onDidDelete(uri => {
                         if (!isExcluded(uri)) {
                             this.unregisterProject(uri);
+                            // A previously-suppressed lower-priority project (e.g. a manifest beside
+                            // the just-deleted bsconfig) may now be eligible. Debounced so a rapid
+                            // delete/create rename pair only triggers one resync.
+                            this.scheduleResync();
                         }
                     }),
                     watcher.onDidChange(uri => {
@@ -171,6 +175,12 @@ export class RokuProjectManager {
         const provider = this.providers[providerIndex];
         const { taskName, taskConfig, project } = provider.createProject(uri);
 
+        // Idempotent: another project (typically registered via refreshLowerPriorityRegistrations
+        // or a duplicate watcher event) already owns this dir. Skip without re-firing side effects.
+        if (this.discoveredProjects.has(project.projectDir)) {
+            return;
+        }
+
         if (await this.isSupersededByHigherPriorityProvider(uri, providerIndex, project.projectDir)) {
             return;
         }
@@ -183,6 +193,27 @@ export class RokuProjectManager {
         this.viewProvider?.setProjects(Array.from(this.discoveredProjects.values()));
         this.syncStatusBar();
         provider.afterConfigRegistered?.(uri);
+    }
+
+    /** Debounce window before a queued resync actually runs, to coalesce delete+create rename pairs and bursts of file events. */
+    private static readonly resyncDebounceMs = 250;
+    private resyncTimer: ReturnType<typeof setTimeout> | undefined;
+
+    /**
+     * Schedules a debounced syncProjects() so previously-suppressed lower-priority projects can
+     * surface after a higher-priority config is removed. Idempotency in registerProject keeps this
+     * safe — already-registered projects are no-ops.
+     */
+    private scheduleResync(): void {
+        if (this.resyncTimer) {
+            clearTimeout(this.resyncTimer);
+        }
+        this.resyncTimer = setTimeout(() => {
+            this.resyncTimer = undefined;
+            this.syncProjects().catch(err => {
+                console.error('Error during scheduled resync of Roku projects:', err);
+            });
+        }, RokuProjectManager.resyncDebounceMs);
     }
 
     /**

--- a/src/managers/RokuProject/RokuProjectManager.ts
+++ b/src/managers/RokuProject/RokuProjectManager.ts
@@ -47,7 +47,9 @@ export class RokuProjectManager {
                     watcher,
                     watcher.onDidCreate(uri => {
                         if (!isExcluded(uri)) {
-                            this.registerProject(uri);
+                            this.registerProject(uri).catch(err => {
+                                console.error('Error registering Roku project:', err);
+                            });
                         }
                     }),
                     watcher.onDidDelete(uri => {
@@ -59,7 +61,9 @@ export class RokuProjectManager {
                         if (!isExcluded(uri)) {
                             // rebuilds the project from the updated file
                             this.unregisterProject(uri);
-                            this.registerProject(uri);
+                            this.registerProject(uri).catch(err => {
+                                console.error('Error registering Roku project after change:', err);
+                            });
                         }
                     })
                 );
@@ -91,10 +95,10 @@ export class RokuProjectManager {
                 // filter down to only the URIs that belong to the folder being added.
                 for (const added of event.added) {
                     for (const provider of this.providers) {
-                        Promise.resolve(provider.findProjectConfigs()).then(uris => {
+                        Promise.resolve(provider.findProjectConfigs()).then(async uris => {
                             for (const uri of uris) {
                                 if (isSubdirectoryOf(added.uri.fsPath, uri.fsPath)) {
-                                    this.registerProject(uri);
+                                    await this.registerProject(uri);
                                 }
                             }
                         }).catch((err: unknown) => {
@@ -149,7 +153,7 @@ export class RokuProjectManager {
             for (const provider of this.providers) {
                 const uris = await provider.findProjectConfigs();
                 for (const uri of uris) {
-                    this.registerProject(uri);
+                    await this.registerProject(uri);
                 }
             }
         } finally {
@@ -157,7 +161,7 @@ export class RokuProjectManager {
         }
     }
 
-    private registerProject(uri: vscode.Uri) {
+    private async registerProject(uri: vscode.Uri) {
         const providerIndex = this.providers.findIndex(configProvider => configProvider.ownsConfig(uri));
         if (providerIndex === -1) {
             return;
@@ -165,11 +169,8 @@ export class RokuProjectManager {
         const provider = this.providers[providerIndex];
         const { taskName, taskConfig, project } = provider.createProject(uri);
 
-        // Skip if a higher-priority provider (lower index) already owns an ancestor directory.
-        for (const [claimedDir, claimedIndex] of this.providerIndexByProjectDir) {
-            if (claimedIndex < providerIndex && isSubdirectoryOf(claimedDir, project.projectDir)) {
-                return;
-            }
+        if (await this.isSupersededByHigherPriorityProvider(uri, providerIndex, project.projectDir)) {
+            return;
         }
 
         if (taskName) {
@@ -180,6 +181,26 @@ export class RokuProjectManager {
         this.viewProvider?.setProjects(Array.from(this.discoveredProjects.values()));
         this.syncStatusBar();
         provider.afterConfigRegistered?.(uri);
+    }
+
+    /**
+     * Returns true if a higher-priority (lower-index) provider already owns this project's
+     * territory. Cheap dir-overlap check first, then falls back to the more expensive
+     * cross-provider claim query so most calls short-circuit without IO.
+     */
+    private async isSupersededByHigherPriorityProvider(uri: vscode.Uri, providerIndex: number, projectDir: string): Promise<boolean> {
+        for (const [claimedDir, claimedIndex] of this.providerIndexByProjectDir) {
+            if (claimedIndex < providerIndex && isSubdirectoryOf(claimedDir, projectDir)) {
+                return true;
+            }
+        }
+        for (let higherIndex = 0; higherIndex < providerIndex; higherIndex++) {
+            const claims = await this.providers[higherIndex].findProjectConfigFromFile(uri);
+            if (claims.length > 0) {
+                return true;
+            }
+        }
+        return false;
     }
 
     private unregisterProject(uri: vscode.Uri) {
@@ -242,16 +263,30 @@ export class RokuProjectManager {
             allMatches.push(...uris);
         }
 
-        if (allMatches.length === 0) {
+        // Mirror registerProject's precedence so F5 silently picks the richer config
+        // (e.g. bsconfig.json wins over a manifest it already owns).
+        const filteredMatches: vscode.Uri[] = [];
+        for (const uri of allMatches) {
+            const providerIndex = this.providers.findIndex(configProvider => configProvider.ownsConfig(uri));
+            if (providerIndex === -1) {
+                continue;
+            }
+            const projectDir = this.providers[providerIndex].createProject(uri).project.projectDir;
+            if (!(await this.isSupersededByHigherPriorityProvider(uri, providerIndex, projectDir))) {
+                filteredMatches.push(uri);
+            }
+        }
+
+        if (filteredMatches.length === 0) {
             return undefined;
         }
 
         let targetUri: vscode.Uri;
-        if (allMatches.length === 1) {
-            targetUri = allMatches[0];
+        if (filteredMatches.length === 1) {
+            targetUri = filteredMatches[0];
         } else {
             const multiRoot = (vscode.workspace.workspaceFolders?.length ?? 0) > 1;
-            const items = allMatches.map(uri => {
+            const items = filteredMatches.map(uri => {
                 const provider = this.providers.find(configProvider => configProvider.ownsConfig(uri));
                 return {
                     label: provider?.createProject(uri).debugConfig.name ?? path.basename(path.dirname(uri.fsPath)),

--- a/src/managers/RokuProject/RokuProjectManager.ts
+++ b/src/managers/RokuProject/RokuProjectManager.ts
@@ -4,6 +4,7 @@ import type { BrightScriptTaskProvider, TaskConfig } from '../../BrightScriptTas
 import type { RokuProjectsViewProvider } from '../../viewProviders/RokuProjectsViewProvider';
 import { BrsConfigProjectProvider } from './BrsConfigProjectProvider';
 import { BsConfigProjectProvider } from './BsConfigProjectProvider';
+import { ManifestProjectProvider } from './ManifestProjectProvider';
 import { VscodeCommand } from '../../commands/VscodeCommand';
 import { util } from '../../util';
 
@@ -23,7 +24,8 @@ export class RokuProjectManager {
 
     private readonly providers: ProjectConfigProvider[] = [
         new BsConfigProjectProvider(),
-        new BrsConfigProjectProvider()
+        new BrsConfigProjectProvider(),
+        new ManifestProjectProvider()
     ];
 
     public register(context: vscode.ExtensionContext) {


### PR DESCRIPTION
## Summary

- New `ManifestProjectProvider` discovers Roku channels by scanning for `manifest` files with an adjacent `source/` or `components/` dir (the Roku-shape signal). Registered at the lowest priority in the providers array so bsconfig and brsconfig naturally win when they coexist.
- New static `BrightScriptDebugConfigurationProvider.defaultFiles` is now the canonical files list — replaces roku-deploy's `DefaultFiles` for both the launch config defaults and the component-library defaults. Doc-URL backed: `manifest`, `source/`, `components/`, `images/`, `locale/`, `fonts/`, `componentLibraries/`.
- The manifest provider uses `defaultFiles` for both its launch config AND for `findProjectConfigFromFile` ownership (via `rokuDeploy.getDestPath`), so a manifest project only claims files matching the channel's deployable globs.
- Extends `RokuProjectManager`'s precedence check with a cross-provider claim query: when a lower-priority provider's config URI is owned (as a file) by a higher-priority provider's project, the lower-priority registration is suppressed. Cheap dir-overlap check first, then the dig. Required so a manifest beside a bsconfig that already includes it doesn't get surfaced as a duplicate project. Same filtering applies to F5's `resolveDebugConfigFromActiveFile` so the picker stays consistent with registration.