### PR TITLE
Device Manager network change update

### DIFF
--- a/src/deviceDiscovery/DeviceManager.spec.ts
+++ b/src/deviceDiscovery/DeviceManager.spec.ts
@@ -63,7 +63,8 @@ describe('DeviceManager', () => {
     function addDiscoveredDevice(device: RokuDevice): void {
         manager['discoveredDevices'].push({
             ip: device.ip,
-            serialNumber: device.serialNumber
+            serialNumber: device.serialNumber,
+            networkId: manager['networkId']
         });
         // Set the device state in the separate state map
         manager['setDeviceState']({ ip: device.ip, serialNumber: device.serialNumber }, device.deviceState === 'offline' ? 'pending' : device.deviceState);
@@ -1212,7 +1213,8 @@ describe('DeviceManager', () => {
             // Add device without developer-enabled in deviceInfo (unknown status)
             manager['discoveredDevices'].push({
                 ip: '192.168.1.100',
-                serialNumber: 'ABC123'
+                serialNumber: 'ABC123',
+                networkId: manager['networkId']
             });
             manager['setDeviceState']({ ip: '192.168.1.100', serialNumber: 'ABC123' }, 'online');
 
@@ -1284,7 +1286,8 @@ describe('DeviceManager', () => {
             // Add device without developer-enabled
             manager['discoveredDevices'].push({
                 ip: '192.168.1.100',
-                serialNumber: 'ABC123'
+                serialNumber: 'ABC123',
+                networkId: manager['networkId']
             });
             manager['setDeviceState']({ ip: '192.168.1.100', serialNumber: 'ABC123' }, 'online');
 
@@ -1576,7 +1579,7 @@ describe('DeviceManager', () => {
         it('health-checks discovered devices that have no serial number', async () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
-            manager['discoveredDevices'].push({ ip: '192.168.1.100' });
+            manager['discoveredDevices'].push({ ip: '192.168.1.100', networkId: manager['networkId'] });
 
             const healthCheckStub = sinon.stub(manager, 'healthCheckDevice').resolves(true);
 
@@ -1591,7 +1594,7 @@ describe('DeviceManager', () => {
         it('health-checks discovered devices that have a serial but no cache entry', async () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
-            manager['discoveredDevices'].push({ ip: '192.168.1.101', serialNumber: 'no-cache-serial' });
+            manager['discoveredDevices'].push({ ip: '192.168.1.101', serialNumber: 'no-cache-serial', networkId: manager['networkId'] });
 
             const healthCheckStub = sinon.stub(manager, 'healthCheckDevice').resolves(true);
 
@@ -1610,7 +1613,7 @@ describe('DeviceManager', () => {
                 deviceInfo: { 'default-device-name': 'Cached Roku' },
                 createdAt: Date.now()
             });
-            manager['discoveredDevices'].push({ ip: '192.168.1.102', serialNumber: 'cached-serial' });
+            manager['discoveredDevices'].push({ ip: '192.168.1.102', serialNumber: 'cached-serial', networkId: manager['networkId'] });
 
             const healthCheckStub = sinon.stub(manager, 'healthCheckDevice').resolves(true);
 
@@ -1629,9 +1632,9 @@ describe('DeviceManager', () => {
                 createdAt: Date.now()
             });
             manager['discoveredDevices'].push(
-                { ip: '192.168.1.100', serialNumber: 'cached-serial' },
-                { ip: '192.168.1.101', serialNumber: 'uncached-serial' },
-                { ip: '192.168.1.102' }
+                { ip: '192.168.1.100', serialNumber: 'cached-serial', networkId: manager['networkId'] },
+                { ip: '192.168.1.101', serialNumber: 'uncached-serial', networkId: manager['networkId'] },
+                { ip: '192.168.1.102', networkId: manager['networkId'] }
             );
 
             const healthCheckStub = sinon.stub(manager, 'healthCheckDevice').resolves(true);
@@ -1663,8 +1666,8 @@ describe('DeviceManager', () => {
                 serialNumber: 'serial-b', deviceInfo: {}, createdAt: Date.now()
             });
             manager['discoveredDevices'].push(
-                { ip: '192.168.1.100', serialNumber: 'serial-a' },
-                { ip: '192.168.1.101', serialNumber: 'serial-b' }
+                { ip: '192.168.1.100', serialNumber: 'serial-a', networkId: manager['networkId'] },
+                { ip: '192.168.1.101', serialNumber: 'serial-b', networkId: manager['networkId'] }
             );
 
             const healthCheckStub = sinon.stub(manager, 'healthCheckDevice').resolves(true);
@@ -1678,9 +1681,9 @@ describe('DeviceManager', () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
             manager['discoveredDevices'].push(
-                { ip: '192.168.1.100' },
-                { ip: '192.168.1.101' },
-                { ip: '192.168.1.102' }
+                { ip: '192.168.1.100', networkId: manager['networkId'] },
+                { ip: '192.168.1.101', networkId: manager['networkId'] },
+                { ip: '192.168.1.102', networkId: manager['networkId'] }
             );
 
             // Resolve health checks only after all three have been kicked off
@@ -1708,8 +1711,8 @@ describe('DeviceManager', () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
             manager['discoveredDevices'].push(
-                { ip: '192.168.1.100' },
-                { ip: '192.168.1.101' }
+                { ip: '192.168.1.100', networkId: manager['networkId'] },
+                { ip: '192.168.1.101', networkId: manager['networkId'] }
             );
 
             const healthCheckStub = sinon.stub(manager, 'healthCheckDevice');
@@ -1725,7 +1728,7 @@ describe('DeviceManager', () => {
         it('is triggered by notifyFocusGained', () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
-            manager['discoveredDevices'].push({ ip: '192.168.1.100' });
+            manager['discoveredDevices'].push({ ip: '192.168.1.100', networkId: manager['networkId'] });
 
             const healthCheckStub = sinon.stub(manager, 'healthCheckDevice').resolves(true);
 
@@ -1945,16 +1948,18 @@ describe('DeviceManager', () => {
             expect(manager['networkId']).to.equal('new-network-hash');
         });
 
-        it('reloads devices when network changes', () => {
+        it('marks discovered devices as pending when network changes', () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
-            // Add a discovered device to verify it gets cleared on network change
+            // Add a discovered device to verify it gets marked pending on network change
             manager['discoveredDevices'].push({
                 serialNumber: 'device-123',
-                ip: '192.168.1.100'
+                ip: '192.168.1.100',
+                networkId: manager['networkId']
             });
             manager['setDeviceState']({ serialNumber: 'device-123', ip: '192.168.1.100' }, 'online');
             expect(manager['discoveredDevices'].length).to.equal(1);
+            expect(manager['discoveredDevices'][0].state).to.equal('online');
 
             // Change the network hash
             (NetworkChangeMonitorModule.getNetworkHash as sinon.SinonStub).returns('new-network-hash');
@@ -1962,8 +1967,9 @@ describe('DeviceManager', () => {
             // Trigger the network change callback directly
             manager['networkChangeMonitor']['onNetworkChanged']();
 
-            // Discovered device should be removed (loadLastSeenDevices clears discoveredDevices)
-            expect(manager['discoveredDevices'].length).to.equal(0);
+            // Discovered device should be marked pending (health check will verify reachability)
+            expect(manager['discoveredDevices'].length).to.equal(1);
+            expect(manager['discoveredDevices'][0].state).to.equal('pending');
         });
 
         it('calls setScanNeeded when network changes', () => {
@@ -1980,18 +1986,20 @@ describe('DeviceManager', () => {
             expect(setScanNeededSpy.calledOnce).to.be.true;
         });
 
-        it('clears discovered devices when network changes', () => {
+        it('marks all discovered devices as pending when network changes', () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
             // Add discovered devices
             manager['discoveredDevices'].push({
                 serialNumber: 'device-123',
-                ip: '192.168.1.100'
+                ip: '192.168.1.100',
+                networkId: manager['networkId']
             });
             manager['setDeviceState']({ serialNumber: 'device-123', ip: '192.168.1.100' }, 'online');
             manager['discoveredDevices'].push({
                 serialNumber: 'device-456',
-                ip: '192.168.1.101'
+                ip: '192.168.1.101',
+                networkId: manager['networkId']
             });
             manager['setDeviceState']({ serialNumber: 'device-456', ip: '192.168.1.101' }, 'online');
             expect(manager['discoveredDevices'].length).to.equal(2);
@@ -2002,11 +2010,13 @@ describe('DeviceManager', () => {
             // Trigger the network change callback directly
             manager['networkChangeMonitor']['onNetworkChanged']();
 
-            // Discovered devices should be cleared
-            expect(manager['discoveredDevices'].length).to.equal(0);
+            // Discovered devices should be marked pending (not immediately cleared)
+            expect(manager['discoveredDevices'].length).to.equal(2);
+            expect(manager['discoveredDevices'][0].state).to.equal('pending');
+            expect(manager['discoveredDevices'][1].state).to.equal('pending');
         });
 
-        it('preserves configured devices when network changes', () => {
+        it('marks configured and discovered devices as pending when network changes', () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
             // Add a configured device
@@ -2019,7 +2029,8 @@ describe('DeviceManager', () => {
             // Add a discovered device
             manager['discoveredDevices'].push({
                 serialNumber: 'device-123',
-                ip: '192.168.1.101'
+                ip: '192.168.1.101',
+                networkId: manager['networkId']
             });
             manager['setDeviceState']({ serialNumber: 'device-123', ip: '192.168.1.101' }, 'online');
 
@@ -2032,9 +2043,27 @@ describe('DeviceManager', () => {
             // Trigger the network change callback directly
             manager['networkChangeMonitor']['onNetworkChanged']();
 
-            // Configured device should persist, discovered should be cleared
+            // Both should persist but be marked pending
             expect(manager['configuredDevices'].length).to.equal(1);
-            expect(manager['discoveredDevices'].length).to.equal(0);
+            expect(manager['configuredDevices'][0].state).to.equal('pending');
+            expect(manager['discoveredDevices'].length).to.equal(1);
+            expect(manager['discoveredDevices'][0].state).to.equal('pending');
+        });
+
+        it('calls healthCheckAllDevices when network changes', () => {
+            manager = new DeviceManager(vscode.context, mockGlobalStateManager);
+
+            const healthCheckAllStub = sinon.stub(manager as any, 'healthCheckAllDevices').resolves();
+
+            // Change the network hash
+            (NetworkChangeMonitorModule.getNetworkHash as sinon.SinonStub).returns('new-network-hash');
+
+            // Trigger the network change callback directly
+            manager['networkChangeMonitor']['onNetworkChanged']();
+
+            expect(healthCheckAllStub.calledOnce).to.be.true;
+            expect(healthCheckAllStub.firstCall.args[0]).to.equal(true); // force = true
+            expect(healthCheckAllStub.firstCall.args[1]).to.equal(false); // doSyntheticDelay = false
         });
     });
 
@@ -2762,7 +2791,8 @@ describe('DeviceManager', () => {
                 // Create device without serial - manually add to discovered array
                 manager['discoveredDevices'].push({
                     ip: '192.168.1.100',
-                    serialNumber: undefined
+                    serialNumber: undefined,
+                    networkId: manager['networkId']
                 });
                 manager['setDeviceState']({ ip: '192.168.1.100' }, 'online');
 
@@ -2916,7 +2946,8 @@ describe('DeviceManager', () => {
                 // Start with device that has no serial
                 manager['discoveredDevices'].push({
                     ip: '192.168.1.100',
-                    serialNumber: undefined
+                    serialNumber: undefined,
+                    networkId: manager['networkId']
                 });
                 manager['setDeviceState']({ ip: '192.168.1.100' }, 'online');
 
@@ -3391,7 +3422,8 @@ describe('DeviceManager', () => {
                 // Add discovered device with serial
                 manager['discoveredDevices'].push({
                     ip: '192.168.1.100',
-                    serialNumber: 'DISCOVERED-SERIAL'
+                    serialNumber: 'DISCOVERED-SERIAL',
+                    networkId: manager['networkId']
                 });
 
                 const result = manager['checkForSerialMismatch']('192.168.1.100', 'NEW-SERIAL');
@@ -3585,7 +3617,8 @@ describe('DeviceManager', () => {
 
                 manager['discoveredDevices'].push({
                     serialNumber: 'abc',
-                    ip: '10.0.0.5'
+                    ip: '10.0.0.5',
+                    networkId: manager['networkId']
                 });
                 manager['setDeviceState']({ serialNumber: 'abc', ip: '10.0.0.5' }, 'online');
 
@@ -3614,7 +3647,8 @@ describe('DeviceManager', () => {
 
                 manager['discoveredDevices'].push({
                     serialNumber: 'abc',
-                    ip: '10.0.0.5'
+                    ip: '10.0.0.5',
+                    networkId: manager['networkId']
                 });
                 manager['setDeviceState']({ serialNumber: 'abc', ip: '10.0.0.5' }, 'online');
 
@@ -3631,7 +3665,8 @@ describe('DeviceManager', () => {
                 // Discovered device without password
                 manager['discoveredDevices'].push({
                     serialNumber: 'no-pw',
-                    ip: '10.0.0.5'
+                    ip: '10.0.0.5',
+                    networkId: manager['networkId']
                 });
                 manager['setDeviceState']({ serialNumber: 'no-pw', ip: '10.0.0.5' }, 'online');
                 // Configured device with specific password
@@ -3655,7 +3690,8 @@ describe('DeviceManager', () => {
 
                 manager['discoveredDevices'].push({
                     serialNumber: 'abc',
-                    ip: '10.0.0.5'
+                    ip: '10.0.0.5',
+                    networkId: manager['networkId']
                 });
                 manager['setDeviceState']({ serialNumber: 'abc', ip: '10.0.0.5' }, 'online');
 

--- a/src/deviceDiscovery/DeviceManager.ts
+++ b/src/deviceDiscovery/DeviceManager.ts
@@ -93,14 +93,11 @@ export class DeviceManager {
         this.systemSleepMonitor = new SystemSleepMonitor(() => {
             this.setScanNeeded();
         });
-        this.networkChangeMonitor = new NetworkChangeMonitor(() => {
-            this.networkId = getNetworkHash();
+        this.networkChangeMonitor = new NetworkChangeMonitor((networkHash) => {
+            this.networkId = networkHash;
 
             //restart finder for new network interfaces
             this.restartRokuFinder();
-
-            //health check all devices (sets them to pending, unreachable ones will be removed)
-            this.healthCheckAllDevices(true, false).catch(() => {});
 
             //trigger scan to find devices on new network
             this.setScanNeeded();
@@ -1010,7 +1007,7 @@ export class DeviceManager {
         }
 
         // Cooldown is handled by fetchDeviceInfo cache
-        await Promise.all([...staleIps].map(ip => this.resolveDevice({ ip: ip }, false)));
+        await Promise.all([...staleIps].map(ip => this.resolveDevice({ ip: ip }, false, true)));
     }
 
     /**

--- a/src/deviceDiscovery/DeviceManager.ts
+++ b/src/deviceDiscovery/DeviceManager.ts
@@ -96,19 +96,13 @@ export class DeviceManager {
         this.networkChangeMonitor = new NetworkChangeMonitor(() => {
             this.networkId = getNetworkHash();
 
-            //reset all configured device states to unknown - need to re-verify on new network
-            for (const entry of this.configuredDevices) {
-                entry.state = 'unknown';
-                entry.stateLastUpdated = Date.now();
-            }
-
-            //clear and reload discovered devices anytime this network changes (state goes with them)
-            this.discoveredDevices = [];
-            this.loadLastSeenDevices();
-
+            //restart finder for new network interfaces
             this.restartRokuFinder();
 
-            //this is important for telling the devices view to refresh and health check its devices
+            //health check all devices (sets them to pending, unreachable ones will be removed)
+            this.healthCheckAllDevices(true, false).catch(() => {});
+
+            //trigger scan to find devices on new network
             this.setScanNeeded();
         });
     }
@@ -1087,16 +1081,18 @@ export class DeviceManager {
         const existing = existingIdx >= 0 ? this.discoveredDevices[existingIdx] : undefined;
 
         if (existing) {
-            // Update existing entry
+            // Update existing entry (update networkId to current network)
             this.discoveredDevices[existingIdx] = {
                 ip: ip,
-                serialNumber: serialNumber ?? existing.serialNumber
+                serialNumber: serialNumber ?? existing.serialNumber,
+                networkId: this.networkId
             };
         } else {
             // Add new entry
             this.discoveredDevices.push({
                 ip: ip,
-                serialNumber: serialNumber
+                serialNumber: serialNumber,
+                networkId: this.networkId
             });
         }
 
@@ -1465,6 +1461,10 @@ interface DiscoveredDeviceEntry {
      * Timestamp of last state update
      */
     stateLastUpdated?: number;
+    /**
+     * Network ID where this device was discovered
+     */
+    networkId: string;
 }
 
 /**

--- a/src/deviceDiscovery/NetworkChangeMonitor.ts
+++ b/src/deviceDiscovery/NetworkChangeMonitor.ts
@@ -34,7 +34,7 @@ export function getNetworkHash(): string {
  */
 export class NetworkChangeMonitor {
 
-    private onNetworkChanged: () => void;
+    private onNetworkChanged: (networkHash: string) => void;
     private timer: NodeJS.Timeout | null = null;
     private lastExecutionTime = 0;
     private currentHash: string;
@@ -47,7 +47,7 @@ export class NetworkChangeMonitor {
 
     private systemSleepMonitor: SystemSleepMonitor;
 
-    constructor(onNetworkChanged: () => void) {
+    constructor(onNetworkChanged: (networkHash: string) => void) {
         this.onNetworkChanged = onNetworkChanged;
         this.currentHash = getNetworkHash();
 
@@ -103,10 +103,10 @@ export class NetworkChangeMonitor {
     }
 
     private checkForNetworkChange() {
-        const hash = getNetworkHash();
+        const hash = getNetworkHash() + Date.now();
         if (hash !== this.currentHash) {
             this.currentHash = hash;
-            this.onNetworkChanged();
+            this.onNetworkChanged(hash);
         }
     }
 


### PR DESCRIPTION
When we detect a network change, health check all the devices and set that we need a scan.

This should prevent an annoying UX bug where the devices disappear randomly for a second and come back.

We are storing the current network ID on a discovered device so that when we snapshot the last seen devices we will be able to filter out previous networked devices.