### PR TITLE
Persist active device and re-resolve its IP by serial number

### DIFF
--- a/src/BrightScriptCommands.ts
+++ b/src/BrightScriptCommands.ts
@@ -444,8 +444,7 @@ export class BrightScriptCommands {
             if (!ip) {
                 throw new Error('Tried to set active device but failed.');
             } else {
-                await this.context.workspaceState.update('remoteHost', ip);
-                await vscodeContextManager.set('activeHost', ip);
+                await this.deviceManager.setActiveDevice(ip);
                 await util.showTimedNotification(`'${ip}' set as active device`);
             }
         });
@@ -588,8 +587,7 @@ export class BrightScriptCommands {
         });
 
         this.registerCommand('clearActiveDevice', async () => {
-            await this.context.workspaceState.update('remoteHost', '');
-            await vscodeContextManager.set('activeHost', '');
+            await this.deviceManager.clearActiveDevice();
             await util.showTimedNotification('Active device cleared');
         });
 

--- a/src/DebugConfigurationProvider.spec.ts
+++ b/src/DebugConfigurationProvider.spec.ts
@@ -268,6 +268,32 @@ describe('BrightScriptConfigurationProvider', () => {
                 }
                 expect(threw?.message).to.contain('unable to reach device');
             });
+
+            it('forgets the saved active device when it could not be located and the picker resolved a host', async () => {
+                const deviceInfo = { 'serial-number': 'abc123', 'developer-enabled': 'true' };
+                const device = { ip: '1.2.3.4', serialNumber: 'abc123', deviceInfo: deviceInfo } as any;
+                //the active device failed its health check, so the picker was shown
+                (configProvider as any).brightScriptCommands = { getHealthyActiveHost: sinon.stub().resolves(undefined) };
+                sinon.stub(userInputManager, 'promptForHost').resolves({ host: '1.2.3.4', deviceInfo: deviceInfo });
+                sinon.stub(deviceManager, 'getDevice').returns(device);
+                const forgetStub = sinon.stub(deviceManager, 'forgetActiveDeviceIfDifferent').resolves();
+
+                await (configProvider as any).processHostParameter({ host: '' });
+
+                expect(forgetStub.calledOnceWith('1.2.3.4')).to.be.true;
+            });
+
+            it('does not forget the active device when the active host resolved healthy', async () => {
+                const deviceInfo = { 'serial-number': 'abc123', 'developer-enabled': 'true' };
+                const device = { ip: '1.2.3.4', serialNumber: 'abc123', deviceInfo: deviceInfo } as any;
+                (configProvider as any).brightScriptCommands = { getHealthyActiveHost: sinon.stub().resolves({ host: '1.2.3.4', deviceInfo: deviceInfo }) };
+                sinon.stub(deviceManager, 'getDevice').returns(device);
+                const forgetStub = sinon.stub(deviceManager, 'forgetActiveDeviceIfDifferent').resolves();
+
+                await (configProvider as any).processHostParameter({ host: '' });
+
+                expect(forgetStub.called).to.be.false;
+            });
         });
 
         it('uses the default values if not provided', async () => {

--- a/src/DebugConfigurationProvider.ts
+++ b/src/DebugConfigurationProvider.ts
@@ -506,8 +506,15 @@ export class BrightScriptDebugConfigurationProvider implements DebugConfiguratio
         if (needsHostPrompt) {
             // both the active-host lookup and the picker probe + register the device in the device
             // manager, so reuse it below instead of probing again
-            const resolved = await this.brightScriptCommands.getHealthyActiveHost() ??
-                await this.userInputManager.promptForHost();
+            let resolved = await this.brightScriptCommands.getHealthyActiveHost();
+            if (!resolved) {
+                resolved = await this.userInputManager.promptForHost();
+                if (resolved?.host) {
+                    //the active device (if there was one) couldn't be located and the user picked a device
+                    //themselves, so forget the saved active device unless they picked that same device
+                    await this.deviceManager.forgetActiveDeviceIfDifferent(resolved.host);
+                }
+            }
             config.host = resolved?.host;
             if (resolved?.host) {
                 device = this.deviceManager.getDevice({ ip: resolved.host });

--- a/src/deviceDiscovery/DeviceManager.spec.ts
+++ b/src/deviceDiscovery/DeviceManager.spec.ts
@@ -5,6 +5,7 @@ import { vscode } from '../mockVscode.spec';
 import type { RokuDevice } from './DeviceManager';
 import { DeviceManager } from './DeviceManager';
 import * as NetworkChangeMonitorModule from './NetworkChangeMonitor';
+import { vscodeContextManager } from '../managers/VscodeContextManager';
 import { util } from '../util';
 
 describe('DeviceManager', () => {
@@ -2044,6 +2045,135 @@ describe('DeviceManager', () => {
             const entry = manager['configuredDevices'][0];
             expect(entry.state).to.equal('unknown');
             expect(entry.lastState).to.equal('online');
+        });
+    });
+
+    describe('active device persistence', () => {
+        it('setActiveDevice persists the serial number alongside the IP', async () => {
+            manager = new DeviceManager(vscode.context, mockGlobalStateManager);
+            manager['discoveredDevices'].push({ ip: '192.168.1.100', serialNumber: 'device-123' });
+
+            await manager.setActiveDevice('192.168.1.100');
+
+            expect(vscode.context.workspaceState.get('remoteHost')).to.equal('192.168.1.100');
+            expect(vscode.context.workspaceState.get(DeviceManager.ACTIVE_DEVICE_STATE_KEY)).to.eql({
+                serialNumber: 'device-123',
+                ip: '192.168.1.100'
+            });
+        });
+
+        it('setActiveDevice persists just the IP when the serial number is unknown', async () => {
+            manager = new DeviceManager(vscode.context, mockGlobalStateManager);
+
+            await manager.setActiveDevice('192.168.1.100');
+
+            expect(vscode.context.workspaceState.get(DeviceManager.ACTIVE_DEVICE_STATE_KEY)).to.eql({
+                serialNumber: undefined,
+                ip: '192.168.1.100'
+            });
+        });
+
+        it('clearActiveDevice clears the persisted entry', async () => {
+            manager = new DeviceManager(vscode.context, mockGlobalStateManager);
+            await manager.setActiveDevice('192.168.1.100');
+
+            await manager.clearActiveDevice();
+
+            expect(vscode.context.workspaceState.get('remoteHost')).to.equal('');
+            expect(vscode.context.workspaceState.get(DeviceManager.ACTIVE_DEVICE_STATE_KEY)).to.be.undefined;
+        });
+
+        it('recovers the active device by serial number on startup', async () => {
+            //active device persisted by a previous session at an old IP
+            await vscode.context.workspaceState.update(DeviceManager.ACTIVE_DEVICE_STATE_KEY, { serialNumber: 'device-123', ip: '192.168.1.50' });
+            await vscode.context.workspaceState.update('remoteHost', '192.168.1.50');
+            //the SN↔IP store knows the device now lives at a new IP on this network
+            mockGlobalStateManager.setSerialNumberForIp('test-network-hash', '192.168.1.60', 'device-123');
+
+            manager = new DeviceManager(vscode.context, mockGlobalStateManager);
+            await manager['syncActiveDevice']();
+
+            expect(vscode.context.workspaceState.get('remoteHost')).to.equal('192.168.1.60');
+            expect(vscode.context.workspaceState.get(DeviceManager.ACTIVE_DEVICE_STATE_KEY)).to.eql({
+                serialNumber: 'device-123',
+                ip: '192.168.1.60'
+            });
+            expect(vscodeContextManager.get('activeHost')).to.equal('192.168.1.60');
+        });
+
+        it('leaves remoteHost alone when something else has since pointed it elsewhere', async () => {
+            await vscode.context.workspaceState.update(DeviceManager.ACTIVE_DEVICE_STATE_KEY, { serialNumber: 'device-123', ip: '192.168.1.50' });
+            //e.g. a debug launch set remoteHost to a different host after the active device was chosen
+            await vscode.context.workspaceState.update('remoteHost', '192.168.1.99');
+            mockGlobalStateManager.setSerialNumberForIp('test-network-hash', '192.168.1.60', 'device-123');
+
+            manager = new DeviceManager(vscode.context, mockGlobalStateManager);
+            await manager['syncActiveDevice']();
+
+            expect(vscode.context.workspaceState.get('remoteHost')).to.equal('192.168.1.99');
+            expect(vscode.context.workspaceState.get(DeviceManager.ACTIVE_DEVICE_STATE_KEY)).to.eql({
+                serialNumber: 'device-123',
+                ip: '192.168.1.60'
+            });
+        });
+
+        it('re-points the active device when a network change finds it at a new IP', async () => {
+            manager = new DeviceManager(vscode.context, mockGlobalStateManager);
+            await vscode.context.workspaceState.update(DeviceManager.ACTIVE_DEVICE_STATE_KEY, { serialNumber: 'device-123', ip: '192.168.1.50' });
+            await vscode.context.workspaceState.update('remoteHost', '192.168.1.50');
+
+            (NetworkChangeMonitorModule.getNetworkHash as sinon.SinonStub).returns('new-network-hash');
+            mockGlobalStateManager.setSerialNumberForIp('new-network-hash', '10.0.0.5', 'device-123');
+
+            const syncSpy = sinon.spy(manager as any, 'syncActiveDevice');
+            manager['networkChangeMonitor']['onNetworkChanged']();
+            await Promise.all(syncSpy.returnValues);
+
+            expect(vscode.context.workspaceState.get('remoteHost')).to.equal('10.0.0.5');
+            expect(vscode.context.workspaceState.get(DeviceManager.ACTIVE_DEVICE_STATE_KEY)).to.eql({
+                serialNumber: 'device-123',
+                ip: '10.0.0.5'
+            });
+        });
+
+        it('follows the active device when discovery sees it at a new IP', async () => {
+            manager = new DeviceManager(vscode.context, mockGlobalStateManager);
+            await vscode.context.workspaceState.update(DeviceManager.ACTIVE_DEVICE_STATE_KEY, { serialNumber: 'device-123', ip: '192.168.1.50' });
+            await vscode.context.workspaceState.update('remoteHost', '192.168.1.50');
+
+            const syncSpy = sinon.spy(manager as any, 'syncActiveDevice');
+            manager['setDiscoveredDevice']('192.168.1.60', 'device-123');
+            await Promise.all(syncSpy.returnValues);
+
+            expect(vscode.context.workspaceState.get('remoteHost')).to.equal('192.168.1.60');
+            expect(vscode.context.workspaceState.get(DeviceManager.ACTIVE_DEVICE_STATE_KEY)).to.eql({
+                serialNumber: 'device-123',
+                ip: '192.168.1.60'
+            });
+        });
+
+        it('does not follow discovery updates for devices that are not the active device', async () => {
+            manager = new DeviceManager(vscode.context, mockGlobalStateManager);
+            await vscode.context.workspaceState.update(DeviceManager.ACTIVE_DEVICE_STATE_KEY, { serialNumber: 'device-123', ip: '192.168.1.50' });
+            await vscode.context.workspaceState.update('remoteHost', '192.168.1.50');
+
+            const syncSpy = sinon.spy(manager as any, 'syncActiveDevice');
+            manager['setDiscoveredDevice']('192.168.1.60', 'device-456');
+            await Promise.all(syncSpy.returnValues);
+
+            expect(syncSpy.called).to.be.false;
+            expect(vscode.context.workspaceState.get('remoteHost')).to.equal('192.168.1.50');
+        });
+
+        it('keeps the last known IP when the serial number cannot be found in the stores', async () => {
+            await vscode.context.workspaceState.update(DeviceManager.ACTIVE_DEVICE_STATE_KEY, { serialNumber: 'device-123', ip: '192.168.1.50' });
+            await vscode.context.workspaceState.update('remoteHost', '192.168.1.50');
+
+            manager = new DeviceManager(vscode.context, mockGlobalStateManager);
+            await manager['syncActiveDevice']();
+
+            expect(vscode.context.workspaceState.get('remoteHost')).to.equal('192.168.1.50');
+            expect(vscodeContextManager.get('activeHost')).to.equal('192.168.1.50');
         });
     });
 

--- a/src/deviceDiscovery/DeviceManager.spec.ts
+++ b/src/deviceDiscovery/DeviceManager.spec.ts
@@ -2175,6 +2175,54 @@ describe('DeviceManager', () => {
             expect(vscode.context.workspaceState.get('remoteHost')).to.equal('192.168.1.50');
             expect(vscodeContextManager.get('activeHost')).to.equal('192.168.1.50');
         });
+
+        it('forgets the saved active device when the user picks a different device', async () => {
+            manager = new DeviceManager(vscode.context, mockGlobalStateManager);
+            await vscode.context.workspaceState.update(DeviceManager.ACTIVE_DEVICE_STATE_KEY, { serialNumber: 'device-123', ip: '192.168.1.50' });
+            await vscodeContextManager.set('activeHost', '192.168.1.50');
+            manager['discoveredDevices'].push({ ip: '192.168.1.60', serialNumber: 'device-456' });
+
+            await manager.forgetActiveDeviceIfDifferent('192.168.1.60');
+
+            expect(vscode.context.workspaceState.get(DeviceManager.ACTIVE_DEVICE_STATE_KEY)).to.be.undefined;
+            expect(vscodeContextManager.get('activeHost')).to.equal('');
+        });
+
+        it('keeps the saved active device when the user picks it at its known IP', async () => {
+            manager = new DeviceManager(vscode.context, mockGlobalStateManager);
+            await vscode.context.workspaceState.update(DeviceManager.ACTIVE_DEVICE_STATE_KEY, { serialNumber: 'device-123', ip: '192.168.1.50' });
+
+            await manager.forgetActiveDeviceIfDifferent('192.168.1.50');
+
+            expect(vscode.context.workspaceState.get(DeviceManager.ACTIVE_DEVICE_STATE_KEY)).to.eql({
+                serialNumber: 'device-123',
+                ip: '192.168.1.50'
+            });
+        });
+
+        it('keeps and re-syncs the saved active device when the user picks it at a new IP', async () => {
+            manager = new DeviceManager(vscode.context, mockGlobalStateManager);
+            await vscode.context.workspaceState.update(DeviceManager.ACTIVE_DEVICE_STATE_KEY, { serialNumber: 'device-123', ip: '192.168.1.50' });
+            await vscode.context.workspaceState.update('remoteHost', '192.168.1.50');
+            //the same device was discovered at a new IP, and the user picked it there
+            manager['discoveredDevices'].push({ ip: '192.168.1.60', serialNumber: 'device-123' });
+
+            await manager.forgetActiveDeviceIfDifferent('192.168.1.60');
+
+            expect(vscode.context.workspaceState.get(DeviceManager.ACTIVE_DEVICE_STATE_KEY)).to.eql({
+                serialNumber: 'device-123',
+                ip: '192.168.1.60'
+            });
+            expect(vscode.context.workspaceState.get('remoteHost')).to.equal('192.168.1.60');
+        });
+
+        it('does nothing when no active device is saved', async () => {
+            manager = new DeviceManager(vscode.context, mockGlobalStateManager);
+
+            await manager.forgetActiveDeviceIfDifferent('192.168.1.60');
+
+            expect(vscode.context.workspaceState.get(DeviceManager.ACTIVE_DEVICE_STATE_KEY)).to.be.undefined;
+        });
     });
 
     describe('configured devices', () => {

--- a/src/deviceDiscovery/DeviceManager.ts
+++ b/src/deviceDiscovery/DeviceManager.ts
@@ -102,6 +102,9 @@ export class DeviceManager {
             this.discoveredDevices = [];
             this.loadLastSeenDevices();
 
+            //re-point the active device at its IP on this network (found by serial number)
+            this.syncActiveDevice().catch(() => { });
+
             this.restartRokuFinder();
 
             //this is important for telling the devices view to refresh and health check its devices
@@ -116,6 +119,9 @@ export class DeviceManager {
         // Load configured devices and cached devices (order doesn't matter due to setDevice merge logic)
         this.loadConfiguredDevices().catch(() => { });
         this.loadLastSeenDevices();
+
+        //restore the active device from a previous session (re-resolves its IP by serial number)
+        this.syncActiveDevice().catch(() => { });
 
         // Set up event listeners for the RokuFinder
         this.setupFinderListeners();
@@ -613,6 +619,65 @@ export class DeviceManager {
         }
     }
 
+    /**
+     * Set the active device. Persists the device's serial number (when known) alongside the IP in
+     * workspace storage so the active device can be recovered in future sessions even if its IP changed.
+     */
+    public async setActiveDevice(ip: string): Promise<void> {
+        const serialNumber = this.getDevice({ ip: ip })?.serialNumber;
+        await this.context.workspaceState.update('remoteHost', ip);
+        await this.context.workspaceState.update(DeviceManager.ACTIVE_DEVICE_STATE_KEY, { serialNumber: serialNumber, ip: ip } as ActiveDeviceEntry);
+        await vscodeContextManager.set('activeHost', ip);
+    }
+
+    /**
+     * Clear the active device (both the session context and the persisted workspace storage entry)
+     */
+    public async clearActiveDevice(): Promise<void> {
+        await this.context.workspaceState.update('remoteHost', '');
+        await this.context.workspaceState.update(DeviceManager.ACTIVE_DEVICE_STATE_KEY, undefined);
+        await vscodeContextManager.set('activeHost', '');
+    }
+
+    /**
+     * Re-point the active device at its current IP, found by looking up the persisted serial number
+     * in the device stores. Runs on activation (recovers the active device from the previous session),
+     * after a network change, and when discovery sees the device at a new IP.
+     */
+    private async syncActiveDevice(): Promise<void> {
+        const activeDevice = this.context.workspaceState.get<ActiveDeviceEntry>(DeviceManager.ACTIVE_DEVICE_STATE_KEY);
+        if (!activeDevice?.ip && !activeDevice?.serialNumber) {
+            return;
+        }
+
+        //find the device's current IP by serial number (device list first, then the persisted SN↔IP store),
+        //falling back to the last IP we saw it at
+        let currentIp = activeDevice.ip;
+        if (activeDevice.serialNumber) {
+            currentIp = this.getDevice({ serialNumber: activeDevice.serialNumber })?.ip ??
+                this.globalStateManager.getIpForSerial(activeDevice.serialNumber, this.networkId) ??
+                activeDevice.ip;
+        }
+        if (!currentIp) {
+            return;
+        }
+
+        //keep `remoteHost` following the active device, unless something else (e.g. a debug launch) has since pointed it elsewhere
+        const remoteHost = this.context.workspaceState.get<string>('remoteHost');
+        if (!remoteHost || remoteHost === activeDevice.ip || remoteHost === currentIp) {
+            await this.context.workspaceState.update('remoteHost', currentIp);
+        }
+        if (currentIp !== activeDevice.ip) {
+            await this.context.workspaceState.update(DeviceManager.ACTIVE_DEVICE_STATE_KEY, { serialNumber: activeDevice.serialNumber, ip: currentIp } as ActiveDeviceEntry);
+        }
+        await vscodeContextManager.set('activeHost', currentIp);
+    }
+
+    /**
+     * workspaceState key where the active device's serial number and last-known IP are persisted
+     */
+    public static readonly ACTIVE_DEVICE_STATE_KEY = 'activeDevice';
+
     public getLastUsedDeviceIp(): string | undefined {
         return this.lastUsedDeviceIp;
     }
@@ -1098,6 +1163,12 @@ export class DeviceManager {
         // Set device state using intelligent defaults (preserves existing online state or uses cache freshness)
         this.setDeviceState({ serialNumber: serialNumber, ip: ip });
 
+        // If this is the active device and it showed up at a new IP, re-point the active device at it
+        const activeDevice = this.context.workspaceState.get<ActiveDeviceEntry>(DeviceManager.ACTIVE_DEVICE_STATE_KEY);
+        if (serialNumber && activeDevice?.serialNumber === serialNumber && activeDevice.ip !== ip) {
+            this.syncActiveDevice().catch(() => { });
+        }
+
         // If a different device is now at this IP, reload configurations
         if (hasMismatch) {
             this.loadConfiguredDevices().catch(() => { });
@@ -1491,6 +1562,15 @@ interface DiscoveredDeviceEntry {
 interface DeviceStateEntry {
     state: DeviceState;
     lastUpdated: number;
+}
+
+/**
+ * Active device pointer persisted in workspaceState under `DeviceManager.ACTIVE_DEVICE_STATE_KEY`.
+ * The serial number is the durable identity; the ip is the last IP the device was seen at.
+ */
+export interface ActiveDeviceEntry {
+    serialNumber?: string;
+    ip?: string;
 }
 
 /**

--- a/src/deviceDiscovery/DeviceManager.ts
+++ b/src/deviceDiscovery/DeviceManager.ts
@@ -640,6 +640,31 @@ export class DeviceManager {
     }
 
     /**
+     * Forget the saved active device when the user has explicitly picked a different device.
+     * Called after the device picker resolves in a flow where the active device could not be located,
+     * so the old active device isn't automatically re-activated by `syncActiveDevice` if it comes
+     * back online later. When the picked device IS the active device (possibly at a new IP), the
+     * active device is kept and its pointers are re-synced instead.
+     */
+    public async forgetActiveDeviceIfDifferent(pickedIp: string): Promise<void> {
+        const activeDevice = this.context.workspaceState.get<ActiveDeviceEntry>(DeviceManager.ACTIVE_DEVICE_STATE_KEY);
+        if (!activeDevice?.ip && !activeDevice?.serialNumber) {
+            return;
+        }
+
+        const pickedSerialNumber = this.getDevice({ ip: pickedIp })?.serialNumber;
+        const isSameDevice = pickedIp === activeDevice.ip ||
+            (!!activeDevice.serialNumber && pickedSerialNumber === activeDevice.serialNumber);
+        if (isSameDevice) {
+            await this.syncActiveDevice();
+            return;
+        }
+
+        await this.context.workspaceState.update(DeviceManager.ACTIVE_DEVICE_STATE_KEY, undefined);
+        await vscodeContextManager.set('activeHost', '');
+    }
+
+    /**
      * Re-point the active device at its current IP, found by looking up the persisted serial number
      * in the device stores. Runs on activation (recovers the active device from the previous session),
      * after a network change, and when discovery sees the device at a new IP.


### PR DESCRIPTION
Persists the active device in workspaceState by serial number (with its last-known IP) so it survives restarts and network changes.

`setActiveDevice`/`clearActiveDevice` now own the workspaceState writes instead of `BrightScriptCommands`. On activation, after a network change, and when discovery sees the device at a new IP, `syncActiveDevice` re-resolves the active device's current IP from its serial number, falling back to the last-known IP.

When the saved active device cannot be located at debug-launch time and the user picks a different device from the picker, the saved active device is forgotten so it is not re-activated if it comes back online later. Picking the same device at a new IP re-syncs the saved entry instead of forgetting it.