### PR TITLE
Fix critical shell-quote advisory (GHSA-w7jw-789q-3m8p)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -9258,10 +9258,14 @@
             }
         },
         "node_modules/shell-quote": {
-            "version": "1.7.4",
-            "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.7.4.tgz",
-            "integrity": "sha512-8o/QEhSSRb1a5i7TFR0iM4G16Z0vYB2OQVs4G3aAFXjn3T6yEx8AZxy1PgDF7I00LZHYA3WxaSYIf5e5sAX8Rw==",
+            "version": "1.8.4",
+            "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.4.tgz",
+            "integrity": "sha512-VsC6n6vz1ihYYyZZwX7YZSF5l5x36ca17OC+a69h94YqB7X6XLwf+5MOgynYir2SLFUbl8gIYvBo8K8RoNQ6bQ==",
             "dev": true,
+            "license": "MIT",
+            "engines": {
+                "node": ">= 0.4"
+            },
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }

--- a/package.json
+++ b/package.json
@@ -140,7 +140,10 @@
         "yargs": "^16.2.0"
     },
     "overrides": {
-        "serialize-javascript": "^7.0.5"
+        "serialize-javascript": "^7.0.5",
+        "@deboxsoft/cpx": {
+            "shell-quote": "^1.8.4"
+        }
     },
     "optionalDependencies": {
         "fsevents": "~2.3.2"


### PR DESCRIPTION
## What

`npm run audit` was failing on a **critical** advisory: [`shell-quote` GHSA-w7jw-789q-3m8p](https://github.com/advisories/GHSA-w7jw-789q-3m8p) — `quote()` does not escape newlines in object `.op` values.

This pins `shell-quote` to `^1.8.4` via a **scoped override** under `@deboxsoft/cpx`, the dev-only transitive dependency that pulled in the vulnerable `1.7.4`. `1.8.4` is the patched release and satisfies cpx's own `^1.6.1` requirement, so it's a clean non-breaking bump.

```jsonc
"overrides": {
    "serialize-javascript": "^7.0.5",
    "@deboxsoft/cpx": {
        "shell-quote": "^1.8.4"
    }
},
```

## Is this an actual risk to the project?

Not an exploitable one — but worth fixing since the patch is free:
- `shell-quote` is only a transitive dep of `@deboxsoft/cpx`, a **devDependency** used solely by the `copy-schema` build script. It never ships in the extension.
- The only `shell-quote` consumer runs at build time with hardcoded paths — no untrusted input flows into `quote()`.

## Why not `npm audit fix` or the allowlist

- **`npm audit fix`** fixed shell-quote but also upgraded `postman-request`, pulling in *new* advisories (`form-data` critical, a different `qs` DoS, `tough-cookie`) — 9 vulns → 15. The scoped override avoids that collateral entirely.
- **Allowlisting** wasn't warranted: unlike the existing allowlist entries (`ip`, `uuid`, `qs`), which have no upstream fix, shell-quote had a patched version the dep range already accepts. No reason to defer a critical when the fix is a one-liner.

## Result

`npm run audit` now **passes** (root + webviews). Critical advisory cleared; remaining moderates/highs are the pre-existing documented allowlist entries. The lock diff is exactly the `shell-quote` 1.7.4 → 1.8.4 bump — nothing else changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)