### PR TITLE
Fix boolean field toggles in SceneGraph Inspector node detail page

### DIFF
--- a/webviews/src/views/SceneGraphInspectorView/NodeDetailPage.svelte
+++ b/webviews/src/views/SceneGraphInspectorView/NodeDetailPage.svelte
@@ -231,9 +231,8 @@
             const element = elements[0]
             const id = element.id;
             if (element.checked === true || element.checked === false) {
+                // Assigning checked fires the checkbox's change event, which runs onBooleanFieldClick to push the reset value
                 element.checked = fields[id].value;
-                // If we dispatch the event like before the new value gets overwritten
-                onBooleanFieldClick.call(element);
             } else {
                 element.value = fields[id].value;
                 // Have to manually trigger the observer
@@ -454,7 +453,7 @@
                     appearance="icon"
                     class="inline"
                     title="Auto Refresh"
-                    on:click={onAutoRefreshClick} />
+                    on:change={onAutoRefreshClick} />
                 <vscode-button
                     appearance="icon"
                     title="Refresh"
@@ -560,7 +559,7 @@
                                 id={id}
                                 class="fieldValue"
                                 checked={field.value}
-                                on:click={onBooleanFieldClick} />
+                                on:change={onBooleanFieldClick} />
                         {:else if field.type === 'roFloat' || field.type === 'roInt'}
                             <NumberField
                                 title="Hold down shift to increment faster"
@@ -633,7 +632,7 @@
                                     <vscode-checkbox
                                         id="{id}.{collectionItemId}"
                                         checked={item}
-                                        on:click={onBooleanFieldClick} />
+                                        on:change={onBooleanFieldClick} />
                                 {:else}
                                     <vscode-text-field
                                         id="{id}.{collectionItemId}"
@@ -680,7 +679,7 @@
                                     <vscode-checkbox
                                         id="{id}.{collectionItemId}"
                                         checked={item}
-                                        on:click={onBooleanFieldClick} />
+                                        on:change={onBooleanFieldClick} />
                                 {:else if typeof item === 'object'}
                                     <vscode-text-area readonly cols="30" resize="both" value="{JSON.stringify(item)}" />
                                 {:else if typeof item === 'number'}


### PR DESCRIPTION
Fixes #834.

Toggling a boolean field (such as `visible`) in the SceneGraph Inspector node detail page set the value one click behind the displayed checkbox: the first click did nothing, the next click applied the change but left the checkbox showing the opposite state, and so on.

The checkboxes used `on:click` and read `this.checked` inside the handler, but the `vscode-checkbox` component toggles its own `checked` state in its own click handler, which had not run yet. So the handler always read the pre-toggle value.

Switched the boolean field checkboxes (and the auto-refresh checkbox) to `on:change`, which fires after the checked state updates, so the value sent to the device matches the checkbox. This matches the pattern already used by the App Overlays panel. The reset-value path no longer calls the handler explicitly, since assigning `checked` now triggers the change handler on its own.

The eyeball visibility toggle in the tree was not affected; it tracks its own state and was already correct.