### PR TITLE
Fix blank webview panels under Svelte 5 by enabling component API v4 compatibility

### DIFF
--- a/webviews/svelte.config.js
+++ b/webviews/svelte.config.js
@@ -4,6 +4,10 @@ export default {
     // Consult https://svelte.dev/docs#compile-time-svelte-preprocess
     // for more information about preprocessors
     preprocess: vitePreprocess(),
+    compilerOptions: {
+        // Keep Svelte-4-style `new Component({ target })` bootstrap in main.ts working under Svelte 5
+        compatibility: { componentApi: 4 }
+    },
     onwarn: (warning, handler) => {
         if (warning.code.startsWith('a11y-')) {
             return;


### PR DESCRIPTION
## Summary
- Webview side panels (Roku Device View, Roku File System, Roku App Overlays, Roku Registry, Roku Commands, Roku Automation, Roku REPL, SceneGraph Inspector) render blank in 2.66.0.
- Caused by the svelte 3 → 5 dependency bump in #794: `webviews/src/main.ts:39` still uses the Svelte-4 class API (`new views[viewName]({ target: document.body })`), which throws `component_api_invalid_new` at runtime in Svelte 5.
- Fix: enable `compilerOptions.compatibility.componentApi: 4` in `webviews/svelte.config.js`. The bundle now goes through Svelte 5's legacy `createClassComponent` shim, so the existing bootstrap keeps working.

Verified locally that `npm run build` succeeds and the compiled bundle emits the `if (new.target) return createClassComponent(...)` legacy-adapter path.

## Test plan
- [x] `npm run build` succeeds.
- [x] Start a BrightScript debug session against a device.
- [x] Confirm Roku Device View, Roku File System, Roku App Overlays render content (not blank).
- [x] Confirm Roku Registry, Roku Commands, Roku Automation, Roku REPL, SceneGraph Inspector also render.

## Follow-ups (out of scope for this PR)
- Migrate `webviews/src/main.ts` to Svelte 5's `mount(Component, { target })` API.
- Address remaining Svelte 5 warnings: self-closing non-void elements (e.g. `<div ... />`, `<vscode-checkbox ... />`), `on:click` → `onclick`, `export let` → `\$props()`.

🤖 In help with [Claude Code](https://claude.com/claude-code)