### PR TITLE
Sg inspector remove appui keypaths

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -38,7 +38,7 @@
                 "resolve": "^1.22.8",
                 "roku-debug": "^0.23.16",
                 "roku-deploy": "^3.17.7",
-                "roku-test-automation": "^2.2.2",
+                "roku-test-automation": "^3.0.0-alpha.0",
                 "semver": "^7.1.3",
                 "source-map": "^0.7.3",
                 "strip-ansi": "^5.2.0",
@@ -1834,12 +1834,6 @@
             "resolved": "https://registry.npmjs.org/@sinonjs/text-encoding/-/text-encoding-0.7.2.tgz",
             "integrity": "sha512-sXXKG+uL9IrKqViTtao2Ws6dy0znu9sOaP1di/jKGW1M6VssO8vlpXCQcpZ+jisQ1tTFAC5Jo/EOzFbggBagFQ==",
             "dev": true
-        },
-        "node_modules/@suitest/types": {
-            "version": "4.25.0",
-            "resolved": "https://registry.npmjs.org/@suitest/types/-/types-4.25.0.tgz",
-            "integrity": "sha512-F6kjVQh9a2pUj/n5CBUhdLIUi6Tx4mDrrWzquiy9//TnD7bC9SweRcb0/bsIjXBJaB8U1k4cKlZrFbkAYPDfyA==",
-            "license": "MIT"
         },
         "node_modules/@textlint/ast-node-types": {
             "version": "15.7.1",
@@ -10688,21 +10682,21 @@
             }
         },
         "node_modules/roku-test-automation": {
-            "version": "2.2.2",
-            "resolved": "https://registry.npmjs.org/roku-test-automation/-/roku-test-automation-2.2.2.tgz",
-            "integrity": "sha512-pn7AKnUvtLaSN/xOHQtkZuGS88x/Uyb4PYFQ5ZtsSCVosDbKwbvq/9EN6VxiFbDHU+BA2Tv+cAGCcjFPphnjww==",
+            "version": "3.0.0-alpha.0",
+            "resolved": "https://registry.npmjs.org/roku-test-automation/-/roku-test-automation-3.0.0-alpha.0.tgz",
+            "integrity": "sha512-4yKurKd7A+sVNbayQrXHYixaCdu8/bing8UB27/Q8akjzCQSaOR8gnIVUFR1xrRo4RKCsgHgJgD65DvInZvU8w==",
+            "license": "MIT",
             "dependencies": {
-                "@suitest/types": "^4.6.0",
                 "@types/express": "^5.0.0",
                 "ajv": "^6.12.6",
                 "express": "^4.21.2",
                 "fs-extra": "^7.0.1",
-                "http-proxy-middleware": "^3.0.3",
+                "http-proxy-middleware": "^3.0.7",
                 "needle": "^2.9.1",
                 "path": "^0.12.7",
                 "portfinder": "^1.0.33",
-                "postman-request": "^2.88.1-postman.40",
-                "roku-deploy": "^3.10.2",
+                "postman-request": "^2.88.1-postman.48",
+                "roku-deploy": "^3.17.6",
                 "stoppable": "^1.1.0"
             }
         },

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
         "resolve": "^1.22.8",
         "roku-debug": "^0.23.16",
         "roku-deploy": "^3.17.7",
-        "roku-test-automation": "^2.2.2",
+        "roku-test-automation": "^3.0.0-alpha.0",
         "semver": "^7.1.3",
         "source-map": "^0.7.3",
         "strip-ansi": "^5.2.0",

--- a/src/managers/RtaManager.ts
+++ b/src/managers/RtaManager.ts
@@ -86,8 +86,7 @@ export class RtaManager {
     }
 
     public async getAppUI(requestorId: string) {
-        await this.sendOdcRequest(requestorId, 'assignElementIdOnAllNodes', { args: {}, options: {} });
-        this.lastAppUIResponse = await rta.ecp.getAppUI();
+        this.lastAppUIResponse = await rta.ecp.getAppUI(this.onDeviceComponent);
 
         const viewIds = [];
         if (requestorId === ViewProviderId.rokuDeviceView) {

--- a/src/viewProviders/RokuReplViewProvider.ts
+++ b/src/viewProviders/RokuReplViewProvider.ts
@@ -75,7 +75,7 @@ export class RokuReplViewProvider extends BaseRdbViewProvider {
                     });
 
                     // Figure out what network interface the Roku device is accessing us from
-                    const { host } = await odc.getServerHost();
+                    const { host } = await odc.getClientHost();
                     this.componentLibraryHost = host;
                 }
 

--- a/webviews/src/ExtensionIntermediary.ts
+++ b/webviews/src/ExtensionIntermediary.ts
@@ -1,10 +1,10 @@
 /** Acts as a middle man that takes request from our views and sends them through vscode message protocol and waits for replies to simplify usage in code */
 import type * as rta from 'roku-test-automation';
-import { RequestType } from 'roku-test-automation/client/dist/types/OnDeviceComponent';
+import { RequestType } from 'roku-test-automation/dist/types/OnDeviceComponent';
 import type { VscodeCommand } from '../../src/commands/VscodeCommand';
 import { ViewProviderEvent } from '../../src/viewProviders/ViewProviderEvent';
 import { ViewProviderCommand } from '../../src/viewProviders/ViewProviderCommand';
