### PR TITLE
Add device commands to Devices view context menu, nest device info

### DIFF
--- a/package.json
+++ b/package.json
@@ -491,34 +491,79 @@
                     "group": "inline"
                 },
                 {
-                    "command": "extension.brightscript.setActiveDevice",
-                    "when": "view == devicesView && viewItem =~ /^device-/",
-                    "group": "navigation@1"
+                    "command": "extension.brightscript.devicesView.deviceMenu.setActiveDevice",
+                    "when": "view == devicesView && viewItem =~ /^device\\b/",
+                    "group": "1_primary@1"
                 },
                 {
-                    "command": "extension.brightscript.refreshDevice",
-                    "when": "view == devicesView && viewItem =~ /^device-/",
-                    "group": "navigation@2"
+                    "command": "extension.brightscript.devicesView.deviceMenu.captureScreenshot",
+                    "when": "view == devicesView && viewItem =~ /^device\\b/",
+                    "group": "1_primary@2"
                 },
                 {
-                    "command": "extension.brightscript.addDeviceToUserSettings",
-                    "when": "view == devicesView && (viewItem == 'device' || viewItem == 'device-workspace')",
-                    "group": "settings@1"
+                    "command": "extension.brightscript.devicesView.deviceMenu.switchTvInput",
+                    "when": "view == devicesView && viewItem =~ /-isTv\\b/",
+                    "group": "1_primary@3"
                 },
                 {
-                    "command": "extension.brightscript.editDeviceInUserSettings",
-                    "when": "view == devicesView && (viewItem == 'device-user' || viewItem == 'device-user-workspace')",
-                    "group": "settings@1"
+                    "command": "extension.brightscript.devicesView.deviceMenu.refreshDevice",
+                    "when": "view == devicesView && viewItem =~ /^device\\b/",
+                    "group": "2_device@1"
                 },
                 {
-                    "command": "extension.brightscript.addDeviceToWorkspaceSettings",
-                    "when": "view == devicesView && (viewItem == 'device' || viewItem == 'device-user')",
-                    "group": "settings@2"
+                    "command": "extension.brightscript.devicesView.deviceMenu.restartDevice",
+                    "when": "view == devicesView && viewItem =~ /-canRestart\\b/",
+                    "group": "2_device@2"
                 },
                 {
-                    "command": "extension.brightscript.editDeviceInWorkspaceSettings",
-                    "when": "view == devicesView && (viewItem == 'device-workspace' || viewItem == 'device-user-workspace')",
-                    "group": "settings@2"
+                    "command": "extension.brightscript.devicesView.deviceMenu.checkAndInstallUpdates",
+                    "when": "view == devicesView && viewItem =~ /-canRestart\\b/",
+                    "group": "2_device@3"
+                },
+                {
+                    "command": "extension.brightscript.devicesView.deviceMenu.openWebPortal",
+                    "when": "view == devicesView && viewItem =~ /^device\\b/",
+                    "group": "3_web@1"
+                },
+                {
+                    "command": "extension.brightscript.devicesView.deviceMenu.viewRegistry",
+                    "when": "view == devicesView && viewItem =~ /-canViewRegistry\\b/",
+                    "group": "3_web@2"
+                },
+                {
+                    "command": "extension.brightscript.devicesView.deviceMenu.setDevicePassword",
+                    "when": "view == devicesView && viewItem =~ /-noPassword\\b/",
+                    "group": "4_password@1"
+                },
+                {
+                    "command": "extension.brightscript.devicesView.deviceMenu.changeDevicePassword",
+                    "when": "view == devicesView && viewItem =~ /-hasPassword\\b/",
+                    "group": "4_password@1"
+                },
+                {
+                    "command": "extension.brightscript.devicesView.deviceMenu.clearDevicePassword",
+                    "when": "view == devicesView && viewItem =~ /-hasPassword\\b/",
+                    "group": "4_password@2"
+                },
+                {
+                    "command": "extension.brightscript.devicesView.deviceMenu.addToUserSettings",
+                    "when": "view == devicesView && viewItem =~ /-notInUser\\b/",
+                    "group": "5_settings@1"
+                },
+                {
+                    "command": "extension.brightscript.devicesView.deviceMenu.editInUserSettings",
+                    "when": "view == devicesView && viewItem =~ /-inUser\\b/",
+                    "group": "5_settings@1"
+                },
+                {
+                    "command": "extension.brightscript.devicesView.deviceMenu.addToWorkspaceSettings",
+                    "when": "view == devicesView && viewItem =~ /-notInWorkspace\\b/",
+                    "group": "5_settings@2"
+                },
+                {
+                    "command": "extension.brightscript.devicesView.deviceMenu.editInWorkspaceSettings",
+                    "when": "view == devicesView && viewItem =~ /-inWorkspace\\b/",
+                    "group": "5_settings@2"
                 }
             ],
             "explorer/context": [
@@ -701,6 +746,66 @@
                 },
                 {
                     "command": "extension.brightscript.devicesView.toggleFilter.autoDetected.active",
+                    "when": "false"
+                },
+                {
+                    "command": "extension.brightscript.devicesView.deviceMenu.setActiveDevice",
+                    "when": "false"
+                },
+                {
+                    "command": "extension.brightscript.devicesView.deviceMenu.captureScreenshot",
+                    "when": "false"
+                },
+                {
+                    "command": "extension.brightscript.devicesView.deviceMenu.switchTvInput",
+                    "when": "false"
+                },
+                {
+                    "command": "extension.brightscript.devicesView.deviceMenu.refreshDevice",
+                    "when": "false"
+                },
+                {
+                    "command": "extension.brightscript.devicesView.deviceMenu.restartDevice",
+                    "when": "false"
+                },
+                {
+                    "command": "extension.brightscript.devicesView.deviceMenu.checkAndInstallUpdates",
+                    "when": "false"
+                },
+                {
+                    "command": "extension.brightscript.devicesView.deviceMenu.openWebPortal",
+                    "when": "false"
+                },
+                {
+                    "command": "extension.brightscript.devicesView.deviceMenu.viewRegistry",
+                    "when": "false"
+                },
+                {
+                    "command": "extension.brightscript.devicesView.deviceMenu.setDevicePassword",
+                    "when": "false"
+                },
+                {
+                    "command": "extension.brightscript.devicesView.deviceMenu.changeDevicePassword",
+                    "when": "false"
+                },
+                {
+                    "command": "extension.brightscript.devicesView.deviceMenu.clearDevicePassword",
+                    "when": "false"
+                },
+                {
+                    "command": "extension.brightscript.devicesView.deviceMenu.addToUserSettings",
+                    "when": "false"
+                },
+                {
+                    "command": "extension.brightscript.devicesView.deviceMenu.editInUserSettings",
+                    "when": "false"
+                },
+                {
+                    "command": "extension.brightscript.devicesView.deviceMenu.addToWorkspaceSettings",
+                    "when": "false"
+                },
+                {
+                    "command": "extension.brightscript.devicesView.deviceMenu.editInWorkspaceSettings",
                     "when": "false"
                 }
             ]
