### PR TITLE
Make .env file optional and support loading system env vars

### DIFF
--- a/docs/Debugging/env-file.md
+++ b/docs/Debugging/env-file.md
@@ -29,3 +29,7 @@ ROKU_PASSWORD=password123
 ```
 
 This extension uses the [dotenv](https://www.npmjs.com/package/dotenv) npm module for parsing the `.env` files, so see [this link](https://github.com/motdotla/dotenv#rules) for syntax information.
+
+## Process environment
+
+The `envFile` is optional. Any `${env:YOUR_VAR_NAME}` reference is resolved against the process environment (the environment VS Code was launched with) as well. When an `envFile` is provided, its values take precedence over the process environment. If the referenced `envFile` cannot be found, the extension falls back to the process environment instead of failing the debug session.

--- a/src/DebugConfigurationProvider.spec.ts
+++ b/src/DebugConfigurationProvider.spec.ts
@@ -1,4 +1,4 @@
-import { assert, expect } from 'chai';
+import { expect } from 'chai';
 import * as path from 'path';
 import { createSandbox } from 'sinon';
 import type { WorkspaceFolder } from 'vscode';
@@ -124,22 +124,18 @@ describe('BrightScriptConfigurationProvider', () => {
             expect(config.password).to.equal((configProvider as any).configDefaults.password);
         });
 
-        it('throws on missing .env file', async () => {
-            sinon.restore();
+        it('does not throw on missing .env file and falls back to the process env', async () => {
             sinon.stub(configProvider.util, 'fileExists').returns(Promise.resolve(false));
             sinon.stub(configProvider, 'getBsConfig').returns({});
+            sinon.stub(process, 'env').value({ ...process.env, ROKU_PASSWORD: 'pass1234' });
 
-            try {
-                await configProvider.resolveDebugConfiguration(folder, <any>{
-                    host: '127.0.0.1',
-                    type: 'brightscript',
-                    envFile: '${workspaceFolder}/.env',
-                    password: '${env:ROKU_PASSWORD}'
-                });
-                assert.fail('Should have thrown exception');
-            } catch (e) {
-                expect((e as Error)?.message).to.contain('Cannot find .env');
-            }
+            const config = await configProvider.resolveDebugConfiguration(folder, <any>{
+                host: '127.0.0.1',
+                type: 'brightscript',
+                envFile: '${workspaceFolder}/.env',
+                password: '${env:ROKU_PASSWORD}'
+            });
+            expect(config.password).to.equal('pass1234');
         });
 
         it('handles non ${workspaceFolder} replacements', async () => {
@@ -342,33 +338,71 @@ describe('BrightScriptConfigurationProvider', () => {
         });
     });
 
-    describe('processEnvFile', () => {
-        function processEnvFile(folder: WorkspaceFolder, config: Partial<BrightScriptLaunchConfiguration> & Record<string, any>) {
-            return configProvider['processEnvFile'](folder, config as any);
+    describe('processEnvVariables', () => {
+        function processEnvVariables(folder: WorkspaceFolder, config: Partial<BrightScriptLaunchConfiguration> & Record<string, any>) {
+            return configProvider['processEnvVariables'](folder, config as any);
         }
-        it('does nothing if .envFile is not specified', async () => {
-            let config = await processEnvFile(folder, {
+        it('leaves placeholder untouched when not found in .envFile or process env', async () => {
+            let config = await processEnvVariables(folder, {
                 rootDir: '${env:ROOT_DIR}'
             });
             expect(config.rootDir).to.equal('${env:ROOT_DIR}');
         });
 
-        it('throws exception when .env file does not exist', async () => {
+        it('reads from process.env when no .envFile is specified', async () => {
+            sinon.stub(process, 'env').value({ ...process.env, SOME_PROCESS_VAR: 'processValue' });
+            let config = await processEnvVariables(folder, {
+                rootDir: '${env:SOME_PROCESS_VAR}'
+            });
+            expect(config.rootDir).to.equal('processValue');
+        });
+
+        it('does not mutate process.env', async () => {
+            fsExtra.outputFileSync(`${rootDir}/.env`, `SOME_ENV_FILE_VAR=envFileValue`);
+            const envBefore = { ...process.env };
+            await processEnvVariables(folder, {
+                envFile: '${workspaceFolder}/.env',
+                rootDir: '${env:SOME_ENV_FILE_VAR}'
+            });
+            expect(process.env).to.eql(envBefore);
+            expect(process.env).to.not.have.property('SOME_ENV_FILE_VAR');
+        });
+
+        it('.envFile values override process.env values', async () => {
+            sinon.stub(process, 'env').value({ ...process.env, SHARED_VAR: 'processValue' });
+            fsExtra.outputFileSync(`${rootDir}/.env`, `SHARED_VAR=envFileValue`);
+            const config = await processEnvVariables(folder, {
+                envFile: '${workspaceFolder}/.env',
+                rootDir: '${env:SHARED_VAR}'
+            });
+            expect(config.rootDir).to.equal('envFileValue');
+        });
+
+        it('does not throw when .env file does not exist', async () => {
             let threw = false;
             try {
-                await processEnvFile(folder, {
+                await processEnvVariables(folder, {
                     envFile: '${workspaceFolder}/.env'
                 });
             } catch (e) {
                 threw = true;
             }
-            expect(threw).to.be.true;
+            expect(threw).to.be.false;
+        });
+
+        it('falls back to process.env when the specified .env file does not exist', async () => {
+            sinon.stub(process, 'env').value({ ...process.env, FALLBACK_VAR: 'fallbackValue' });
+            const config = await processEnvVariables(folder, {
+                envFile: '${workspaceFolder}/.env',
+                rootDir: '${env:FALLBACK_VAR}'
+            });
+            expect(config.rootDir).to.equal('fallbackValue');
         });
 
         it('replaces ${workspaceFolder} in .envFile path', async () => {
             let stub = sinon.stub(configProvider.util, 'fileExists').returns(Promise.resolve(false));
             try {
-                await processEnvFile(folder, {
+                await processEnvVariables(folder, {
                     envFile: '${workspaceFolder}/.env'
                 });
             } catch (e) { }
@@ -378,7 +412,7 @@ describe('BrightScriptConfigurationProvider', () => {
 
         it('replaces same env value multiple times in a config', async () => {
             fsExtra.outputFileSync(`${rootDir}/.env`, `PASSWORD=password`);
-            let config = await processEnvFile(folder, {
+            let config = await processEnvVariables(folder, {
                 envFile: '${workspaceFolder}/.env',
                 rootDir: '${env:PASSWORD}',
                 stagingDir: '${env:PASSWORD}'
@@ -390,7 +424,7 @@ describe('BrightScriptConfigurationProvider', () => {
 
         it('does not replace text outside of the ${} syntax', async () => {
             fsExtra.outputFileSync(`${rootDir}/.env`, `PASSWORD=password`);
-            const config = await processEnvFile(folder, {
+            const config = await processEnvVariables(folder, {
                 'envFile': '${workspaceFolder}/.env',
                 //this key looks exactly like the text within the ${}, make sure it persists. (dunno why someone would do this...)
                 'env:PASSWORD': '${env:PASSWORD}'
@@ -401,7 +435,7 @@ describe('BrightScriptConfigurationProvider', () => {
 
         it('ignores ${env:} items that are not found in the env file', async () => {
             fsExtra.outputFileSync(`${rootDir}/.env`, `PASSWORD=password`);
-            const config = await processEnvFile(folder, {
+            const config = await processEnvVariables(folder, {
                 envFile: '${workspaceFolder}/.env',
                 rootDir: '${env:NOT_PASSWORD}'
             });
@@ -411,7 +445,7 @@ describe('BrightScriptConfigurationProvider', () => {
 
         it('loads env file when not using ${workspaceFolder} var', async () => {
             fsExtra.outputFileSync(`${tempDir}/.env`, `TEST_ENV_VAR=./somePath`);
-            const config = await processEnvFile(folder, {
+            const config = await processEnvVariables(folder, {
                 envFile: `${tempDir}/.env`,
                 rootDir: '${env:TEST_ENV_VAR}/123'
             });

--- a/src/DebugConfigurationProvider.ts
+++ b/src/DebugConfigurationProvider.ts
@@ -134,7 +134,7 @@ export class BrightScriptDebugConfigurationProvider implements DebugConfiguratio
             result.stagingFolderPath = result.stagingDir;
 
             result = await this.sanitizeConfiguration(result, folder);
-            result = await this.processEnvFile(folder, result);
+            result = await this.processEnvVariables(folder, result);
             const [resultAfterHost, device] = await this.processHostParameter(result);
             result = resultAfterHost;
             result = await this.processPasswordParameter(config, result, device);
@@ -421,12 +421,17 @@ export class BrightScriptDebugConfigurationProvider implements DebugConfiguratio
     }
 
     /**
-     * Reads the manifest file and updates any config values that are mapped to it
+     * Resolves any `${env:*}` placeholders in the config using the process environment
+     * and (if present) the optional `.env` file, without mutating `process.env`.
      * @param folder current workspace folder
      * @param config current config object
      */
-    private async processEnvFile(folder: WorkspaceFolder | undefined, config: BrightScriptLaunchConfiguration): Promise<BrightScriptLaunchConfiguration> {
-        //process .env file if present
+    private async processEnvVariables(folder: WorkspaceFolder | undefined, config: BrightScriptLaunchConfiguration): Promise<BrightScriptLaunchConfiguration> {
+        //start with a copy of the current process environment so we never mutate process.env
+        let environmentValues = { ...process.env };
+        let loadedEnvFile = false;
+
+        //layer any values from the .env file on top of the process environment (the .env file is optional)
         if (config.envFile) {
             let envFilePath = config.envFile;
             //resolve ${workspaceFolder} so we can actually load the .env file now
@@ -434,46 +439,55 @@ export class BrightScriptDebugConfigurationProvider implements DebugConfiguratio
                 envFilePath = config.envFile.replace('${workspaceFolder}', folder.uri.fsPath);
             }
             if (await this.util.fileExists(envFilePath) === false) {
-                throw new Error(`Cannot find .env file at "${envFilePath}`);
+                //the .env file is optional, so just warn instead of failing the debug session
+                console.warn(`Cannot find .env file at "${envFilePath}". Falling back to the process environment for '\${env:*}' values.`);
+            } else {
+                //parse the .env file, letting its values override the process environment
+                environmentValues = {
+                    ...environmentValues,
+                    ...dotenv.parse(await this.fsExtra.readFile(envFilePath))
+                };
+                loadedEnvFile = true;
             }