-import type { DeleteEntireRegistrySectionsArgs, DeleteRegistrySectionsArgs, FindNodesAtLocationArgs, GetFocusedNodeArgs, GetNodesInfoArgs, GetNodesWithPropertiesArgs, GetValueArgs, GetValuesArgs, HasFocusArgs, IsInFocusChainArgs, OnFieldChangeOnceArgs, ReadRegistryArgs, RequestOptions, SetValueArgs, WriteRegistryArgs, GetVolumeListArgs, GetDirectoryListingArgs, StatPathArgs, RenameFileArgs, DeleteFileArgs, CreateDirectoryArgs, RemoveNodeArgs, RemoveNodeChildrenArgs, FocusNodeArgs, AppUIResponse } from 'roku-test-automation';
+import type { DeleteEntireRegistrySectionsArgs, DeleteRegistrySectionsArgs, GetFocusedNodeArgs, GetNodesInfoArgs, GetNodesWithPropertiesArgs, GetValueArgs, GetValuesArgs, HasFocusArgs, IsInFocusChainArgs, OnFieldChangeOnceArgs, ReadRegistryArgs, RequestOptions, SetValueArgs, WriteRegistryArgs, GetVolumeListArgs, GetDirectoryListingArgs, StatPathArgs, RenameFileArgs, DeleteFileArgs, CreateDirectoryArgs, RemoveNodeArgs, RemoveNodeChildrenArgs, FocusNodeArgs, AppUIResponse } from 'roku-test-automation';
 
 class ExtensionIntermediary {
     private inflightRequests = {};
@@ -224,10 +224,6 @@ class ODCIntermediary {
 
     public async getNodesWithProperties(args: GetNodesWithPropertiesArgs, options?: RequestOptions) {
         return this.sendOdcMessage<ReturnType<typeof rta.odc.getNodesWithProperties>>(RequestType.getNodesWithProperties, args, options);
-    }
-
-    public async findNodesAtLocation(args: FindNodesAtLocationArgs, options?: RequestOptions) {
-        return this.sendOdcMessage<ReturnType<typeof rta.odc.findNodesAtLocation>>(RequestType.findNodesAtLocation, args, options);
     }
 
     public async getVolumeList(args: GetVolumeListArgs, options?: RequestOptions) {

--- a/webviews/src/ExtensionIntermediary.ts
+++ b/webviews/src/ExtensionIntermediary.ts
@@ -4,7 +4,7 @@ import { RequestType } from 'roku-test-automation/client/dist/types/OnDeviceComp
 import type { VscodeCommand } from '../../src/commands/VscodeCommand';
 import { ViewProviderEvent } from '../../src/viewProviders/ViewProviderEvent';
 import { ViewProviderCommand } from '../../src/viewProviders/ViewProviderCommand';
-import type { DeleteEntireRegistrySectionsArgs, DeleteRegistrySectionsArgs, FindNodesAtLocationArgs, GetFocusedNodeArgs, GetNodesInfoArgs, GetNodesWithPropertiesArgs, GetValueArgs, GetValuesArgs, HasFocusArgs, IsInFocusChainArgs, OnFieldChangeOnceArgs, ReadRegistryArgs, RequestOptions, SetValueArgs, WriteRegistryArgs, GetVolumeListArgs, GetDirectoryListingArgs, StatPathArgs, RenameFileArgs, DeleteFileArgs, CreateDirectoryArgs, RemoveNodeArgs, RemoveNodeChildrenArgs, FocusNodeArgs, AppUIResponse, ConvertKeyPathToSceneKeyPathArgs } from 'roku-test-automation';
+import type { DeleteEntireRegistrySectionsArgs, DeleteRegistrySectionsArgs, FindNodesAtLocationArgs, GetFocusedNodeArgs, GetNodesInfoArgs, GetNodesWithPropertiesArgs, GetValueArgs, GetValuesArgs, HasFocusArgs, IsInFocusChainArgs, OnFieldChangeOnceArgs, ReadRegistryArgs, RequestOptions, SetValueArgs, WriteRegistryArgs, GetVolumeListArgs, GetDirectoryListingArgs, StatPathArgs, RenameFileArgs, DeleteFileArgs, CreateDirectoryArgs, RemoveNodeArgs, RemoveNodeChildrenArgs, FocusNodeArgs, AppUIResponse } from 'roku-test-automation';
 
 class ExtensionIntermediary {
     private inflightRequests = {};
@@ -268,10 +268,6 @@ class ODCIntermediary {
 
     public async focusNode(args: FocusNodeArgs, options?: RequestOptions) {
         return this.sendOdcMessage<ReturnType<typeof rta.odc.focusNode>>(RequestType.focusNode, args, options);
-    }
-
-    public async convertKeyPathToSceneKeyPath(args: ConvertKeyPathToSceneKeyPathArgs, options?: RequestOptions) {
-        return this.sendOdcMessage<ReturnType<typeof rta.odc.convertKeyPathToSceneKeyPath>>(RequestType.convertKeyPathToSceneKeyPath, args, options);
     }
 }
 

--- a/webviews/src/shared/types.ts
+++ b/webviews/src/shared/types.ts
@@ -1,11 +1,6 @@
 import type { odc } from '../ExtensionIntermediary';
-import type { AppUIResponseChild } from 'roku-test-automation';
 export type PathContentsInfo = Omit<Partial<Awaited<ReturnType<typeof odc.statPath>>>, 'type'> & {
     name: string;
     path: string;
     type?: 'file' | 'directory' | 'fileSystem';
-};
-
-export type AppUIResponseChildWithAppUIKeyPath = AppUIResponseChild & {
-    appUIKeyPath?: string;
 };

--- a/webviews/src/utils.ts
+++ b/webviews/src/utils.ts
@@ -1,5 +1,4 @@
-import { odc } from './ExtensionIntermediary';
-import type { AppUIResponseChildWithAppUIKeyPath } from './shared/types';
+import type { AppUIResponseChild } from 'roku-test-automation';
 
 type AllowedStorageTypes = string | number | boolean | Record<string, string | number | boolean>;
 
@@ -69,22 +68,8 @@ class Utils {
     /**
      * Helps improve performance by removing the children from the AppUIResponseChild object to make the object being passed around much smaller
      */
-    public getShallowCloneOfAppUIResponseChild(appUIResponseChild: AppUIResponseChildWithAppUIKeyPath) {
+    public getShallowCloneOfAppUIResponseChild(appUIResponseChild: AppUIResponseChild) {
         return { ...appUIResponseChild, children: [] };
-    }
-
-    /** Provides a central spot to convert key path to be scene based to avoid extra appUI calls */
-    public async convertAppUIKeyPathToSceneKeyPath(child: AppUIResponseChildWithAppUIKeyPath) {
-        const { keyPath } = await odc.convertKeyPathToSceneKeyPath({
-            base: child.base,
-            keyPath: child.keyPath
-        });
-
-        // Keeping existing appUI key path to allow more fallback options if needed
-        child.appUIKeyPath = child.keyPath;
-
-        child.base = 'scene';
-        child.keyPath = keyPath;
     }
 }
 

--- a/webviews/src/views/RokuDeviceView/RokuDeviceView.svelte
+++ b/webviews/src/views/RokuDeviceView/RokuDeviceView.svelte
@@ -6,7 +6,7 @@
     import { ViewProviderEvent } from '../../../../src/viewProviders/ViewProviderEvent';
     import { ViewProviderCommand } from '../../../../src/viewProviders/ViewProviderCommand';
     import type { AppUIResponseChild, AppUIResponse } from 'roku-test-automation';
-    import { utils as rtaUtils } from 'roku-test-automation/client/dist/utils';
+    import { utils as rtaUtils } from 'roku-test-automation/dist/utils';
     import { VscodeCommand } from '../../../../src/commands/VscodeCommand';
     import { utils } from '../../utils';
 

--- a/webviews/src/views/SceneGraphInspectorView/Branch.svelte
+++ b/webviews/src/views/SceneGraphInspectorView/Branch.svelte
@@ -77,8 +77,7 @@
 
     function doNodesMatch(nodeA: AppUIResponseChild, nodeB: AppUIResponseChild | undefined) {
         if (nodeB) {
-            if (nodeA.keyPath === nodeB.keyPath && (nodeA.base === nodeB.base || (nodeA.base === 'appUI' || nodeB.base === 'appUI'))) {
-                // console.log('Nodes match', nodeA.keyPath, nodeB.keyPath, nodeB.base === nodeB.base);
+            if (nodeA.keyPath === nodeB.keyPath && nodeA.base === nodeB.base) {
                 return true;
             }
         }
@@ -161,10 +160,6 @@
     }
 
     async function setNodeValue(field: string, value: any, options = {}) {
-        if (appUIResponseChild.base === 'appUI') {
-            await utils.convertAppUIKeyPathToSceneKeyPath(appUIResponseChild)
-        }
-
         await odc.setValue({
             base: appUIResponseChild.base,
             keyPath: `${appUIResponseChild.keyPath}.${field}`,

--- a/webviews/src/views/SceneGraphInspectorView/SceneGraphInspectorView.svelte
+++ b/webviews/src/views/SceneGraphInspectorView/SceneGraphInspectorView.svelte
@@ -174,8 +174,7 @@
             if (node) {
                 node = utils.getShallowCloneOfAppUIResponseChild(node);
 
-                if ((node.base !== 'appUI' && node.base !== selectNode?.base) || node.keyPath !== selectNode?.keyPath) {
-                    // If the focused node is not the same as the currently selected node, we want to inspect it
+                if (node.base !== selectNode?.base || node.keyPath !== selectNode?.keyPath) {
 
                     selectNode = node;
                     expandNode = node;


### PR DESCRIPTION
With the upgrade to RTA 3 we no longer need appUI key paths in the SceneGraph Inspector. This makes the initial request a small amount slower but substantially improves all future user actions that would have required converting the appUI key path into an elementID key path.