### PR TITLE
Accept GHSA-w5hq-g745-h8pq (uuid <11.1.1) advisory

### DIFF
--- a/audit-ci.jsonc
+++ b/audit-ci.jsonc
@@ -10,6 +10,13 @@
                 "active": true,
                 "notes": "`ip` (via `node-ssdp`): no fixed version published. `ip` is only used by `node-ssdp` for local-network Roku discovery; no untrusted input flows into `ip.isPublic()` in any path we control."
             }
+        },
+        {
+            "GHSA-w5hq-g745-h8pq": {
+                // Added: 2026-05-22
+                "active": true,
+                "notes": "`uuid` <11.1.1 (via direct dep, `postman-request`, `node-notifier`, and dev-only `nyc>istanbul-lib-processinfo`): vulnerable code path is `v3()`/`v5()`/`v6()` when a caller-provided buffer is passed. Every consumer (including our own `src/viewProviders/RokuAppOverlaysViewViewProvider.ts`) calls only `v4()` with no buffer arg, so the vulnerable path is unreachable."
+            }
         }
     ]
 }


### PR DESCRIPTION
## Summary

- Adds GHSA-w5hq-g745-h8pq (`uuid` <11.1.1, missing buffer bounds check in `v3()`/`v5()`/`v6()`) to the existing audit-ci allowlist.

## Why it's safe to defer

The vulnerable code path is `v3()`/`v5()`/`v6()` when a caller-provided output buffer is passed. Every consumer in this dep graph (the repo's direct `uuid` dep used in `src/viewProviders/RokuAppOverlaysViewViewProvider.ts`, `postman-request`, `node-notifier`, and dev-only `nyc>istanbul-lib-processinfo`) calls only `v4()` with no buffer arg, so the vulnerable path is unreachable. See `audit-ci.jsonc` for the exact reasoning.