-            //parse the .env file
-            let envConfig = dotenv.parse(await this.fsExtra.readFile(envFilePath));
+        }
 
-            // temporarily convert entire config to string for any envConfig replacements.
-            let configString = JSON.stringify(config);
+        //describe where we looked so any "not found" message only mentions the sources we actually used
+        const environmentSourceLabel = loadedEnvFile ? 'environment variable or env file' : 'environment variable';
+
+        // temporarily convert entire config to string for any environment replacements.
+        let configString = JSON.stringify(config);
+        let match: RegExpMatchArray;
+        let regexp = /\$\{env:([\w\d_]*)\}/g;
+        let updatedConfigString = configString;
+
+        // apply any defined values to env placeholders
+        while ((match = regexp.exec(configString))) {
+            let environmentVariableName = match[1];
+            let environmentVariableValue = environmentValues[environmentVariableName];
+
+            if (environmentVariableValue) {
+                updatedConfigString = updatedConfigString.replace(match[0], environmentVariableValue);
+            }
+        }
+
+        config = JSON.parse(updatedConfigString);
+
+        let configDefaults = {
+            rootDir: config.rootDir,
+            ...this.configDefaults
+        };
+
+        // apply any default values to env placeholders
+        for (let key in config) {
+            let configValue = config[key];
             let match: RegExpMatchArray;
-            let regexp = /\$\{env:([\w\d_]*)\}/g;
-            let updatedConfigString = configString;
-
-            // apply any defined values to env placeholders
-            while ((match = regexp.exec(configString))) {
+            //replace all environment variable placeholders with their values
+            while ((match = regexp.exec(configValue))) {
                 let environmentVariableName = match[1];
-                let environmentVariableValue = envConfig[environmentVariableName];
-
-                if (environmentVariableValue) {
-                    updatedConfigString = updatedConfigString.replace(match[0], environmentVariableValue);
-                }
+                configValue = configDefaults[key];
+                console.log(`The configuration value for ${key} was not found in the environment variables${loadedEnvFile ? ' or env file' : ''} under the name ${environmentVariableName}. Defaulting the value to: ${configValue}`);
             }
-
-            config = JSON.parse(updatedConfigString);
-
-            let configDefaults = {
-                rootDir: config.rootDir,
-                ...this.configDefaults
-            };
-
-            // apply any default values to env placeholders
-            for (let key in config) {
-                let configValue = config[key];
-                let match: RegExpMatchArray;
-                //replace all environment variable placeholders with their values
-                while ((match = regexp.exec(configValue))) {
-                    let environmentVariableName = match[1];
-                    configValue = configDefaults[key];
-                    console.log(`The configuration value for ${key} was not found in the env file under the name ${environmentVariableName}. Defaulting the value to: ${configValue}`);
-                }
-                config[key] = configValue;
-            }
+            config[key] = configValue;
         }
         return config;
     }

--- a/src/DebugConfigurationProvider.ts
+++ b/src/DebugConfigurationProvider.ts
@@ -451,9 +451,6 @@ export class BrightScriptDebugConfigurationProvider implements DebugConfiguratio
             }
         }
 
-        //describe where we looked so any "not found" message only mentions the sources we actually used
-        const environmentSourceLabel = loadedEnvFile ? 'environment variable or env file' : 'environment variable';
-
         // temporarily convert entire config to string for any environment replacements.
         let configString = JSON.stringify(config);
         let match: RegExpMatchArray;


### PR DESCRIPTION
Previously, using `${env:KEY}` in a launch configuration required an `envFile`, and a missing file failed the debug session with `Cannot find .env file`.

Now `${env:KEY}` placeholders resolve against the process environment as well as the optional `.env` file:

- `envFile` is optional. When omitted, placeholders resolve from the process environment.
- A configured-but-missing `envFile` warns and falls back to the process environment instead of throwing.
- When both define a variable, the `.env` file value wins (preserving prior behavior for existing setups).
- The lookup starts from a copy of `process.env`, so `process.env` is never mutated.

Renamed `processEnvFile` to `processEnvVariables` to reflect that it now reads from more than just the file.
