### PR TITLE
Fix nested namespace display and nesting in outline

### DIFF
--- a/src/DeclarationProvider.spec.ts
+++ b/src/DeclarationProvider.spec.ts
@@ -1,5 +1,7 @@
 import { expect } from 'chai';
+import * as fsExtra from 'fs-extra';
 import * as sinon from 'sinon';
+import { standardizePath as s } from 'brighterscript';
 let Module = require('module');
 
 import { vscode } from './mockVscode.spec';
@@ -16,7 +18,9 @@ Module.prototype.require = function hijacked(file) {
 };
 
 import { SymbolKind } from 'vscode';
-import { DeclarationProvider } from './DeclarationProvider';
+import { DeclarationProvider, WorkspaceEncoding } from './DeclarationProvider';
+
+const tempDir = s`${__dirname}/../.tmp`;
 
 describe('DeclarationProvider', () => {
     let provider: DeclarationProvider;
@@ -35,6 +39,48 @@ describe('DeclarationProvider', () => {
 
     afterEach(() => {
         sandbox.restore();
+        fsExtra.removeSync(tempDir);
+    });
+
+    describe('flush', () => {
+        beforeEach(() => {
+            fsExtra.emptyDirSync(tempDir);
+            //the constructor queued a full workspace scan; disable it so tests control the dirty list directly
+            provider['fullscan'] = false;
+        });
+
+        it('emits a delete event instead of crashing when a dirty file was deleted before flush ran', async () => {
+            const filePath = s`${tempDir}/deleted.brs`;
+            const fileUri = vscode.Uri.file(filePath);
+            provider['dirty'].set(filePath, fileUri);
+
+            const deletedUris = [];
+            provider.onDidDelete((event) => deletedUris.push(event.uri));
+
+            await provider['flush']();
+
+            expect(deletedUris).to.eql([fileUri]);
+            expect(provider['dirty'].size).to.equal(0);
+        });
+
+        it('reads declarations from a file that is outside every workspace folder', async () => {
+            //this file has no workspace folder
+            (vscode.workspace.getWorkspaceFolder as any).returns(undefined);
+
+            const filePath = s`${tempDir}/main.brs`;
+            fsExtra.outputFileSync(filePath, 'sub main()\nend sub');
+            const fileUri = vscode.Uri.file(filePath);
+            provider['dirty'].set(filePath, fileUri);
+
+            const changeEvents = [];
+            provider.onDidChange((event) => changeEvents.push(event));
+
+            await provider['flush']();
+
+            expect(changeEvents).to.have.lengthOf(1);
+            expect(changeEvents[0].decls.map(declaration => declaration.name)).to.include('main');
+            expect(provider['dirty'].size).to.equal(0);
+        });
     });
 
     describe('readDeclarations', () => {
@@ -89,5 +135,12 @@ describe('DeclarationProvider', () => {
             expect(byName('deep').bodyRange.start.line).to.equal(3);
             expect(byName('deep').bodyRange.end.line).to.equal(6);
         });
+    });
+});
+
+describe('WorkspaceEncoding', () => {
+    it('falls back to utf8 for a path outside every workspace folder', () => {
+        const encoding = new WorkspaceEncoding();
+        expect(encoding.find(s`${tempDir}/main.brs`)).to.equal('utf8');
     });
 });

--- a/src/DeclarationProvider.spec.ts
+++ b/src/DeclarationProvider.spec.ts
@@ -1,0 +1,93 @@
+import { expect } from 'chai';
+import * as sinon from 'sinon';
+let Module = require('module');
+
+import { vscode } from './mockVscode.spec';
+
+//override the "require" call to mock certain items
+const { require: oldRequire } = Module.prototype;
+
+Module.prototype.require = function hijacked(file) {
+    if (file === 'vscode') {
+        return vscode;
+    } else {
+        return oldRequire.apply(this, arguments);
+    }
+};
+
+import { SymbolKind } from 'vscode';
+import { DeclarationProvider } from './DeclarationProvider';
+
+describe('DeclarationProvider', () => {
+    let provider: DeclarationProvider;
+    let uri: any;
+    let sandbox: sinon.SinonSandbox;
+
+    beforeEach(() => {
+        sandbox = sinon.createSandbox();
+        uri = vscode.Uri.file('/some/project/source/main.bs');
+        //readDeclarations reads the workspace folder to filter out the `out` dir
+        sandbox.stub(vscode.workspace, 'getWorkspaceFolder').returns({
+            uri: vscode.Uri.file('/some/project')
+        } as any);
+        provider = new DeclarationProvider();
+    });
+
+    afterEach(() => {
+        sandbox.restore();
+    });
+
+    describe('readDeclarations', () => {
+        it('shows only the final segment for dotted/nested namespaces', () => {
+            const symbols = provider.readDeclarations(uri, [
+                `namespace get`,
+                `end namespace`,
+                `namespace get.deep`,
+                `end namespace`
+            ].join('\n'));
+
+            const namespaceNames = symbols
+                .filter(symbol => symbol.kind === SymbolKind.Namespace)
+                .map(symbol => symbol.name);
+            expect(namespaceNames).to.eql(['get', 'deep']);
+        });
+
+        it('leaves single-segment namespaces unchanged', () => {
+            const symbols = provider.readDeclarations(uri, [
+                `namespace alpha`,
+                `end namespace`
+            ].join('\n'));
+
+            const namespaceNames = symbols
+                .filter(symbol => symbol.kind === SymbolKind.Namespace)
+                .map(symbol => symbol.name);
+            expect(namespaceNames).to.eql(['alpha']);
+        });
+
+        it('nests a namespace under its parent instead of the preceding function', () => {
+            // lines: 0 namespace get, 1 function outer, 2 end function, 3 namespace deep,
+            // 4 function inner, 5 end function, 6 end namespace (deep), 7 end namespace (get)
+            const symbols = provider.readDeclarations(uri, [
+                `namespace get`,
+                `    function outer()`,
+                `    end function`,
+                `    namespace deep`,
+                `        function inner()`,
+                `        end function`,
+                `    end namespace`,
+                `end namespace`
+            ].join('\n'));
+
+            const byName = (name: string) => symbols.find(symbol => symbol.name === name);
+            //the nested namespace's parent is `get`, NOT the `outer` function that precedes it
+            expect(byName('deep').containerName).to.equal('get');
+            //the function that precedes the nested namespace must not swallow it
+            expect(byName('outer').bodyRange.end.line).to.be.lessThan(byName('deep').bodyRange.start.line);
+            //functions inside the nested namespace nest under it
+            expect(byName('inner').containerName).to.equal('deep');
+            //the namespace spans its whole block so its members are range-contained
+            expect(byName('deep').bodyRange.start.line).to.equal(3);
+            expect(byName('deep').bodyRange.end.line).to.equal(6);
+        });
+    });
+});

--- a/src/DeclarationProvider.ts
+++ b/src/DeclarationProvider.ts
@@ -253,12 +253,21 @@ export class DeclarationProvider implements Disposable {
 
         let namespaces = new Set<string>();
         let classes = new Set<string>();
-        let namespaceSymbol: BrightScriptDeclaration | null;
-        let classSymbol: BrightScriptDeclaration | null;
         let enums = new Set<string>();
         let interfaces = new Set<string>();
-        let interfaceSymbol: BrightScriptDeclaration | null;
-        let enumSymbol: BrightScriptDeclaration | null;
+
+        // Stack of container declarations (namespace/class/interface/enum) that are currently open.
+        // The innermost open container is the parent for any symbols found inside it, so the outline
+        // nests correctly. Each container's bodyRange is closed out when its matching `end` is reached.
+        let containerStack: BrightScriptDeclaration[] = [];
+        const currentContainer = () => (containerStack.length > 0 ? containerStack[containerStack.length - 1] : container);
+        const closeContainer = (kind: SymbolKind, endLine: number, endChar: number) => {
+            const openContainer = containerStack[containerStack.length - 1];
+            if (openContainer && openContainer.kind === kind) {
+                openContainer.bodyRange = openContainer.bodyRange.with({ end: new Position(endLine, endChar) });
+                containerStack.pop();
+            }
+        };
 
         for (const [line, text] of iterlines(input)) {
             // console.log("" + line + ": " + text);
@@ -276,18 +285,12 @@ export class DeclarationProvider implements Disposable {
                 currentFunction = new BrightScriptDeclaration(
                     match[1].trim(),
                     match[1].trim().toLowerCase() === 'new' ? SymbolKind.Constructor : SymbolKind.Function,
-                    container,
+                    currentContainer(),
                     match[2].split(','),
                     new Range(line, match[0].length - match[1].length - match[2].length - 2, line, match[0].length - 1),
                     new Range(line, 0, line, text.length)
                 );
                 symbols.push(currentFunction);
-
-                if (classSymbol) {
-                    currentFunction.container = classSymbol;
-                } else if (namespaceSymbol) {
-                    currentFunction.container = namespaceSymbol;
-                }
                 continue;
             }
 
@@ -297,6 +300,8 @@ export class DeclarationProvider implements Disposable {
                 // console.log("function END");
                 if (currentFunction !== undefined) {
                     currentFunction.bodyRange = currentFunction.bodyRange.with({ end: new Position(funcEndLine, funcEndChar) });
+                    //reset so the function's range isn't stretched over whatever follows it (e.g. a nested namespace)
+                    currentFunction = undefined;
                 }
                 continue;
             }
@@ -311,19 +316,13 @@ export class DeclarationProvider implements Disposable {
                     let varSymbol = new BrightScriptDeclaration(
                         name,
                         SymbolKind.Field,
-                        container,
+                        currentContainer(),
                         undefined,
                         new Range(line, match[0].length - match[1].length, line, match[0].length),
                         new Range(line, 0, line, text.length)
                     );
                     // console.log('FOUND VAR ' + varSymbol.name);
                     symbols.push(varSymbol);
-
-                    if (classSymbol) {
-                        varSymbol.container = classSymbol;
-                    } else if (namespaceSymbol) {
-                        varSymbol.container = namespaceSymbol;
-                    }
                 }
                 continue;
             }
@@ -333,10 +332,13 @@ export class DeclarationProvider implements Disposable {
             if (match !== null) {
                 const name = match[1].trim();
                 if (name) {
-                    namespaceSymbol = new BrightScriptDeclaration(
-                        name,
+                    // For nested/dotted namespaces (e.g. `get.deep`), show only the final
+                    // segment (`deep`) in the outline, matching the language server behavior.
+                    const displayName = name.split('.').pop();
+                    const namespaceSymbol = new BrightScriptDeclaration(
+                        displayName,
                         SymbolKind.Namespace,
-                        container,
+                        currentContainer(),
                         undefined,
                         new Range(line, match[0].length - match[1].length, line, match[0].length),
                         new Range(line, 0, line, text.length)
@@ -344,12 +346,15 @@ export class DeclarationProvider implements Disposable {
                     // console.log('FOUND NAMESPACES ' + namespaceSymbol.name);
                     symbols.push(namespaceSymbol);
                     namespaces.add(name.toLowerCase());
+                    containerStack.push(namespaceSymbol);
                 }
+                continue;
             }
             //end namespace declaration
             match = /^(?: |\t)*end namespace.*$/i.exec(text);
-            if (match !== null && namespaceSymbol) {
-                namespaceSymbol = null;
+            if (match !== null) {
+                closeContainer(SymbolKind.Namespace, line, text.length);
+                continue;
             }
 
             //start enum declaration
@@ -357,10 +362,10 @@ export class DeclarationProvider implements Disposable {
             if (match !== null) {
                 const name = match[1].trim();
                 if (name) {
-                    enumSymbol = new BrightScriptDeclaration(
+                    const enumSymbol = new BrightScriptDeclaration(
                         name,
                         SymbolKind.Enum,
-                        container,
+                        currentContainer(),
                         undefined,
                         new Range(line, match[0].length - match[1].length, line, match[0].length),
                         new Range(line, 0, line, text.length)
@@ -368,12 +373,15 @@ export class DeclarationProvider implements Disposable {
                     // console.log('FOUND enumS ' + enumSymbol.name);
                     symbols.push(enumSymbol);
                     enums.add(name.toLowerCase());
+                    containerStack.push(enumSymbol);
                 }
+                continue;
             }
             //end enum declaration
             match = /^(?: |\t)*end enum.*$/i.exec(text);
-            if (match !== null && enumSymbol) {
-                enumSymbol = null;
+            if (match !== null) {
+                closeContainer(SymbolKind.Enum, line, text.length);
+                continue;
             }
 
             //start class declaration
@@ -381,10 +389,10 @@ export class DeclarationProvider implements Disposable {
             if (match !== null) {
                 const name = match[2].trim();
                 if (name) {
-                    classSymbol = new BrightScriptDeclaration(
+                    const classSymbol = new BrightScriptDeclaration(
                         name,
                         SymbolKind.Class,
-                        container,
+                        currentContainer(),
                         undefined,
                         new Range(line, match[0].length - match[2].length, line, match[0].length),
                         new Range(line, 0, line, text.length)
@@ -392,17 +400,26 @@ export class DeclarationProvider implements Disposable {
                     // console.log('FOUND CLASS ' + classSymbol.name);
                     symbols.push(classSymbol);
                     classes.add(name.toLowerCase());
+                    containerStack.push(classSymbol);
                 }
+                continue;
             }
+            //end class declaration
+            match = /^(?: |\t)*end class.*$/i.exec(text);
+            if (match !== null) {
+                closeContainer(SymbolKind.Class, line, text.length);
+                continue;
+            }
+
             //start interface declaration
             match = /(?:(interface)\s+([a-z_][a-z0-9_]*))\s*(?:extends\s*([a-z_][a-z0-9_]+))*$/i.exec(text);
             if (match !== null) {
                 const name = match[2].trim();
                 if (name) {
-                    interfaceSymbol = new BrightScriptDeclaration(
+                    const interfaceSymbol = new BrightScriptDeclaration(
                         name,
                         SymbolKind.Interface,
-                        container,
+                        currentContainer(),
                         undefined,
                         new Range(line, match[0].length - match[2].length, line, match[0].length),
                         new Range(line, 0, line, text.length)
@@ -410,7 +427,15 @@ export class DeclarationProvider implements Disposable {
                     // console.log('FOUND interface ' + interfaceSymbol.name);
                     symbols.push(interfaceSymbol);
                     interfaces.add(name.toLowerCase());
+                    containerStack.push(interfaceSymbol);
                 }
+                continue;
+            }
+            //end interface declaration
+            match = /^(?: |\t)*end interface.*$/i.exec(text);
+            if (match !== null) {
+                closeContainer(SymbolKind.Interface, line, text.length);
+                continue;
             }
 
         }

--- a/src/DeclarationProvider.ts
+++ b/src/DeclarationProvider.ts
@@ -44,7 +44,7 @@ export class WorkspaceEncoding {
     private encoding: string[][];
 
     public find(path: string): string {
-        return this.encoding.find((v) => path.startsWith(v[0]))[1];
+        return this.encoding.find((v) => path.startsWith(v[0]))?.[1] ?? 'utf8';
     }
 
     public reset() {
@@ -179,7 +179,7 @@ export class DeclarationProvider implements Disposable {
                     }
                 });
             });
-            if (input === undefined) {
+            if (input === null) {
                 this.dirty.delete(path);
                 this.onDidDeleteEmitter.fire(new DeclarationDeleteEvent(uri));
                 continue;
@@ -192,11 +192,14 @@ export class DeclarationProvider implements Disposable {
 
     public readDeclarations(uri: Uri, input: string): BrightScriptDeclaration[] {
         const uriPath = util.normalizeFileScheme(uri.toString());
-        const outDir = util.normalizeFileScheme(path.join(vscode.workspace.getWorkspaceFolder(uri).uri.toString(), 'out'));
+        const workspaceFolder = vscode.workspace.getWorkspaceFolder(uri);
+        if (workspaceFolder) {
+            const outDir = util.normalizeFileScheme(path.join(workspaceFolder.uri.toString(), 'out'));
 
-        // Prevents results in the out directory from being returned
-        if (uriPath.startsWith(outDir)) {
-            return [];
+            // Prevents results in the out directory from being returned
+            if (uriPath.startsWith(outDir)) {
+                return [];
+            }
         }
 
         const container = BrightScriptDeclaration.fromUri(uri);

--- a/src/mockVscode.spec.ts
+++ b/src/mockVscode.spec.ts
@@ -393,17 +393,26 @@ export let vscode = {
         public label: string;
         public documentation: any;
     },
-    Range: class {
+    Range: class Range {
         constructor(startLine: number, startCharacter: number, endLine: number, endCharacter: number) {
             this.startLine = startLine;
             this.startCharacter = startCharacter;
             this.endLine = endLine;
             this.endCharacter = endCharacter;
+            this.start = { line: startLine, character: startCharacter };
+            this.end = { line: endLine, character: endCharacter };
         }
         public startLine: number;
         public startCharacter: number;
         public endLine: number;
         public endCharacter: number;
+        public start: { line: number; character: number };
+        public end: { line: number; character: number };
+        public with(change: { start?: { line: number; character: number }; end?: { line: number; character: number } }) {
+            const start = change.start ?? this.start;
+            const end = change.end ?? this.end;
+            return new Range(start.line, start.character, end.line, end.character);
+        }
     },
     SymbolKind: {
         File: 0,


### PR DESCRIPTION
Fixes the document symbol outline (used when the language server is disabled) for nested namespaces.

Previously a nested namespace showed its full dotted name and was mis-nested: the function preceding it over-extended its range and swallowed the namespace, and namespaces never got an end-of-block range so their members flattened up to the parent.

- Show only the final segment of a namespace name (`deep` instead of `get.deep`), matching the language server
- Reset the current function at `end function`/`end sub` so it no longer over-extends past its own body
- Track open containers (namespace/class/interface/enum) with a stack and close each at its matching `end`, so members nest under the correct parent

Also fixes a crash in `DeclarationProvider.flush()`: when a file was deleted after the watcher marked it dirty but before flush ran, the ENOENT branch resolved `null` but the guard checked for `undefined`, so `null` flowed into `readDeclarations` and crashed Go To Definition with `Cannot read properties of null (reading 'split')`. Guarded two adjacent cases in the same path: `WorkspaceEncoding.find()` now falls back to `utf8` for files outside every workspace folder, and `readDeclarations()` no longer dereferences a missing workspace folder.

Closes #554