### PR TITLE
Show an indicator for the active device in the Devices panel

### DIFF
--- a/package.json
+++ b/package.json
@@ -492,7 +492,12 @@
                 },
                 {
                     "command": "extension.brightscript.devicesView.deviceMenu.setActiveDevice",
-                    "when": "view == devicesView && viewItem =~ /^device\\b/",
+                    "when": "view == devicesView && viewItem =~ /-notActive\\b/",
+                    "group": "1_primary@1"
+                },
+                {
+                    "command": "extension.brightscript.devicesView.deviceMenu.clearActiveDevice",
+                    "when": "view == devicesView && viewItem =~ /-isActive\\b/",
                     "group": "1_primary@1"
                 },
                 {
@@ -750,6 +755,10 @@
                 },
                 {
                     "command": "extension.brightscript.devicesView.deviceMenu.setActiveDevice",
+                    "when": "false"
+                },
+                {
+                    "command": "extension.brightscript.devicesView.deviceMenu.clearActiveDevice",
                     "when": "false"
                 },
                 {
@@ -4022,6 +4031,11 @@
             {
                 "command": "extension.brightscript.devicesView.deviceMenu.setActiveDevice",
                 "title": "⭐ Set as Active Device",
+                "category": "BrightScript"
+            },
+            {
+                "command": "extension.brightscript.devicesView.deviceMenu.clearActiveDevice",
+                "title": "⭐ Clear Active Device",
                 "category": "BrightScript"
             },
             {

--- a/src/BrightScriptCommands.ts
+++ b/src/BrightScriptCommands.ts
@@ -1199,6 +1199,9 @@ export class BrightScriptCommands {
         this.registerCommand('devicesView.deviceMenu.setActiveDevice', (element?: { key?: string }) => {
             return vscode.commands.executeCommand('extension.brightscript.setActiveDevice', element);
         });
+        this.registerCommand('devicesView.deviceMenu.clearActiveDevice', () => {
+            return vscode.commands.executeCommand('extension.brightscript.clearActiveDevice');
+        });
         this.registerCommand('devicesView.deviceMenu.captureScreenshot', (element?: { key?: string }) => {
             return vscode.commands.executeCommand('extension.brightscript.captureScreenshot', getDevice(element)?.ip);
         });

--- a/src/managers/VscodeContextManager.ts
+++ b/src/managers/VscodeContextManager.ts
@@ -1,4 +1,5 @@
 import * as vscode from 'vscode';
+import { EventEmitter } from 'eventemitter3';
 
 type ContextValue = boolean | string;
 
@@ -9,18 +10,31 @@ type ContextValue = boolean | string;
  */
 class VSCodeContextManager {
     private readonly cache = new Map<string, ContextValue>();
+    private readonly emitter = new EventEmitter();
 
     public async set(key: string, value: ContextValue): Promise<void> {
         const prev = this.get(key);
         if (prev !== value) {
             //   Logger.get('vscode-context').debug(`Setting key='${key}' to value='${value}'`);
             this.cache.set(key, value);
+            this.emitter.emit('change', key, value);
             await vscode.commands.executeCommand('setContext', key, value);
         }
     }
 
     public get<T extends ContextValue>(key: string, defaultValue?: T): T | undefined {
         return this.cache.get(key) as T ?? defaultValue;
+    }
+
+    /**
+     * Subscribe to context value changes (only fired when a key's value actually changes).
+     * @returns an unsubscribe function
+     */
+    public onChange(handler: (key: string, value: ContextValue) => void): () => void {
+        this.emitter.on('change', handler);
+        return () => {
+            this.emitter.removeListener('change', handler);
+        };
     }
 }
 

--- a/src/mockVscode.spec.ts
+++ b/src/mockVscode.spec.ts
@@ -503,7 +503,9 @@ export let vscode = {
         }
         public value: string;
     },
-    ThemeColor: class { },
+    ThemeColor: class {
+        constructor(public readonly id: string) { }
+    },
     ThemeIcon: class {
         constructor(public id: string, public color?: any) { }
     },

--- a/src/viewProviders/DevicesViewProvider.spec.ts
+++ b/src/viewProviders/DevicesViewProvider.spec.ts
@@ -15,6 +15,7 @@ Module.prototype.require = function hijacked(file) {
 };
 
 import { DevicesViewProvider } from './DevicesViewProvider';
+import { vscodeContextManager } from '../managers/VscodeContextManager';
 import type { DeviceFilters } from '../deviceFilters';
 
 if (!(vscode as any).TreeItemCollapsibleState) {
@@ -67,10 +68,10 @@ afterEach(() => {
 });
 
 describe('DevicesViewProvider', () => {
-    function makeDevice(overrides: { key: string; isTv?: boolean; isStick?: boolean; deviceState?: string; lastDeviceState?: string; developerEnabled?: 'true' | 'false' | undefined; isConfigured?: boolean; serialNumber?: string; softwareVersion?: string; configuredIn?: string[] }) {
+    function makeDevice(overrides: { key: string; ip?: string; isTv?: boolean; isStick?: boolean; deviceState?: string; lastDeviceState?: string; developerEnabled?: 'true' | 'false' | undefined; isConfigured?: boolean; serialNumber?: string; softwareVersion?: string; configuredIn?: string[] }) {
         return {
             key: overrides.key,
-            ip: '1.2.3.4',
+            ip: overrides.ip ?? '1.2.3.4',
             deviceState: overrides.deviceState ?? 'online',
             lastDeviceState: overrides.lastDeviceState ?? 'unknown',
             isConfigured: overrides.isConfigured ?? false,
@@ -105,9 +106,11 @@ describe('DevicesViewProvider', () => {
         return { provider: provider, deviceManager: deviceManager, emitter: emitter };
     }
 
-    beforeEach(() => {
+    beforeEach(async () => {
         clearFilters();
         (vscode.workspace as any)._onDidChangeConfigurationEmitter?.removeAllListeners();
+        //make sure no active device leaks in from a previous test (the context manager is a module singleton)
+        await vscodeContextManager.set('activeHost', '');
     });
 
     describe('applyFilters via getChildren', () => {
@@ -208,21 +211,21 @@ describe('DevicesViewProvider', () => {
             const devices = [makeDevice({ key: 'tv1', isTv: true, softwareVersion: '15.3.4', serialNumber: 'SERIAL1' })];
             const { provider } = createProvider(devices);
             const items = await provider.getChildren();
-            expect(items[0].contextValue).to.equal('device-notInUser-notInWorkspace-noPassword-isTv-canViewRegistry-canRestart');
+            expect(items[0].contextValue).to.equal('device-notInUser-notInWorkspace-noPassword-isTv-canViewRegistry-canRestart-notActive');
         });
 
         it('includes hasPassword and configured-in tokens, and gates version-specific tokens', async () => {
             const devices = [makeDevice({ key: 'stb1', softwareVersion: '12.0.0', serialNumber: 'SERIAL2', configuredIn: ['user', 'workspace'] })];
             const { provider } = createProvider(devices, { storedPasswords: { SERIAL2: 'secret' } });
             const items = await provider.getChildren();
-            expect(items[0].contextValue).to.equal('device-inUser-inWorkspace-hasPassword-canViewRegistry');
+            expect(items[0].contextValue).to.equal('device-inUser-inWorkspace-hasPassword-canViewRegistry-notActive');
         });
 
         it('omits password and version-gated tokens when serial number and software version are unknown', async () => {
             const devices = [makeDevice({ key: 'stb1' })];
             const { provider } = createProvider(devices);
             const items = await provider.getChildren();
-            expect(items[0].contextValue).to.equal('device-notInUser-notInWorkspace');
+            expect(items[0].contextValue).to.equal('device-notInUser-notInWorkspace-notActive');
         });
 
         it('lists the action items followed by an expandable Device Info group holding the info fields', async () => {
@@ -266,6 +269,100 @@ describe('DevicesViewProvider', () => {
                 '📺 Switch TV Input',
                 'Device Info'
             ]);
+        });
+    });
+
+    describe('active device indicator', () => {
+        it('marks the active device with an isActive contextValue token', async () => {
+            const devices = [
+                makeDevice({ key: 'stb1', ip: '1.1.1.1' }),
+                makeDevice({ key: 'stb2', ip: '2.2.2.2' })
+            ];
+            await vscodeContextManager.set('activeHost', '2.2.2.2');
+            const { provider } = createProvider(devices);
+
+            const items = await provider.getChildren();
+
+            expect(items[0].contextValue).to.contain('-notActive');
+            expect(items[1].contextValue).to.contain('-isActive');
+        });
+
+        it('shows a star decoration badge on the active device only', async () => {
+            const devices = [
+                makeDevice({ key: 'stb1', ip: '1.1.1.1' }),
+                makeDevice({ key: 'stb2', ip: '2.2.2.2' })
+            ];
+            await vscodeContextManager.set('activeHost', '2.2.2.2');
+            const { provider } = createProvider(devices);
+            const decorationProvider = provider['decorationProvider'];
+
+            const activeDecoration = decorationProvider.provideFileDecoration({ scheme: 'roku-device', path: '/stb2' } as any);
+            expect(activeDecoration?.badge).to.equal('⭐');
+            expect(activeDecoration?.tooltip).to.equal('Active device');
+            //the badge is the colored element; the row label keeps its normal theme color
+            expect(activeDecoration?.color).to.be.undefined;
+
+            const inactiveDecoration = decorationProvider.provideFileDecoration({ scheme: 'roku-device', path: '/stb1' } as any);
+            expect(inactiveDecoration?.badge).to.be.undefined;
+            expect(inactiveDecoration?.color).to.be.undefined;
+        });
+
+        it('keeps the offline coloring alongside the active badge', async () => {
+            const devices = [makeDevice({ key: 'stb1', ip: '1.1.1.1', deviceState: 'offline' })];
+            await vscodeContextManager.set('activeHost', '1.1.1.1');
+            const { provider } = createProvider(devices);
+
+            const decoration = provider['decorationProvider'].provideFileDecoration({ scheme: 'roku-device', path: '/stb1' } as any);
+            expect(decoration?.badge).to.equal('⭐');
+            expect((decoration?.color as any)?.id).to.equal('disabledForeground');
+        });
+
+        it('moves the badge and refreshes the tree when the active device changes', async () => {
+            const devices = [
+                makeDevice({ key: 'stb1', ip: '1.1.1.1' }),
+                makeDevice({ key: 'stb2', ip: '2.2.2.2' })
+            ];
+            await vscodeContextManager.set('activeHost', '1.1.1.1');
+            const { provider } = createProvider(devices);
+            const decorationProvider = provider['decorationProvider'];
+
+            let treeChanges = 0;
+            provider.onDidChangeTreeData(() => treeChanges++);
+
+            await vscodeContextManager.set('activeHost', '2.2.2.2');
+
+            expect(treeChanges).to.equal(1);
+            expect(decorationProvider.provideFileDecoration({ scheme: 'roku-device', path: '/stb1' } as any)?.badge).to.be.undefined;
+            expect(decorationProvider.provideFileDecoration({ scheme: 'roku-device', path: '/stb2' } as any)?.badge).to.equal('⭐');
+        });
+
+        it('shows Clear Active Device instead of Set as Active Device on the active device row', async () => {
+            const devices = [
+                makeDevice({ key: 'stb1', ip: '1.1.1.1' }),
+                makeDevice({ key: 'stb2', ip: '2.2.2.2' })
+            ];
+            await vscodeContextManager.set('activeHost', '2.2.2.2');
+            const { provider } = createProvider(devices);
+            const [inactiveItem, activeItem] = await provider.getChildren();
+
+            const inactiveChildren = await provider.getChildren(inactiveItem);
+            const setItem = inactiveChildren.find(child => child.label === '⭐ Set as Active Device');
+            expect((setItem as any)?.command?.command).to.equal('extension.brightscript.setActiveDevice');
+            expect(inactiveChildren.map(child => child.label)).to.not.include('⭐ Clear Active Device');
+
+            const activeChildren = await provider.getChildren(activeItem);
+            const clearItem = activeChildren.find(child => child.label === '⭐ Clear Active Device');
+            expect((clearItem as any)?.command?.command).to.equal('extension.brightscript.clearActiveDevice');
+            expect(activeChildren.map(child => child.label)).to.not.include('⭐ Set as Active Device');
+        });
+
+        it('shows no badge when the active host does not match any device', async () => {
+            const devices = [makeDevice({ key: 'stb1', ip: '1.1.1.1' })];
+            await vscodeContextManager.set('activeHost', '9.9.9.9');
+            const { provider } = createProvider(devices);
+
+            const decoration = provider['decorationProvider'].provideFileDecoration({ scheme: 'roku-device', path: '/stb1' } as any);
+            expect(decoration?.badge).to.be.undefined;
         });
     });
 

--- a/src/viewProviders/DevicesViewProvider.ts
+++ b/src/viewProviders/DevicesViewProvider.ts
@@ -2,6 +2,7 @@ import * as vscode from 'vscode';
 import * as semver from 'semver';
 import type { ConfiguredDevice, DeviceManager, RokuDevice } from '../deviceDiscovery/DeviceManager';
 import type { CredentialStore } from '../managers/CredentialStore';
+import { vscodeContextManager } from '../managers/VscodeContextManager';
 import { util } from '../util';
 import { ViewProviderId } from './ViewProviderId';
 import {
@@ -56,11 +57,19 @@ export class DevicesViewProvider implements vscode.TreeDataProvider<vscode.TreeI
 
         // Pre-populate devices and decorations so they're ready before first render
         this.devices = this.deviceManager.getAllDevices();
-        this.decorationProvider.updateDevices(this.devices);
+        this.decorationProvider.updateDevices(this.devices, this.getActiveDeviceKey());
 
         this.deviceManager.on('devices-changed', () => {
             this.handleDevicesChanged();
         });
+
+        // Re-render when the active device changes so the indicator moves to the correct row
+        const unsubscribeContextChange = vscodeContextManager.onChange((key) => {
+            if (key === 'activeHost') {
+                this.handleDevicesChanged();
+            }
+        });
+        this.context.subscriptions.push({ dispose: unsubscribeContextChange });
 
         this.deviceManager.on('scanNeeded-changed', () => {
             if (!this.visible) {
@@ -139,8 +148,25 @@ export class DevicesViewProvider implements vscode.TreeDataProvider<vscode.TreeI
 
     private handleDevicesChanged(): void {
         this.devices = this.deviceManager.getAllDevices();
-        this.decorationProvider.updateDevices(this.devices);
+        this.decorationProvider.updateDevices(this.devices, this.getActiveDeviceKey());
         this._onDidChangeTreeData.fire(null);
+    }
+
+    /**
+     * Is this device the active device? The active device is tracked by IP in the
+     * `activeHost` context value (set by the setActiveDevice/clearActiveDevice commands).
+     */
+    private isActiveDevice(device: RokuDevice): boolean {
+        const activeHost = vscodeContextManager.get<string>('activeHost');
+        return !!activeHost && device.ip === activeHost;
+    }
+
+    /**
+     * Get the tree key of the active device, or undefined when no device is active
+     * or the active host doesn't match any known device
+     */
+    private getActiveDeviceKey(): string | undefined {
+        return this.devices?.find(device => this.isActiveDevice(device))?.key;
     }
 
     /**
@@ -157,7 +183,7 @@ export class DevicesViewProvider implements vscode.TreeDataProvider<vscode.TreeI
             // Fetch directly if devices haven't been populated yet (avoids debounce delay on initial load)
             if (this.devices.length === 0) {
                 this.devices = this.deviceManager.getAllDevices();
-                this.decorationProvider.updateDevices(this.devices);
+                this.decorationProvider.updateDevices(this.devices, this.getActiveDeviceKey());
             }
             if (this.devices) {
                 let items: DeviceTreeItem[] = [];
@@ -293,19 +319,34 @@ export class DevicesViewProvider implements vscode.TreeDataProvider<vscode.TreeI
                 }
             }
 
-            result.push(
-                this.createDeviceInfoTreeItem({
-                    label: '⭐ Set as Active Device',
-                    parent: element,
-                    collapsibleState: vscode.TreeItemCollapsibleState.None,
-                    tooltip: 'Set as active device',
-                    command: {
-                        command: 'extension.brightscript.setActiveDevice',
-                        title: 'Set Active Device',
-                        arguments: [device.ip]
-                    }
-                })
-            );
+            if (this.isActiveDevice(device)) {
+                result.push(
+                    this.createDeviceInfoTreeItem({
+                        label: '⭐ Clear Active Device',
+                        parent: element,
+                        collapsibleState: vscode.TreeItemCollapsibleState.None,
+                        tooltip: 'This is the active device. Click to clear it.',
+                        command: {
+                            command: 'extension.brightscript.clearActiveDevice',
+                            title: 'Clear Active Device'
+                        }
+                    })
+                );
+            } else {
+                result.push(
+                    this.createDeviceInfoTreeItem({
+                        label: '⭐ Set as Active Device',
+                        parent: element,
+                        collapsibleState: vscode.TreeItemCollapsibleState.None,
+                        tooltip: 'Set as active device',
+                        command: {
+                            command: 'extension.brightscript.setActiveDevice',
+                            title: 'Set Active Device',
+                            arguments: [device.ip]
+                        }
+                    })
+                );
+            }
 
             result.push(
                 this.createDeviceInfoTreeItem({
@@ -395,6 +436,7 @@ export class DevicesViewProvider implements vscode.TreeDataProvider<vscode.TreeI
         if (semver.satisfies(softwareVersion, '>=15.0.4')) {
             tokens.push('canRestart');
         }
+        tokens.push(this.isActiveDevice(device) ? 'isActive' : 'notActive');
         return tokens.join('-');
     }
 
@@ -629,8 +671,9 @@ class DeviceDecorationProvider implements vscode.FileDecorationProvider {
     readonly onDidChangeFileDecorations = this._onDidChangeFileDecorations.event;
 
     private deviceStates = new Map<string, string>();
+    private activeDeviceKey: string | undefined;
 
-    updateDevices(devices: RokuDevice[]): void {
+    updateDevices(devices: RokuDevice[], activeDeviceKey: string | undefined): void {
         const changedUris: vscode.Uri[] = [];
         for (const device of devices) {
             const oldState = this.deviceStates.get(device.key);
@@ -638,6 +681,15 @@ class DeviceDecorationProvider implements vscode.FileDecorationProvider {
                 this.deviceStates.set(device.key, device.deviceState);
                 changedUris.push(vscode.Uri.parse(`${DEVICE_URI_SCHEME}:/${device.key}`));
             }
+        }
+        if (activeDeviceKey !== this.activeDeviceKey) {
+            // Refresh both the row losing the badge and the row gaining it
+            for (const key of [this.activeDeviceKey, activeDeviceKey]) {
+                if (key) {
+                    changedUris.push(vscode.Uri.parse(`${DEVICE_URI_SCHEME}:/${key}`));
+                }
+            }
+            this.activeDeviceKey = activeDeviceKey;
         }
         if (changedUris.length > 0) {
             this._onDidChangeFileDecorations.fire(changedUris);
@@ -652,12 +704,17 @@ class DeviceDecorationProvider implements vscode.FileDecorationProvider {
         const deviceKey = uri.path.slice(1); // Remove leading slash (key is "s:..." or "i:...")
         const state = this.deviceStates.get(deviceKey);
 
+        const decoration: vscode.FileDecoration = {};
+        if (deviceKey === this.activeDeviceKey) {
+            //the emoji star renders in its native gold color without tinting the row label
+            //(FileDecoration.color would color the label and badge together)
+            decoration.badge = '⭐';
+            decoration.tooltip = 'Active device';
+        }
         if (state !== 'online') {
-            return {
-                color: new vscode.ThemeColor('disabledForeground')
-            };
+            decoration.color = new vscode.ThemeColor('disabledForeground');
         }
 
-        return undefined;
+        return (decoration.badge || decoration.color) ? decoration : undefined;
     }
 }


### PR DESCRIPTION
Marks the active device in the Devices panel with a gold ⭐ decoration badge (tooltip "Active device"). The badge is the colored element; the row label keeps its normal theme color, and the existing offline grey still applies to the row.

Device rows now carry an `isActive`/`notActive` contextValue token, so the right-click menu shows "Set as Active Device" only on non-active devices and a new "Clear Active Device" entry on the active one. The expanded device row swaps its action item the same way.

`VscodeContextManager` now emits a change event when a context value changes, and the view listens for `activeHost` changes so the badge moves as soon as the active device is set or cleared.