### PR TITLE
Skip link-local addresses in network change hash

### DIFF
--- a/src/deviceDiscovery/NetworkChangeMonitor.spec.ts
+++ b/src/deviceDiscovery/NetworkChangeMonitor.spec.ts
@@ -72,6 +72,101 @@ describe('NetworkChangeMonitor', () => {
             expect(getNetworkHash()).to.equal('no-network');
         });
 
+        it('excludes IPv6 link-local addresses (fe80::/10)', () => {
+            // Real interface
+            networkInterfacesStub.returns({
+                'en0': [{
+                    address: '192.168.1.100',
+                    netmask: '255.255.255.0',
+                    family: 'IPv4',
+                    internal: false
+                }]
+            });
+            const hashRealOnly = getNetworkHash();
+
+            // Same real interface plus a bunch of link-local-only interfaces
+            // (VPN tunnels, AirDrop, etc.) — should produce the same hash.
+            networkInterfacesStub.returns({
+                'en0': [{
+                    address: '192.168.1.100',
+                    netmask: '255.255.255.0',
+                    family: 'IPv4',
+                    internal: false
+                }],
+                'awdl0': [{
+                    address: 'fe80::2c21:e0ff:fe03:9ee5',
+                    netmask: 'ffff:ffff:ffff:ffff::',
+                    family: 'IPv6',
+                    internal: false
+                }],
+                'utun0': [{
+                    address: 'fe80::c295:9871:8607:4b6f',
+                    netmask: 'ffff:ffff:ffff:ffff::',
+                    family: 'IPv6',
+                    internal: false
+                }]
+            });
+            const hashWithLinkLocal = getNetworkHash();
+
+            expect(hashRealOnly).to.equal(hashWithLinkLocal);
+        });
+
+        it('excludes IPv4 link-local addresses (169.254/16)', () => {
+            networkInterfacesStub.returns({
+                'en0': [{
+                    address: '192.168.1.100',
+                    netmask: '255.255.255.0',
+                    family: 'IPv4',
+                    internal: false
+                }]
+            });
+            const hashRealOnly = getNetworkHash();
+
+            networkInterfacesStub.returns({
+                'en0': [{
+                    address: '192.168.1.100',
+                    netmask: '255.255.255.0',
+                    family: 'IPv4',
+                    internal: false
+                }],
+                'en1': [{
+                    address: '169.254.42.17',
+                    netmask: '255.255.0.0',
+                    family: 'IPv4',
+                    internal: false
+                }]
+            });
+            const hashWithApipa = getNetworkHash();
+
+            expect(hashRealOnly).to.equal(hashWithApipa);
+        });
+
+        it('keeps non-link-local IPv6 addresses (e.g. ULA)', () => {
+            // A hard-coded device IP could be an IPv6 ULA, so we must hash these.
+            networkInterfacesStub.returns({
+                'en0': [{
+                    address: 'fd1b:f33d:a9f:30d5:1842:621b:8739:48d7',
+                    netmask: 'ffff:ffff:ffff:ffff::',
+                    family: 'IPv6',
+                    internal: false
+                }]
+            });
+            const hash1 = getNetworkHash();
+
+            networkInterfacesStub.returns({
+                'en0': [{
+                    address: 'fd1b:f33d:a9f:30d5:aaaa:bbbb:cccc:dddd',
+                    netmask: 'ffff:ffff:ffff:ffff::',
+                    family: 'IPv6',
+                    internal: false
+                }]
+            });
+            const hash2 = getNetworkHash();
+
+            expect(hash1).to.not.equal(hash2);
+            expect(hash1).to.not.equal('no-network');
+        });
+
         it('excludes internal/loopback interfaces', () => {
             networkInterfacesStub.returns({
                 'lo0': [{

--- a/src/deviceDiscovery/NetworkChangeMonitor.ts
+++ b/src/deviceDiscovery/NetworkChangeMonitor.ts
@@ -11,7 +11,7 @@ export function getNetworkHash(): string {
 
     for (const name of Object.keys(interfaces)) {
         for (const net of interfaces[name] ?? []) {
-            if (!net.internal) {
+            if (!net.internal && !isLinkLocal(net)) {
                 parts.push(`${net.address}-${net.netmask}`);
             }
         }
@@ -22,6 +22,16 @@ export function getNetworkHash(): string {
     }
 
     return md5(parts.sort().join('|'));
+}
+
+// Link-local addresses (IPv4 169.254/16, IPv6 fe80::/10) can't route to an
+// arbitrary device IP, so changes on these interfaces (VPN tunnels, AirDrop,
+// etc.) shouldn't count as network changes for device reachability.
+function isLinkLocal(net: os.NetworkInterfaceInfo): boolean {
+    if (net.family === 'IPv4') {
+        return net.address.startsWith('169.254.');
+    }
+    return /^fe[89ab]/i.test(net.address);
 }
 
 /**


### PR DESCRIPTION
## Summary
- `getNetworkHash()` was including every non-internal interface, so VPN tunnels (`utun*`), AirDrop (`awdl0`), and similar interfaces with only link-local addresses would change the hash and trigger spurious network-change broadcasts.
- Added an `isLinkLocal` filter for IPv4 `169.254/16` (APIPA) and IPv6 `fe80::/10`. These addresses can't route to an arbitrary device IP, so changes on them aren't meaningful for device reachability.
- Non-link-local IPv6 (ULA `fc00::/7`, global unicast) is still hashed — a user with a hard-coded IPv6 device IP would otherwise lose change detection on that interface.

### Example interface dump where this matters
On a typical macOS box you can have ~10 non-internal interfaces but only one (`en0`) is actually on the LAN where the Roku lives. The rest are `awdl0`, `llw0`, `utun0`–`utun5`, each with a single `fe80::` link-local address. Every VPN connect/disconnect was flapping the hash and broadcasting a network change.