### PR TITLE
Update minimum audit threshold

### DIFF
--- a/audit-ci.jsonc
+++ b/audit-ci.jsonc
@@ -1,8 +1,8 @@
 {
-    // Fail on moderate severity and above. See README "Accepted security advisories" for
+    // Fail on high severity and above. See README "Accepted security advisories" for
     // why each allowlisted entry is safe to defer.
     "$schema": "https://github.com/IBM/audit-ci/raw/main/docs/schema.json",
-    "moderate": true,
+    "high": true,
     "allowlist": [
         {
             "GHSA-2p57-rm9w-gvfp": {


### PR DESCRIPTION
Raises the audit-ci threshold from moderate to high so the security audit only fails on high or critical advisories.