### PR TITLE
Accept GHSA-q8mj-m7cp-5q26 (qs DoS via postman-request) advisory

### DIFF
--- a/audit-ci.jsonc
+++ b/audit-ci.jsonc
@@ -17,6 +17,13 @@
                 "active": true,
                 "notes": "`uuid` <11.1.1 (via direct dep, `postman-request`, `node-notifier`, and dev-only `nyc>istanbul-lib-processinfo`): vulnerable code path is `v3()`/`v5()`/`v6()` when a caller-provided buffer is passed. Every consumer (including our own `src/viewProviders/RokuAppOverlaysViewViewProvider.ts`) calls only `v4()` with no buffer arg, so the vulnerable path is unreachable."
             }
+        },
+        {
+            "GHSA-q8mj-m7cp-5q26": {
+                // Added: 2026-05-26
+                "active": true,
+                "notes": "`qs` 6.11.1-6.15.1 (via `postman-request`'s `~6.14.1` pin; transitive through `roku-debug`, `roku-deploy`, `roku-test-automation`): DoS in `qs.stringify` triggered only when called with `arrayFormat: 'comma'` + `encodeValuesOnly: true` and null/undefined entries. `postman-request` is used only for local-network Roku HTTP calls and does not invoke `qs.stringify` with that option combo. Latest `postman-request@2.88.1-postman.48` still pins `qs ~6.14.1`, so there is no upstream fix; `npm audit fix` downgrades `postman-request` and `uuid` significantly, which is a worse outcome."
+            }
         }
     ]
 }


### PR DESCRIPTION
## Summary
Allowlist `GHSA-q8mj-m7cp-5q26` (qs 6.11.1–6.15.1 DoS) in [audit-ci.jsonc](audit-ci.jsonc). Reaches us only via `postman-request`'s `~6.14.1` pin (direct + transitive through `roku-debug`, `roku-deploy`, `roku-test-automation`).

The crash requires `qs.stringify` called with `arrayFormat: 'comma'` + `encodeValuesOnly: true` and null/undefined entries; `postman-request` does not use that option combo, and it's only used for local-network Roku HTTP calls. Latest `postman-request@2.88.1-postman.48` still pins `qs ~6.14.1`, so there's no upstream fix. `npm audit fix` downgrades `postman-request` and `uuid` to much older versions, which is a worse outcome than accepting this advisory.