### PR TITLE
Security enhancements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5003,15 +5003,15 @@
             }
         },
         "node_modules/form-data": {
-            "version": "2.5.5",
-            "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.5.tgz",
-            "integrity": "sha512-jqdObeR2rxZZbPSGL+3VckHMYtu+f9//KXBsVny6JSX/pa38Fy+bGjuG8eW/H6USNQWhLi8Num++cU2yOCNz4A==",
+            "version": "2.5.6",
+            "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.6.tgz",
+            "integrity": "sha512-Ogz/E85h9tlfJzpI6TuFpGcHZFhLrb9Gw8wq9v40CxSCPnv7ahKr6Xgtkn0KYCDQJ8DNn5VoMO8EXr9V5PadyA==",
             "license": "MIT",
             "dependencies": {
                 "asynckit": "^0.4.0",
                 "combined-stream": "^1.0.8",
                 "es-set-tostringtag": "^2.1.0",
-                "hasown": "^2.0.2",
+                "hasown": "^2.0.4",
                 "mime-types": "^2.1.35",
                 "safe-buffer": "^5.2.1"
             },
@@ -5639,9 +5639,10 @@
             }
         },
         "node_modules/hasown": {
-            "version": "2.0.2",
-            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.2.tgz",
-            "integrity": "sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==",
+            "version": "2.0.4",
+            "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.4.tgz",
+            "integrity": "sha512-T2UbfbBEF32wiepXIsMlTW9+dDYC6wMh/t/vYA4tuOMKqWz/n3vr1NFSxQiyP+zk2mXsoMA/i/7qV6LKut1t1A==",
+            "license": "MIT",
             "dependencies": {
                 "function-bind": "^1.1.2"
             },
@@ -5736,9 +5737,9 @@
             }
         },
         "node_modules/http-proxy-middleware": {
-            "version": "3.0.5",
-            "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-3.0.5.tgz",
-            "integrity": "sha512-GLZZm1X38BPY4lkXA01jhwxvDoOkkXqjgVyUzVxiEK4iuRu03PZoYHhHRwxnfhQMDuaxi3vVri0YgSro/1oWqg==",
+            "version": "3.0.7",
+            "resolved": "https://registry.npmjs.org/http-proxy-middleware/-/http-proxy-middleware-3.0.7.tgz",
+            "integrity": "sha512-iwbQltVlx8bCrqePUM8C+hllHvdawVhQJaLrj1X7qllkvFQdXFsr16pW/mo9+JDVjN+QO2XUx9jd8SmoFkE5qw==",
             "license": "MIT",
             "dependencies": {
                 "@types/http-proxy": "^1.17.15",
@@ -5749,7 +5750,7 @@
                 "micromatch": "^4.0.8"
             },
             "engines": {
-                "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+                "node": "^14.18.0 || ^16.10.0 || >=18.0.0"
             }
         },
         "node_modules/http-proxy-middleware/node_modules/debug": {
@@ -9957,9 +9958,9 @@
             }
         },
         "node_modules/tmp": {
-            "version": "0.2.6",
-            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.6.tgz",
-            "integrity": "sha512-5sJPdPjfI5Kx+qbrDesxkglRBxW//g7hCsqspEjwkewGvBMGIKMOTKzLt1hFVJzyadba3lDUN20O9qhvbQUSTA==",
+            "version": "0.2.7",
+            "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.2.7.tgz",
+            "integrity": "sha512-e0votIpp4Uo2AJYSzVHV6xCcawuiez3DzqDAbrTc3YxBkplN6e+dM13ZeIcZnDg/QpSuU2zfZ3rzwY8ukEnaXw==",
             "dev": true,
             "license": "MIT",
             "engines": {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
         "build": "npm run copy-schema && tsc -p ./ && npm run build-webviews",
         "build-webviews": "cd ./webviews && npm run build && cd ..",
         "lint": "eslint \"./src/**/*.ts\"",
-        "audit": "npm audit || audit-ci --config ./audit-ci.jsonc && cd webviews && npm run audit",
+        "audit": "npm audit --audit-level=high || audit-ci --config ./audit-ci.jsonc && cd webviews && npm run audit",
         "watch": "npm run copy-schema && tsc -w -p ./",
         "watch-webviews": "cd ./webviews && npm run watch",
         "watch-all": "ts-node ./scripts/watch-all.ts",
@@ -141,6 +141,9 @@
     },
     "overrides": {
         "serialize-javascript": "^7.0.5",
+        "tmp": "^0.2.7",
+        "http-proxy-middleware": "^3.0.7",
+        "form-data": "^2.5.6",
         "@deboxsoft/cpx": {
             "shell-quote": "^1.8.4"
         }

--- a/webviews/package-lock.json
+++ b/webviews/package-lock.json
@@ -16,7 +16,7 @@
         "svelte-codicons": "^0.21.0",
         "tslib": "^2.4.1",
         "typescript": "^5.5.4",
-        "vite": "^6.4.2"
+        "vite": "^6.4.3"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1528,9 +1528,9 @@
       }
     },
     "node_modules/vite": {
-      "version": "6.4.2",
-      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.2.tgz",
-      "integrity": "sha512-2N/55r4JDJ4gdrCvGgINMy+HH3iRpNIz8K6SFwVsA+JbQScLiC+clmAxBgwiSPgcG9U15QmvqCGWzMbqda5zGQ==",
+      "version": "6.4.3",
+      "resolved": "https://registry.npmjs.org/vite/-/vite-6.4.3.tgz",
+      "integrity": "sha512-NTKlcQjlAK7MlQoyb6LgaqHc8sso/pVyUJYWMws3jg21uTJw/LddqIFPcPqP6PzpgbIcZyKI85sFE4HBrQDA8A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {

--- a/webviews/package.json
+++ b/webviews/package.json
@@ -7,7 +7,7 @@
     "watch": "vite build --watch",
     "build": "vite build",
     "check": "svelte-check --tsconfig ./tsconfig.json",
-    "audit": "npm audit"
+    "audit": "npm audit --audit-level=high"
   },
   "devDependencies": {
     "@sveltejs/vite-plugin-svelte": "^5.1.1",
@@ -18,6 +18,6 @@
     "svelte-codicons": "^0.21.0",
     "tslib": "^2.4.1",
     "typescript": "^5.5.4",
-    "vite": "^6.4.2"
+    "vite": "^6.4.3"
   }
 }


### PR DESCRIPTION
Clears the outstanding high-severity audit advisories and tightens the audit gate to high and above.

### Root
- Override `tmp` `^0.2.7`, `http-proxy-middleware` `^3.0.7`, and `form-data` `^2.5.6` to patched versions. These come in transitively (`tmp` via `@vscode/vsce`/`ovsx`, `http-proxy-middleware` via `roku-test-automation`, `form-data` via `@types/request`); each patched version satisfies the parent's existing range.
- Raise the `npm audit` step to `--audit-level=high`.

### Webviews
- Bump `vite` `^6.4.2` → `^6.4.3` (clears the `server.fs.deny` bypass / `launch-editor` advisory).
- Raise the `npm audit` step to `--audit-level=high`.

`npm run audit` passes across root and webviews with no high/critical advisories.

The `http-proxy-middleware` override can be dropped once a roku-test-automation release that floors it at `^3.0.7` is consumed (rokucommunity/roku-test-automation#168).