### PR TITLE
Advertise processStagingDir capability and handle the reverse request

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -34,7 +34,7 @@
                 "postman-request": "^2.88.1-postman.48",
                 "pretty-bytes": "^5.6.0",
                 "resolve": "^1.22.8",
-                "roku-debug": "^0.23.12",
+                "roku-debug": "^0.23.13",
                 "roku-deploy": "^3.17.6",
                 "roku-test-automation": "^2.2.1",
                 "semver": "^7.1.3",
@@ -8792,9 +8792,10 @@
             }
         },
         "node_modules/roku-debug": {
-            "version": "0.23.12",
-            "resolved": "https://registry.npmjs.org/roku-debug/-/roku-debug-0.23.12.tgz",
-            "integrity": "sha512-Z13tv1tgNkvfLly4b1/P0DqQuaFIhIZhsDQvQLNET8ss3oiefUqGDWkyfF8aBrZZ8uZOOU6AA8J4zdgyMg7WeQ==",
+            "version": "0.23.13",
+            "resolved": "https://registry.npmjs.org/roku-debug/-/roku-debug-0.23.13.tgz",
+            "integrity": "sha512-J9cxuEvuVRtGhke+x54icpFt1VE2FIJMvPJ3VSR8CJJmAVXIe78mJ0QuV+GguV/D4q6apLeCoTjdaY4F/3MO9g==",
+            "license": "MIT",
             "dependencies": {
                 "@rokucommunity/logger": "^0.3.13",
                 "@types/request": "^2.48.8",
@@ -8840,7 +8841,8 @@
         "node_modules/roku-debug/node_modules/eventemitter3": {
             "version": "4.0.7",
             "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
-            "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
+            "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+            "license": "MIT"
         },
         "node_modules/roku-debug/node_modules/fs-extra": {
             "version": "10.1.0",
@@ -8881,6 +8883,7 @@
             "version": "0.5.0",
             "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
             "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
+            "license": "MIT",
             "dependencies": {
                 "sax": ">=0.6.0",
                 "xmlbuilder": "~11.0.0"
@@ -10825,9 +10828,10 @@
             }
         },
         "node_modules/ws": {
-            "version": "8.20.1",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.20.1.tgz",
-            "integrity": "sha512-It4dO0K5v//JtTXuPkfEOaI3uUN87iYPnqo/ZzqCoG3g8uhA66QUMs/SrM0YK7/NAu+r4LMh/9dq2A7k+rHs+w==",
+            "version": "8.21.0",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+            "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+            "license": "MIT",
             "engines": {
                 "node": ">=10.0.0"
             },

--- a/package.json
+++ b/package.json
@@ -77,7 +77,7 @@
         "postman-request": "^2.88.1-postman.48",
         "pretty-bytes": "^5.6.0",
         "resolve": "^1.22.8",
-        "roku-debug": "^0.23.12",
+        "roku-debug": "^0.23.13",
         "roku-deploy": "^3.17.6",
         "roku-test-automation": "^2.2.1",
         "semver": "^7.1.3",

--- a/src/DebugConfigurationProvider.ts
+++ b/src/DebugConfigurationProvider.ts
@@ -158,6 +158,13 @@ export class BrightScriptDebugConfigurationProvider implements DebugConfiguratio
             }
             await this.context.workspaceState.update('enableDebuggerAutoRecovery', result.enableDebuggerAutoRecovery);
 
+            //advertise the optional features this client supports to the debug adapter. This is populated by the
+            //extension itself (not a user-facing setting) and gates optional roku-debug behavior like the
+            //`processStagingDir` reverse request.
+            result.clientCapabilities = {
+                supportsProcessStagingDir: true
+            };
+
             return result;
         } catch (e) {
             //log any exceptions to the extension panel

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -24,7 +24,7 @@ import { TelemetryManager } from './managers/TelemetryManager';
 import { RemoteControlManager } from './managers/RemoteControlManager';
 import { WhatsNewManager } from './managers/WhatsNewManager';
 import type { CustomRequestEvent, ProcessCrashEventData } from 'roku-debug';
-import { isChannelPublishedEvent, isChanperfEvent, isDiagnosticsEvent, isDebugServerLogOutputEvent, isLaunchStartEvent, isRendezvousEvent, isCustomRequestEvent, isExecuteTaskCustomRequest, ClientToServerCustomEventName, isShowPopupMessageCustomRequest, isProcessCrashEvent } from 'roku-debug';
+import { isChannelPublishedEvent, isChanperfEvent, isDiagnosticsEvent, isDebugServerLogOutputEvent, isLaunchStartEvent, isRendezvousEvent, isCustomRequestEvent, isExecuteTaskCustomRequest, ClientToServerCustomEventName, isShowPopupMessageCustomRequest, isProcessCrashEvent, isProcessStagingDirCustomRequest } from 'roku-debug';
 import { RtaManager } from './managers/RtaManager';
 import { WebviewViewProviderManager } from './managers/WebviewViewProviderManager';
 import { ViewProviderId } from './viewProviders/ViewProviderId';
@@ -416,6 +416,8 @@ export class Extension {
                 response = await this.executeTask(event.body.task);
             } else if (isShowPopupMessageCustomRequest(event)) {
                 response = await this.showMessage(event);
+            } else if (isProcessStagingDirCustomRequest(event)) {
+                response = await this.processStagingDir(event);
             }
             //send the response back to the server
             await session.customRequest(ClientToServerCustomEventName.customRequestEventResponse, {
@@ -454,6 +456,19 @@ export class Extension {
         execution = await vscode.tasks.executeTask(targetTask);
         console.log(execution);
         await taskFinished;
+    }
+
+    /**
+     * Handle the `processStagingDir` reverse request from roku-debug. For now this just proves the round-trip
+     * works: it logs the projects the debug adapter sent and confirms each staging dir exists on disk.
+     */
+    private async processStagingDir(event: CustomRequestEvent<{ projects: Array<{ type: string; stagingDir: string }> }>) {
+        const projects = event.body.projects ?? [];
+        console.log(`[processStagingDir] received ${projects.length} project(s) to process`);
+        for (const project of projects) {
+            const exists = await fsExtra.pathExists(project.stagingDir);
+            console.log(`[processStagingDir] ${project.type} staging dir ${exists ? 'exists' : 'is MISSING'}: ${project.stagingDir}`);
+        }
     }
 
     /**


### PR DESCRIPTION
Client side of rokucommunity/roku-debug#366.

- Advertises `clientCapabilities.supportsProcessStagingDir` in the resolved debug configuration.
- Handles the `processStagingDir` reverse request: logs each project the debug adapter sends and confirms its staging directory exists on disk. Real staging-dir processing comes in a later PR; for now this proves the capability is wired and gives clients a hook to inspect or modify the staging dirs before zipping.

Depends on roku-debug#366. This imports `isProcessStagingDirCustomRequest` and `clientCapabilities`, which don't exist in the published `roku-debug` yet, so CI will fail until roku-debug ships a release with the new API and the `roku-debug` dependency here is bumped to it.