@@ -3913,6 +4018,81 @@
                 "title": "Check for Software Updates",
                 "category": "BrightScript",
                 "icon": "$(cloud-download)"
+            },
+            {
+                "command": "extension.brightscript.devicesView.deviceMenu.setActiveDevice",
+                "title": "⭐ Set as Active Device",
+                "category": "BrightScript"
+            },
+            {
+                "command": "extension.brightscript.devicesView.deviceMenu.captureScreenshot",
+                "title": "📷 Capture Screenshot",
+                "category": "BrightScript"
+            },
+            {
+                "command": "extension.brightscript.devicesView.deviceMenu.switchTvInput",
+                "title": "📺 Switch TV Input",
+                "category": "BrightScript"
+            },
+            {
+                "command": "extension.brightscript.devicesView.deviceMenu.refreshDevice",
+                "title": "🔃 Refresh Device",
+                "category": "BrightScript"
+            },
+            {
+                "command": "extension.brightscript.devicesView.deviceMenu.restartDevice",
+                "title": "🔁 Restart Device",
+                "category": "BrightScript"
+            },
+            {
+                "command": "extension.brightscript.devicesView.deviceMenu.checkAndInstallUpdates",
+                "title": "🔄 Check for Software Updates",
+                "category": "BrightScript"
+            },
+            {
+                "command": "extension.brightscript.devicesView.deviceMenu.openWebPortal",
+                "title": "🔗 Open Device Web Portal",
+                "category": "BrightScript"
+            },
+            {
+                "command": "extension.brightscript.devicesView.deviceMenu.viewRegistry",
+                "title": "📋 View Registry",
+                "category": "BrightScript"
+            },
+            {
+                "command": "extension.brightscript.devicesView.deviceMenu.setDevicePassword",
+                "title": "🔑 Set Device Password",
+                "category": "BrightScript"
+            },
+            {
+                "command": "extension.brightscript.devicesView.deviceMenu.changeDevicePassword",
+                "title": "🔑 Change Device Password",
+                "category": "BrightScript"
+            },
+            {
+                "command": "extension.brightscript.devicesView.deviceMenu.clearDevicePassword",
+                "title": "🗑️ Clear Device Password",
+                "category": "BrightScript"
+            },
+            {
+                "command": "extension.brightscript.devicesView.deviceMenu.addToUserSettings",
+                "title": "👤 Add to User Settings",
+                "category": "BrightScript"
+            },
+            {
+                "command": "extension.brightscript.devicesView.deviceMenu.editInUserSettings",
+                "title": "👤 Edit in User Settings",
+                "category": "BrightScript"
+            },
+            {
+                "command": "extension.brightscript.devicesView.deviceMenu.addToWorkspaceSettings",
+                "title": "📁 Add to Workspace Settings",
+                "category": "BrightScript"
+            },
+            {
+                "command": "extension.brightscript.devicesView.deviceMenu.editInWorkspaceSettings",
+                "title": "📁 Edit in Workspace Settings",
+                "category": "BrightScript"
             },
             {
                 "command": "extension.brightscript.addDeviceToUserSettings",

--- a/src/BrightScriptCommands.ts
+++ b/src/BrightScriptCommands.ts
@@ -1180,6 +1180,71 @@ export class BrightScriptCommands {
         this.registerCommand('devicesView.checkAndInstallUpdates', (element?: { key?: string }) => {
             return this.checkForUpdates(element?.key ? this.deviceManager.getDevice(element.key)?.ip : undefined);
         });
+
+        this.registerDeviceContextMenuCommands();
+    }
+
+    /**
+     * Register the commands behind the right-click context menu on a device in the Devices view.
+     * Each receives the clicked tree element and resolves it into the argument shape its
+     * underlying command expects. These are hidden from the command palette (they only make
+     * sense with a tree element), which also lets their titles carry the emoji icons shown
+     * in the context menu.
+     */
+    private registerDeviceContextMenuCommands() {
+        const getDevice = (element?: { key?: string }) => {
+            return element?.key ? this.deviceManager.getDevice(element.key) : undefined;
+        };
+
+        this.registerCommand('devicesView.deviceMenu.setActiveDevice', (element?: { key?: string }) => {
+            return vscode.commands.executeCommand('extension.brightscript.setActiveDevice', element);
+        });
+        this.registerCommand('devicesView.deviceMenu.captureScreenshot', (element?: { key?: string }) => {
+            return vscode.commands.executeCommand('extension.brightscript.captureScreenshot', getDevice(element)?.ip);
+        });
+        this.registerCommand('devicesView.deviceMenu.switchTvInput', (element?: { key?: string }) => {
+            return vscode.commands.executeCommand('extension.brightscript.changeTvInput', getDevice(element)?.ip);
+        });
+        this.registerCommand('devicesView.deviceMenu.refreshDevice', (element?: { key?: string }) => {
+            return vscode.commands.executeCommand('extension.brightscript.refreshDevice', element);
+        });
+        this.registerCommand('devicesView.deviceMenu.restartDevice', (element?: { key?: string }) => {
+            return this.restartDevice(getDevice(element)?.ip);
+        });
+        this.registerCommand('devicesView.deviceMenu.checkAndInstallUpdates', (element?: { key?: string }) => {
+            return this.checkForUpdates(getDevice(element)?.ip);
+        });
+        this.registerCommand('devicesView.deviceMenu.openWebPortal', (element?: { key?: string }) => {
+            const ip = getDevice(element)?.ip;
+            if (!ip) {
+                return vscode.window.showErrorMessage('Could not determine the IP address for this device');
+            }
+            return vscode.commands.executeCommand('extension.brightscript.openUrl', `http://${ip}`);
+        });
+        this.registerCommand('devicesView.deviceMenu.viewRegistry', (element?: { key?: string }) => {
+            return vscode.commands.executeCommand('extension.brightscript.openRegistryInBrowser', getDevice(element)?.ip);
+        });
+        // Set and Change share a handler; the menu shows one or the other based on whether a password is stored
+        for (const commandName of ['devicesView.deviceMenu.setDevicePassword', 'devicesView.deviceMenu.changeDevicePassword']) {
+            this.registerCommand(commandName, (element?: { key?: string }) => {
+                return vscode.commands.executeCommand('extension.brightscript.setDevicePassword', getDevice(element)?.serialNumber);
+            });
+        }
+        this.registerCommand('devicesView.deviceMenu.clearDevicePassword', (element?: { key?: string }) => {
+            return vscode.commands.executeCommand('extension.brightscript.clearDevicePassword', getDevice(element)?.serialNumber);
+        });
+        this.registerCommand('devicesView.deviceMenu.addToUserSettings', (element?: { key?: string }) => {
+            return vscode.commands.executeCommand('extension.brightscript.addDeviceToUserSettings', element);
+        });
+        this.registerCommand('devicesView.deviceMenu.editInUserSettings', (element?: { key?: string }) => {
+            return vscode.commands.executeCommand('extension.brightscript.editDeviceInUserSettings', element);
+        });
+        this.registerCommand('devicesView.deviceMenu.addToWorkspaceSettings', (element?: { key?: string }) => {
+            return vscode.commands.executeCommand('extension.brightscript.addDeviceToWorkspaceSettings', element);
+        });
+        this.registerCommand('devicesView.deviceMenu.editInWorkspaceSettings', (element?: { key?: string }) => {
+            return vscode.commands.executeCommand('extension.brightscript.editDeviceInWorkspaceSettings', element);
+        });
     }
 
     private async sendAsciiToDevice(character: string) {

--- a/src/viewProviders/DevicesViewProvider.spec.ts
+++ b/src/viewProviders/DevicesViewProvider.spec.ts
@@ -67,22 +67,25 @@ afterEach(() => {
 });
 
 describe('DevicesViewProvider', () => {
-    function makeDevice(overrides: { key: string; isTv?: boolean; isStick?: boolean; deviceState?: string; lastDeviceState?: string; developerEnabled?: 'true' | 'false' | undefined; isConfigured?: boolean }) {
+    function makeDevice(overrides: { key: string; isTv?: boolean; isStick?: boolean; deviceState?: string; lastDeviceState?: string; developerEnabled?: 'true' | 'false' | undefined; isConfigured?: boolean; serialNumber?: string; softwareVersion?: string; configuredIn?: string[] }) {
         return {
             key: overrides.key,
             ip: '1.2.3.4',
             deviceState: overrides.deviceState ?? 'online',
             lastDeviceState: overrides.lastDeviceState ?? 'unknown',
             isConfigured: overrides.isConfigured ?? false,
+            ...(overrides.serialNumber !== undefined ? { serialNumber: overrides.serialNumber } : {}),
+            ...(overrides.configuredIn !== undefined ? { configuredIn: overrides.configuredIn } : {}),
             deviceInfo: {
                 'is-tv': overrides.isTv ? 'true' : 'false',
                 'is-stick': overrides.isStick ? 'true' : 'false',
+                ...(overrides.softwareVersion !== undefined ? { 'software-version': overrides.softwareVersion } : {}),
                 ...(overrides.developerEnabled !== undefined ? { 'developer-enabled': overrides.developerEnabled } : {})
             } as any
         } as any;
     }
 
-    function createProvider(devices: any[]) {
+    function createProvider(devices: any[], options?: { storedPasswords?: Record<string, string> }) {
         const emitter = new EventEmitter();
         const deviceManager: any = {
             on: (event: string, handler: any) => emitter.on(event, handler),
@@ -96,7 +99,7 @@ describe('DevicesViewProvider', () => {
         };
         const credentialStore: any = {
             on: () => undefined,
-            getPassword: () => Promise.resolve(undefined)
+            getPassword: (serialNumber: string) => Promise.resolve(options?.storedPasswords?.[serialNumber])
         };
         const provider = new DevicesViewProvider(deviceManager, credentialStore, vscode.context as any);
         return { provider: provider, deviceManager: deviceManager, emitter: emitter };
@@ -118,7 +121,7 @@ describe('DevicesViewProvider', () => {
             ];
             const { provider } = createProvider(devices);
             const items = await provider.getChildren();
-            expect(items.map(i => (i).key)).to.deep.equal(['tv-online', 'stick-online', 'stb-online']);
+            expect(items.map(i => (i as any).key)).to.deep.equal(['tv-online', 'stick-online', 'stb-online']);
         });
 
         it('hides TVs when the TV filter is off', async () => {
@@ -130,7 +133,7 @@ describe('DevicesViewProvider', () => {
             seedFilters({ tv: false });
             const { provider } = createProvider(devices);
             const items = await provider.getChildren();
-            expect(items.map(i => (i).key)).to.deep.equal(['stb1', 'stick1']);
+            expect(items.map(i => (i as any).key)).to.deep.equal(['stb1', 'stick1']);
         });
 
         it('hides offline devices when the offline filter is off (pending with prior online stays visible)', async () => {
@@ -142,7 +145,7 @@ describe('DevicesViewProvider', () => {
             ];
             const { provider } = createProvider(devices);
             const items = await provider.getChildren();
-            expect(items.map(i => (i).key)).to.deep.equal(['on1', 'pending-was-online']);
+            expect(items.map(i => (i as any).key)).to.deep.equal(['on1', 'pending-was-online']);
         });
 
         it('hides online devices when the online filter is off (pending with prior online counts as online)', async () => {
@@ -155,7 +158,7 @@ describe('DevicesViewProvider', () => {
             seedFilters({ online: false, offline: true });
             const { provider } = createProvider(devices);
             const items = await provider.getChildren();
-            expect(items.map(i => (i).key)).to.deep.equal(['off1', 'pending-first-load']);
+            expect(items.map(i => (i as any).key)).to.deep.equal(['off1', 'pending-first-load']);
         });
 
         it('treats missing developer-enabled as enabled', async () => {
@@ -167,7 +170,7 @@ describe('DevicesViewProvider', () => {
             seedFilters({ devModeEnabled: false, devModeDisabled: true, offline: true });
             const { provider } = createProvider(devices);
             const items = await provider.getChildren();
-            expect(items.map(i => (i).key)).to.deep.equal(['explicit-off']);
+            expect(items.map(i => (i as any).key)).to.deep.equal(['explicit-off']);
         });
 
         it('hides user-defined devices when the userDefined filter is off', async () => {
@@ -178,7 +181,7 @@ describe('DevicesViewProvider', () => {
             seedFilters({ userDefined: false });
             const { provider } = createProvider(devices);
             const items = await provider.getChildren();
-            expect(items.map(i => (i).key)).to.deep.equal(['discovered1']);
+            expect(items.map(i => (i as any).key)).to.deep.equal(['discovered1']);
         });
 
         it('hides auto-detected devices when the autoDetected filter is off', async () => {
@@ -189,14 +192,80 @@ describe('DevicesViewProvider', () => {
             seedFilters({ autoDetected: false });
             const { provider } = createProvider(devices);
             const items = await provider.getChildren();
-            expect(items.map(i => (i).key)).to.deep.equal(['configured1']);
+            expect(items.map(i => (i as any).key)).to.deep.equal(['configured1']);
         });
 
         it('uses defaults when no filter settings are present', async () => {
             const devices = [makeDevice({ key: 'stb-online' })];
             const { provider } = createProvider(devices);
             const items = await provider.getChildren();
-            expect(items.map(i => (i).key)).to.deep.equal(['stb-online']);
+            expect(items.map(i => (i as any).key)).to.deep.equal(['stb-online']);
+        });
+    });
+
+    describe('device tree structure', () => {
+        it('builds a capability-token contextValue for a fully-capable device', async () => {
+            const devices = [makeDevice({ key: 'tv1', isTv: true, softwareVersion: '15.3.4', serialNumber: 'SERIAL1' })];
+            const { provider } = createProvider(devices);
+            const items = await provider.getChildren();
+            expect(items[0].contextValue).to.equal('device-notInUser-notInWorkspace-noPassword-isTv-canViewRegistry-canRestart');
+        });
+
+        it('includes hasPassword and configured-in tokens, and gates version-specific tokens', async () => {
+            const devices = [makeDevice({ key: 'stb1', softwareVersion: '12.0.0', serialNumber: 'SERIAL2', configuredIn: ['user', 'workspace'] })];
+            const { provider } = createProvider(devices, { storedPasswords: { SERIAL2: 'secret' } });
+            const items = await provider.getChildren();
+            expect(items[0].contextValue).to.equal('device-inUser-inWorkspace-hasPassword-canViewRegistry');
+        });
+
+        it('omits password and version-gated tokens when serial number and software version are unknown', async () => {
+            const devices = [makeDevice({ key: 'stb1' })];
+            const { provider } = createProvider(devices);
+            const items = await provider.getChildren();
+            expect(items[0].contextValue).to.equal('device-notInUser-notInWorkspace');
+        });
+
+        it('lists the action items followed by an expandable Device Info group holding the info fields', async () => {
+            const devices = [makeDevice({ key: 'stb1' })];
+            const { provider } = createProvider(devices);
+            const [deviceItem] = await provider.getChildren();
+
+            const deviceChildren = await provider.getChildren(deviceItem);
+            expect(deviceChildren.map(child => child.label)).to.deep.equal([
+                '🔗 Open device web portal',
+                '⭐ Set as Active Device',
+                '📷 Capture Screenshot',
+                'Device Info'
+            ]);
+
+            const deviceInfoGroup = deviceChildren[deviceChildren.length - 1];
+            expect(deviceInfoGroup.collapsibleState).to.equal((vscode as any).TreeItemCollapsibleState.Collapsed);
+
+            const infoItems = await provider.getChildren(deviceInfoGroup);
+            expect(infoItems.map(item => (item as any).key)).to.include.members(['is-tv', 'is-stick']);
+            for (const infoItem of infoItems) {
+                expect((infoItem as any).command?.command).to.equal('extension.brightscript.copyToClipboard');
+            }
+        });
+
+        it('includes the version-gated and device-specific action items when the device supports them', async () => {
+            const devices = [makeDevice({ key: 'tv1', isTv: true, softwareVersion: '15.3.4', serialNumber: 'SERIAL1' })];
+            const { provider } = createProvider(devices, { storedPasswords: { SERIAL1: 'secret' } });
+            const [deviceItem] = await provider.getChildren();
+
+            const deviceChildren = await provider.getChildren(deviceItem);
+            expect(deviceChildren.map(child => child.label)).to.deep.equal([
+                '🔗 Open device web portal',
+                '🔁 Restart Device',
+                '🔄 Check for Software Updates',
+                '📋 View Registry',
+                '🔑 Change Device Password',
+                '🗑️ Clear Device Password',
+                '⭐ Set as Active Device',
+                '📷 Capture Screenshot',
+                '📺 Switch TV Input',
+                'Device Info'
+            ]);
         });
     });
 
@@ -262,7 +331,7 @@ describe('DevicesViewProvider', () => {
             const { provider } = createProvider(devices);
             // Confirm seeded override is honored before the reset
             let items = await provider.getChildren();
-            expect(items.map(i => (i).key)).to.deep.equal(['stb1']);
+            expect(items.map(i => (i as any).key)).to.deep.equal(['stb1']);
 
             const treeChanged = sinon.spy();
             provider.onDidChangeTreeData(treeChanged);
@@ -271,7 +340,7 @@ describe('DevicesViewProvider', () => {
 
             expect(treeChanged.called).to.be.true;
             items = await provider.getChildren();
-            expect(items.map(i => (i).key)).to.deep.equal(['tv1', 'stb1']);
+            expect(items.map(i => (i as any).key)).to.deep.equal(['tv1', 'stb1']);
         });
 
         it('is a no-op on persistence when nothing was overridden', async () => {
@@ -298,7 +367,7 @@ describe('DevicesViewProvider', () => {
 
             expect(treeChanged.called).to.be.true;
             const items = await provider.getChildren();
-            expect(items.map(i => (i).key)).to.deep.equal(['stb1']);
+            expect(items.map(i => (i as any).key)).to.deep.equal(['stb1']);
         });
 
         it('ignores changes to unrelated configuration sections', () => {

--- a/src/viewProviders/DevicesViewProvider.ts
+++ b/src/viewProviders/DevicesViewProvider.ts
@@ -94,8 +94,8 @@ export class DevicesViewProvider implements vscode.TreeDataProvider<vscode.TreeI
 
         // Health check device when expanded (not on every getChildren/devices-changed)
         treeView.onDidExpandElement(e => {
-            const element = e.element as DeviceTreeItem;
-            if (element?.contextValue === 'device' && element.key) {
+            const element = e.element;
+            if (element instanceof DeviceTreeItem && element.key) {
                 const device = this.deviceManager.getDevice(element.key);
                 if (device) {
                     this.deviceManager.healthCheckDevice(device).catch(() => { });
@@ -152,7 +152,7 @@ export class DevicesViewProvider implements vscode.TreeDataProvider<vscode.TreeI
 
     private devices: Array<RokuDevice>;
 
-    async getChildren(element?: DeviceTreeItem | DeviceInfoTreeItem): Promise<DeviceTreeItem[] | DeviceInfoTreeItem[]> {
+    async getChildren(element?: vscode.TreeItem): Promise<vscode.TreeItem[]> {
         if (!element) {
             // Fetch directly if devices haven't been populated yet (avoids debounce delay on initial load)
             if (this.devices.length === 0) {
@@ -163,7 +163,7 @@ export class DevicesViewProvider implements vscode.TreeDataProvider<vscode.TreeI
                 let items: DeviceTreeItem[] = [];
                 const visibleDevices = this.applyFilters(this.devices);
                 for (const device of visibleDevices) {
-                    // Make a rook item for each device
+                    // Make a root item for each device
                     let treeItem = new DeviceTreeItem(
                         this.deviceManager.getDeviceDisplayName(device),
                         vscode.TreeItemCollapsibleState.Collapsed,
@@ -176,20 +176,7 @@ export class DevicesViewProvider implements vscode.TreeDataProvider<vscode.TreeI
                     // Use the device key which is serial-based when available, IP-based as fallback
                     treeItem.resourceUri = vscode.Uri.parse(`${DEVICE_URI_SCHEME}:/${device.key}`);
                     treeItem.iconPath = this.deviceManager.getIconPath(device);
-
-                    // Set contextValue for context menu actions
-                    // Values: device, device-user, device-workspace, device-user-workspace
-                    const inUser = device.configuredIn?.includes('user');
-                    const inWorkspace = device.configuredIn?.includes('workspace');
-                    let contextValue = 'device';
-                    if (inUser && inWorkspace) {
-                        contextValue = 'device-user-workspace';
-                    } else if (inUser) {
-                        contextValue = 'device-user';
-                    } else if (inWorkspace) {
-                        contextValue = 'device-workspace';
-                    }
-                    treeItem.contextValue = contextValue;
+                    treeItem.contextValue = await this.buildDeviceContextValue(device);
 
                     items.push(treeItem);
                 }
@@ -201,11 +188,165 @@ export class DevicesViewProvider implements vscode.TreeDataProvider<vscode.TreeI
                 return [];
             }
         } else if (element instanceof DeviceTreeItem) {
+            // Build the device's action items (also available in the right-click context menu),
+            // followed by the expandable device info group
+            let result: Array<vscode.TreeItem> = [];
+
+            const device = this.deviceManager.getDevice(element.key);
+            if (!device) {
+                return;
+            }
+
+            result.push(
+                this.createDeviceInfoTreeItem({
+                    label: '🔗 Open device web portal',
+                    parent: element,
+                    collapsibleState: vscode.TreeItemCollapsibleState.None,
+                    tooltip: 'Open the web portal for this device',
+                    description: device.ip,
+                    command: {
+                        command: 'extension.brightscript.openUrl',
+                        title: 'Open',
+                        arguments: [`http://${device.ip}`]
+                    }
+                })
+            );
+
+            // Device actions that require software version 15.0.4 or later
+            if (semver.satisfies(element.details['software-version'], '>=15.0.4')) {
+                result.push(
+                    this.createDeviceInfoTreeItem({
+                        label: '🔁 Restart Device',
+                        parent: element,
+                        collapsibleState: vscode.TreeItemCollapsibleState.None,
+                        tooltip: 'Restart this device',
+                        command: {
+                            command: 'extension.brightscript.devicesView.restartDevice',
+                            title: 'Restart Device',
+                            arguments: [{ key: element.key }]
+                        }
+                    })
+                );
+
+                result.push(
+                    this.createDeviceInfoTreeItem({
+                        label: '🔄 Check for Software Updates',
+                        parent: element,
+                        collapsibleState: vscode.TreeItemCollapsibleState.None,
+                        tooltip: 'Check for and install software updates',
+                        command: {
+                            command: 'extension.brightscript.devicesView.checkAndInstallUpdates',
+                            title: 'Check for Updates',
+                            arguments: [{ key: element.key }]
+                        }
+                    })
+                );
+            }
+
+            if (semver.satisfies(element.details['software-version'], '>=11')) {
+                // TODO: add ECP system hooks here in the future (like registry call, etc...)
+                result.push(
+                    this.createDeviceInfoTreeItem({
+                        label: '📋 View Registry',
+                        parent: element,
+                        collapsibleState: vscode.TreeItemCollapsibleState.None,
+                        tooltip: 'View the ECP Registry',
+                        description: device.ip,
+                        command: {
+                            command: 'extension.brightscript.openRegistryInBrowser',
+                            title: 'Open',
+                            arguments: [device.ip]
+                        }
+                    })
+                );
+            }
+
+            if (device.serialNumber) {
+                const hasPassword = await this.hasStoredPasswordForSerial(device.serialNumber);
+                result.push(
+                    this.createDeviceInfoTreeItem({
+                        label: hasPassword ? '🔑 Change Device Password' : '🔑 Set Device Password',
+                        parent: element,
+                        collapsibleState: vscode.TreeItemCollapsibleState.None,
+                        tooltip: hasPassword ? 'Change the stored developer password for this device' : 'Set password for this device',
+                        command: {
+                            command: 'extension.brightscript.setDevicePassword',
+                            title: hasPassword ? 'Change Device Password' : 'Set Device Password',
+                            arguments: [device.serialNumber]
+                        }
+                    })
+                );
+                if (hasPassword) {
+                    result.push(
+                        this.createDeviceInfoTreeItem({
+                            label: '🗑️ Clear Device Password',
+                            parent: element,
+                            collapsibleState: vscode.TreeItemCollapsibleState.None,
+                            tooltip: 'Clear the stored developer password for this device',
+                            command: {
+                                command: 'extension.brightscript.clearDevicePassword',
+                                title: 'Clear Device Password',
+                                arguments: [device.serialNumber]
+                            }
+                        })
+                    );
+                }
+            }
+
+            result.push(
+                this.createDeviceInfoTreeItem({
+                    label: '⭐ Set as Active Device',
+                    parent: element,
+                    collapsibleState: vscode.TreeItemCollapsibleState.None,
+                    tooltip: 'Set as active device',
+                    command: {
+                        command: 'extension.brightscript.setActiveDevice',
+                        title: 'Set Active Device',
+                        arguments: [device.ip]
+                    }
+                })
+            );
+
+            result.push(
+                this.createDeviceInfoTreeItem({
+                    label: '📷 Capture Screenshot',
+                    parent: element,
+                    collapsibleState: vscode.TreeItemCollapsibleState.None,
+                    tooltip: 'Capture a screenshot',
+                    command: {
+                        command: 'extension.brightscript.captureScreenshot',
+                        title: 'Capture Screenshot',
+                        arguments: [device.ip]
+                    }
+                })
+            );
+
+            if (device.deviceInfo?.['is-tv'] === 'true') {
+                result.push(
+                    this.createDeviceInfoTreeItem({
+                        label: '📺 Switch TV Input',
+                        parent: element,
+                        collapsibleState: vscode.TreeItemCollapsibleState.None,
+                        description: 'click to change',
+                        tooltip: 'Change the current TV input',
+                        command: {
+                            command: 'extension.brightscript.changeTvInput',
+                            title: 'Switch TV Input',
+                            arguments: [device.ip]
+                        }
+                    })
+                );
+            }
+
+            result.push(new DeviceInfoGroupTreeItem(element));
+
+            return result;
+        } else if (element instanceof DeviceInfoGroupTreeItem) {
             // Process the details of a device
             let result: Array<DeviceInfoTreeItem> = [];
 
             //conceal all of these unique keys
-            const details = this.concealObject(element.details, ['udn', 'device-id', 'advertising-id', 'wifi-mac', 'ethernet-mac', 'serial-number', 'keyed-developer-id']);
+            const details = this.concealObject(element.parent.details, ['udn', 'device-id', 'advertising-id', 'wifi-mac', 'ethernet-mac', 'serial-number', 'keyed-developer-id']);
 
             for (let [key, values] of details) {
                 result.push(
@@ -227,160 +368,39 @@ export class DevicesViewProvider implements vscode.TreeDataProvider<vscode.TreeI
                 );
             }
 
-            const device = this.deviceManager.getDevice(element.key);
-            if (!device) {
-                return;
-            }
-
-            if (device.deviceInfo?.['is-tv'] === 'true') {
-                result.unshift(
-                    this.createDeviceInfoTreeItem({
-                        label: '📺 Switch TV Input',
-                        parent: element,
-                        collapsibleState: vscode.TreeItemCollapsibleState.None,
-                        description: 'click to change',
-                        tooltip: 'Change the current TV input',
-                        command: {
-                            command: 'extension.brightscript.changeTvInput',
-                            title: 'Switch TV Input',
-                            arguments: [device.ip]
-                        }
-                    })
-                );
-            }
-
-            result.unshift(
-                this.createDeviceInfoTreeItem({
-                    label: '📷 Capture Screenshot',
-                    parent: element,
-                    collapsibleState: vscode.TreeItemCollapsibleState.None,
-                    tooltip: 'Capture a screenshot',
-                    command: {
-                        command: 'extension.brightscript.captureScreenshot',
-                        title: 'Capture Screenshot',
-                        arguments: [device.ip]
-                    }
-                })
-            );
-
-            result.unshift(
-                this.createDeviceInfoTreeItem({
-                    label: '⭐ Set as Active Device',
-                    parent: element,
-                    collapsibleState: vscode.TreeItemCollapsibleState.None,
-                    tooltip: 'Set as active device',
-                    command: {
-                        command: 'extension.brightscript.setActiveDevice',
-                        title: 'Set Active Device',
-                        arguments: [device.ip]
-                    }
-                })
-            );
-
-            if (device.serialNumber) {
-                const hasPassword = await this.hasStoredPasswordForSerial(device.serialNumber);
-                if (hasPassword) {
-                    result.unshift(
-                        this.createDeviceInfoTreeItem({
-                            label: '🗑️ Clear Device Password',
-                            parent: element,
-                            collapsibleState: vscode.TreeItemCollapsibleState.None,
-                            tooltip: 'Clear the stored developer password for this device',
-                            command: {
-                                command: 'extension.brightscript.clearDevicePassword',
-                                title: 'Clear Device Password',
-                                arguments: [device.serialNumber]
-                            }
-                        })
-                    );
-                }
-                result.unshift(
-                    this.createDeviceInfoTreeItem({
-                        label: hasPassword ? '🔑 Change Device Password' : '🔑 Set Device Password',
-                        parent: element,
-                        collapsibleState: vscode.TreeItemCollapsibleState.None,
-                        tooltip: hasPassword ? 'Change the stored developer password for this device' : 'Set password for this device',
-                        command: {
-                            command: 'extension.brightscript.setDevicePassword',
-                            title: hasPassword ? 'Change Device Password' : 'Set Device Password',
-                            arguments: [device.serialNumber]
-                        }
-                    })
-                );
-            }
-
-            if (semver.satisfies(element.details['software-version'], '>=11')) {
-                // TODO: add ECP system hooks here in the future (like registry call, etc...)
-                result.unshift(
-                    this.createDeviceInfoTreeItem({
-                        label: '📋 View Registry',
-                        parent: element,
-                        collapsibleState: vscode.TreeItemCollapsibleState.None,
-                        tooltip: 'View the ECP Registry',
-                        description: device.ip,
-                        command: {
-                            command: 'extension.brightscript.openRegistryInBrowser',
-                            title: 'Open',
-                            arguments: [device.ip]
-                        }
-                    })
-                );
-            }
-
-            // Device actions that require software version 15.0.4 or later
-            if (semver.satisfies(element.details['software-version'], '>=15.0.4')) {
-                result.unshift(
-                    this.createDeviceInfoTreeItem({
-                        label: '🔄 Check for Software Updates',
-                        parent: element,
-                        collapsibleState: vscode.TreeItemCollapsibleState.None,
-                        tooltip: 'Check for and install software updates',
-                        command: {
-                            command: 'extension.brightscript.devicesView.checkAndInstallUpdates',
-                            title: 'Check for Updates',
-                            arguments: [{ key: element.key }]
-                        }
-                    })
-                );
-
-                result.unshift(
-                    this.createDeviceInfoTreeItem({
-                        label: '🔁 Restart Device',
-                        parent: element,
-                        collapsibleState: vscode.TreeItemCollapsibleState.None,
-                        tooltip: 'Restart this device',
-                        command: {
-                            command: 'extension.brightscript.devicesView.restartDevice',
-                            title: 'Restart Device',
-                            arguments: [{ key: element.key }]
-                        }
-                    })
-                );
-            }
-
-            result.unshift(
-                this.createDeviceInfoTreeItem({
-                    label: '🔗 Open device web portal',
-                    parent: element,
-                    collapsibleState: vscode.TreeItemCollapsibleState.None,
-                    tooltip: 'Open the web portal for this device',
-                    description: device.ip,
-                    command: {
-                        command: 'extension.brightscript.openUrl',
-                        title: 'Open',
-                        arguments: [`http://${device.ip}`]
-                    }
-                })
-            );
-
             // Return the device details
             return result;
         }
     }
 
+    /**
+     * Build the contextValue for a device row. The value is a dash-separated list of capability
+     * tokens that the `view/item/context` menu entries in package.json match against with regex
+     * `when` clauses to decide which context menu entries to show for the device.
+     */
+    private async buildDeviceContextValue(device: RokuDevice): Promise<string> {
+        const tokens = ['device'];
+        tokens.push(device.configuredIn?.includes('user') ? 'inUser' : 'notInUser');
+        tokens.push(device.configuredIn?.includes('workspace') ? 'inWorkspace' : 'notInWorkspace');
+        if (device.serialNumber) {
+            tokens.push(await this.hasStoredPasswordForSerial(device.serialNumber) ? 'hasPassword' : 'noPassword');
+        }
+        if (device.deviceInfo?.['is-tv'] === 'true') {
+            tokens.push('isTv');
+        }
+        const softwareVersion = device.deviceInfo?.['software-version'];
+        if (semver.satisfies(softwareVersion, '>=11')) {
+            tokens.push('canViewRegistry');
+        }
+        if (semver.satisfies(softwareVersion, '>=15.0.4')) {
+            tokens.push('canRestart');
+        }
+        return tokens.join('-');
+    }
+
     private createDeviceInfoTreeItem(options: {
         label: string;
-        parent: DeviceTreeItem;
+        parent: DeviceTreeItem | DeviceInfoGroupTreeItem;
         collapsibleState: vscode.TreeItemCollapsibleState;
         key?: string;
         description?: string;
@@ -407,7 +427,7 @@ export class DevicesViewProvider implements vscode.TreeDataProvider<vscode.TreeI
      * Currently we don't modify this element so it is just returned back.
      * @param element the requested element
      */
-    getParent?(element: DeviceTreeItem | DeviceInfoTreeItem): vscode.ProviderResult<vscode.TreeItem> {
+    getParent?(element: DeviceTreeItem | DeviceInfoGroupTreeItem | DeviceInfoTreeItem): vscode.ProviderResult<vscode.TreeItem> {
         return element?.parent;
     }
 
@@ -573,10 +593,24 @@ class DeviceTreeItem extends vscode.TreeItem {
 
     public readonly parent = null;
 }
+/**
+ * The expandable "Device Info" group shown as the only child of a device. Its children
+ * are the individual device-info fields reported by the device.
+ */
+class DeviceInfoGroupTreeItem extends vscode.TreeItem {
+    constructor(
+        public readonly parent: DeviceTreeItem
+    ) {
+        super('Device Info', vscode.TreeItemCollapsibleState.Collapsed);
+        this.contextValue = 'deviceInfoGroup';
+        this.tooltip = 'Information reported by this device';
+        this.iconPath = new vscode.ThemeIcon('info');
+    }
+}
 class DeviceInfoTreeItem extends vscode.TreeItem {
     constructor(
         public readonly label: string,
-        public readonly parent: DeviceTreeItem,
+        public readonly parent: DeviceTreeItem | DeviceInfoGroupTreeItem,
         public readonly collapsibleState: vscode.TreeItemCollapsibleState,
         public readonly key: string,
         public readonly description: string,


### PR DESCRIPTION
## What this does

- Right-clicking a device in the Devices view now shows every device command (set active, capture screenshot, switch TV input, refresh, restart, check for software updates, open web portal, view registry, set/change/clear password, add/edit settings). VS Code doesn't render codicons in tree context menus, so the menu entries use the same emoji as the tree action items. The menu-only commands are hidden from the command palette.
- Device rows now carry a capability-token `contextValue` (e.g. `device-notInUser-inWorkspace-noPassword-isTv-canViewRegistry-canRestart`) so the menu `when` clauses can honor the same conditions the tree items use (firmware version, serial number, TV, stored password, configured-in scope).
- The device info fields are nested under an expandable **Device Info** group instead of sitting alongside the action items. Click-to-copy and the conceal-device-info setting still work the same.
- Fixes "Set as Active Device" and "Refresh Device" never appearing in the context menu for auto-discovered devices (the old `/^device-/` when clause didn't match the plain `device` contextValue).
<img width="452" height="404" alt="image" src="https://github.com/user-attachments/assets/7acbead9-1824-4331-8106-b4cd61d3bafa" />
