### PR TITLE
Security enhancements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9950,10 +9950,11 @@
             }
         },
         "node_modules/tmp": {
-            "version": "0.2.5",
-            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.5.tgz",
-            "integrity": "sha512-voyz6MApa1rQGUxT3E+BK7/ROe8itEx7vD8/HEvt4xwXucvQ5G5oeEiHkmHZJuBO21RpOf+YYm9MOivj709jow==",
+            "version": "0.2.6",
+            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.6.tgz",
+            "integrity": "sha512-5sJPdPjfI5Kx+qbrDesxkglRBxW//g7hCsqspEjwkewGvBMGIKMOTKzLt1hFVJzyadba3lDUN20O9qhvbQUSTA==",
             "dev": true,
+            "license": "MIT",
             "engines": {
                 "node": ">=14.14"
             }


### PR DESCRIPTION
Bumps `tmp` from 0.2.5 to 0.2.6 (transitive via `@vscode/vsce` and `ovsx`) to address [GHSA-ph9p-34f9-6g65](https://github.com/advisories/GHSA-ph9p-34f9-6g65) (path traversal, high). The existing `^0.2.3` range in both parents already permits the patched version; only the lockfile needed updating.