### PR TITLE
Show an empty-state for empty Perfetto trace files

### DIFF
--- a/src/editors/PerfettoEditor.ts
+++ b/src/editors/PerfettoEditor.ts
@@ -1,7 +1,6 @@
 import * as vscode from 'vscode';
 import type { CancellationToken, Webview, WebviewPanel } from 'vscode';
 
-
 export class PerfettoEditorProvider implements vscode.CustomReadonlyEditorProvider {
     public static register(context: vscode.ExtensionContext): vscode.Disposable {
         return vscode.window.registerCustomEditorProvider('brightscript.perfettoViewer', new PerfettoEditorProvider(), {
@@ -20,23 +19,33 @@ export class PerfettoEditorProvider implements vscode.CustomReadonlyEditorProvid
             enableScripts: true
         };
 
-        // An empty trace file has no data for Perfetto to parse, which surfaces a confusing "not a recognized format"
-        // error inside the embedded UI. Detect that case up front and show a friendly empty-state instead.
-        if (await this.isEmptyFile(document.uri)) {
-            webviewPanel.webview.html = this.getEmptyStateHtml(webviewPanel.webview);
-            webviewPanel.webview.onDidReceiveMessage(message => {
-                if (message.type === 'openAsText') {
-                    void vscode.commands.executeCommand('vscode.openWith', document.uri, 'default');
-                }
+        // Read the trace up front so we can surface read/empty failures immediately rather than booting the
+        // Perfetto UI only for it to fail with a confusing "not a recognized format" error.
+        let fileData: Uint8Array;
+        try {
+            fileData = await vscode.workspace.fs.readFile(document.uri);
+        } catch (error) {
+            this.showErrorState(webviewPanel, document, {
+                message: `This trace file could not be read.`,
+                detail: error instanceof Error ? error.message : String(error),
+                button: { label: 'Open in Text Editor', command: 'openAsText' }
+            });
+            return;
+        }
+
+        // An empty trace file has no data for Perfetto to parse, so show a friendly empty-state instead.
+        if (fileData.length === 0) {
+            this.showErrorState(webviewPanel, document, {
+                message: `This trace file is empty (0 bytes), so there's nothing to display.\nNo trace data was captured before tracing stopped.`,
+                button: { label: 'Open in Text Editor', command: 'openAsText' }
             });
             return;
         }
 
         webviewPanel.webview.html = this.getHtmlForWebview(webviewPanel.webview);
+        const filename = document.uri.fsPath;
         let isPerfettoReady = false;
-        const sendUpdate = async () => {
-            const filename = document.uri.fsPath;
-            let fileData = await vscode.workspace.fs.readFile(document.uri);
+        const sendUpdate = () => {
             if (isPerfettoReady) {
                 void webviewPanel.webview.postMessage({
                     type: 'update',
@@ -49,33 +58,54 @@ export class PerfettoEditorProvider implements vscode.CustomReadonlyEditorProvid
                 });
             }
         };
-        webviewPanel.onDidDispose(() => { });
         webviewPanel.webview.onDidReceiveMessage(message => {
             if (message.type === 'PERFETTO_READY') {
                 isPerfettoReady = true;
-                void sendUpdate();
+                sendUpdate();
             }
         });
     }
 
     /**
-     * Determine whether the given file is empty (zero bytes). A failed stat is treated as not-empty so we fall
-     * through to the normal Perfetto flow rather than masking an unrelated read error behind the empty-state.
+     * Render an error/empty state into the webview and wire up its optional action button.
      */
-    private async isEmptyFile(uri: vscode.Uri): Promise<boolean> {
-        try {
-            const stat = await vscode.workspace.fs.stat(uri);
-            return stat.size === 0;
-        } catch {
-            return false;
-        }
+    private showErrorState(webviewPanel: WebviewPanel, document: vscode.CustomDocument, options: ErrorStateOptions) {
+        webviewPanel.webview.html = this.getErrorStateHtml(webviewPanel.webview, options);
+        webviewPanel.webview.onDidReceiveMessage(message => {
+            if (message.type === 'openAsText') {
+                void vscode.commands.executeCommand('vscode.openWith', document.uri, 'default');
+            }
+        });
+    }
+
+    private encodeHtmlEntities(value: string): string {
+        return value
+            .replace(/&/g, '&amp;')
+            .replace(/</g, '&lt;')
+            .replace(/>/g, '&gt;')
+            .replace(/"/g, '&quot;');
     }
 
     /**
-     * Empty-state shown when a trace file has no data. Mirrors VS Code's own binary/unsupported-file warning so the
-     * experience feels native, with a button to fall back to the plain text editor.
+     * Error/empty state shown when a trace can't be displayed. Mirrors VS Code's own binary/unsupported-file
+     * warning so the experience feels native, with an optional button to fall back to the plain text editor.
      */
-    getEmptyStateHtml(webview: Webview) {
+    private getErrorStateHtml(webview: Webview, options: ErrorStateOptions) {
+        const messageHtml = this.encodeHtmlEntities(options.message).replace(/\n/g, '<br>');
+        const detailHtml = options.detail
+            ? `<div class="detail">${this.encodeHtmlEntities(options.detail)}</div>`
+            : '';
+        const buttonHtml = options.button
+            ? `<button id="action-button">${this.encodeHtmlEntities(options.button.label)}</button>`
+            : '';
+        const buttonScript = options.button
+            ? `(function () {
+                            const vscode = acquireVsCodeApi();
+                            document.getElementById('action-button').addEventListener('click', () => {
+                                vscode.postMessage({ type: ${JSON.stringify(options.button.command)} });
+                            });
+                        })();`
+            : '';
         return `
             <!DOCTYPE html>
             <html lang="en">
@@ -98,7 +128,7 @@ export class PerfettoEditorProvider implements vscode.CustomReadonlyEditorProvid
                             color: var(--vscode-foreground);
                             font-family: var(--vscode-font-family);
                         }
-                        .empty-state {
+                        .error-state {
                             display: flex;
                             flex-direction: column;
                             align-items: center;
@@ -106,17 +136,24 @@ export class PerfettoEditorProvider implements vscode.CustomReadonlyEditorProvid
                             padding: 24px;
                             max-width: 520px;
                         }
-                        .empty-state svg {
+                        .error-state svg {
                             width: 48px;
                             height: 48px;
                             color: var(--vscode-notificationsWarningIcon-foreground, #cca700);
                             margin-bottom: 16px;
                         }
-                        .empty-state .message {
+                        .error-state .message {
                             font-size: 13px;
                             line-height: 1.5;
                         }
-                        .empty-state button {
+                        .error-state .detail {
+                            margin-top: 10px;
+                            font-size: 12px;
+                            line-height: 1.4;
+                            opacity: 0.7;
+                            word-break: break-word;
+                        }
+                        .error-state button {
                             margin-top: 20px;
                             color: var(--vscode-button-foreground);
                             background-color: var(--vscode-button-background);
@@ -127,30 +164,23 @@ export class PerfettoEditorProvider implements vscode.CustomReadonlyEditorProvid
                             font-family: var(--vscode-font-family);
                             font-size: 13px;
                         }
-                        .empty-state button:hover {
+                        .error-state button:hover {
                             background-color: var(--vscode-button-hoverBackground);
                         }
                     </style>
                     <title>Performance Trace Viewer</title>
                 </head>
                 <body>
-                    <div class="empty-state">
+                    <div class="error-state">
                         <svg viewBox="0 0 16 16" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
                             <path fill-rule="evenodd" clip-rule="evenodd" d="M7.56 1.14a.5.5 0 0 1 .88 0l6.5 12A.5.5 0 0 1 14.5 14h-13a.5.5 0 0 1-.44-.74l6.5-12zM8 2.46 2.34 13h11.32L8 2.46zM7.25 6h1.5v4h-1.5V6zm0 5h1.5v1.5h-1.5V11z"/>
                         </svg>
-                        <div class="message">
-                            This trace file is empty (0&nbsp;bytes), so there's nothing to display.<br>
-                            No trace data was captured before tracing stopped.
-                        </div>
-                        <button id="open-as-text">Open in Text Editor</button>
+                        <div class="message">${messageHtml}</div>
+                        ${detailHtml}
+                        ${buttonHtml}
                     </div>
                     <script>
-                        (function () {
-                            const vscode = acquireVsCodeApi();
-                            document.getElementById('open-as-text').addEventListener('click', () => {
-                                vscode.postMessage({ type: 'openAsText' });
-                            });
-                        })();
+                        ${buttonScript}
                     </script>
                 </body>
             </html>
@@ -290,4 +320,17 @@ export class PerfettoEditorProvider implements vscode.CustomReadonlyEditorProvid
             </html>
       `;
     }
+}
+
+interface ErrorStateOptions {
+    /** Primary message. Plain text; newlines are rendered as line breaks. */
+    message: string;
+    /** Optional secondary line, rendered smaller and dimmed (e.g. an underlying error message). */
+    detail?: string;
+    /** Optional action button. */
+    button?: {
+        label: string;
+        /** Message type posted back to the extension when the button is clicked. */
+        command: string;
+    };
 }

--- a/src/editors/PerfettoEditor.ts
+++ b/src/editors/PerfettoEditor.ts
@@ -15,10 +15,23 @@ export class PerfettoEditorProvider implements vscode.CustomReadonlyEditorProvid
         return { uri: uri, dispose: () => { } };
     }
 
-    public resolveCustomEditor(document: vscode.CustomDocument, webviewPanel: WebviewPanel, _token: CancellationToken) {
+    public async resolveCustomEditor(document: vscode.CustomDocument, webviewPanel: WebviewPanel, _token: CancellationToken) {
         webviewPanel.webview.options = {
             enableScripts: true
         };
+
+        // An empty trace file has no data for Perfetto to parse, which surfaces a confusing "not a recognized format"
+        // error inside the embedded UI. Detect that case up front and show a friendly empty-state instead.
+        if (await this.isEmptyFile(document.uri)) {
+            webviewPanel.webview.html = this.getEmptyStateHtml(webviewPanel.webview);
+            webviewPanel.webview.onDidReceiveMessage(message => {
+                if (message.type === 'openAsText') {
+                    void vscode.commands.executeCommand('vscode.openWith', document.uri, 'default');
+                }
+            });
+            return;
+        }
+
         webviewPanel.webview.html = this.getHtmlForWebview(webviewPanel.webview);
         let isPerfettoReady = false;
         const sendUpdate = async () => {
@@ -43,6 +56,105 @@ export class PerfettoEditorProvider implements vscode.CustomReadonlyEditorProvid
                 void sendUpdate();
             }
         });
+    }
+
+    /**
+     * Determine whether the given file is empty (zero bytes). A failed stat is treated as not-empty so we fall
+     * through to the normal Perfetto flow rather than masking an unrelated read error behind the empty-state.
+     */
+    private async isEmptyFile(uri: vscode.Uri): Promise<boolean> {
+        try {
+            const stat = await vscode.workspace.fs.stat(uri);
+            return stat.size === 0;
+        } catch {
+            return false;
+        }
+    }
+
+    /**
+     * Empty-state shown when a trace file has no data. Mirrors VS Code's own binary/unsupported-file warning so the
+     * experience feels native, with a button to fall back to the plain text editor.
+     */
+    getEmptyStateHtml(webview: Webview) {
+        return `
+            <!DOCTYPE html>
+            <html lang="en">
+                <head>
+                    <meta charset="UTF-8">
+                    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+                    <meta http-equiv="Content-Security-Policy"
+                            content="default-src 'none';
+                                style-src ${webview.cspSource} 'unsafe-inline';
+                                script-src ${webview.cspSource} 'unsafe-inline';">
+                    <style>
+                        body {
+                            margin: 0;
+                            padding: 0;
+                            height: 100vh;
+                            display: flex;
+                            align-items: center;
+                            justify-content: center;
+                            background-color: var(--vscode-editor-background);
+                            color: var(--vscode-foreground);
+                            font-family: var(--vscode-font-family);
+                        }
+                        .empty-state {
+                            display: flex;
+                            flex-direction: column;
+                            align-items: center;
+                            text-align: center;
+                            padding: 24px;
+                            max-width: 520px;
+                        }
+                        .empty-state svg {
+                            width: 48px;
+                            height: 48px;
+                            color: var(--vscode-notificationsWarningIcon-foreground, #cca700);
+                            margin-bottom: 16px;
+                        }
+                        .empty-state .message {
+                            font-size: 13px;
+                            line-height: 1.5;
+                        }
+                        .empty-state button {
+                            margin-top: 20px;
+                            color: var(--vscode-button-foreground);
+                            background-color: var(--vscode-button-background);
+                            border: none;
+                            padding: 4px 14px;
+                            border-radius: 2px;
+                            cursor: pointer;
+                            font-family: var(--vscode-font-family);
+                            font-size: 13px;
+                        }
+                        .empty-state button:hover {
+                            background-color: var(--vscode-button-hoverBackground);
+                        }
+                    </style>
+                    <title>Performance Trace Viewer</title>
+                </head>
+                <body>
+                    <div class="empty-state">
+                        <svg viewBox="0 0 16 16" fill="currentColor" xmlns="http://www.w3.org/2000/svg">
+                            <path fill-rule="evenodd" clip-rule="evenodd" d="M7.56 1.14a.5.5 0 0 1 .88 0l6.5 12A.5.5 0 0 1 14.5 14h-13a.5.5 0 0 1-.44-.74l6.5-12zM8 2.46 2.34 13h11.32L8 2.46zM7.25 6h1.5v4h-1.5V6zm0 5h1.5v1.5h-1.5V11z"/>
+                        </svg>
+                        <div class="message">
+                            This trace file is empty (0&nbsp;bytes), so there's nothing to display.<br>
+                            No trace data was captured before tracing stopped.
+                        </div>
+                        <button id="open-as-text">Open in Text Editor</button>
+                    </div>
+                    <script>
+                        (function () {
+                            const vscode = acquireVsCodeApi();
+                            document.getElementById('open-as-text').addEventListener('click', () => {
+                                vscode.postMessage({ type: 'openAsText' });
+                            });
+                        })();
+                    </script>
+                </body>
+            </html>
+        `;
     }
 
     getHtmlForWebview(webview: Webview) {


### PR DESCRIPTION
Opening an empty (zero-byte) `.pftrace` / `.perfetto-trace` file showed a confusing "not a recognized format" error from the embedded Perfetto UI.

This detects the empty case up front and shows a friendly empty-state instead, with a button to open the file in the plain text editor.
