### PR TITLE
Migrate to roku-deploy v4

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -37,7 +37,7 @@
                 "pretty-bytes": "^5.6.0",
                 "resolve": "^1.22.8",
                 "roku-debug": "^0.23.16",
-                "roku-deploy": "^3.17.7",
+                "roku-deploy": "^4.0.0-alpha.3",
                 "roku-test-automation": "^2.2.2",
                 "semver": "^7.1.3",
                 "source-map": "^0.7.3",
@@ -3841,6 +3841,71 @@
             "license": "MIT",
             "engines": {
                 "node": ">=4"
+            }
+        },
+        "node_modules/brighterscript/node_modules/iconv-lite": {
+            "version": "0.6.3",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+            "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+            "license": "MIT",
+            "dependencies": {
+                "safer-buffer": ">= 2.1.2 < 3.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/brighterscript/node_modules/needle": {
+            "version": "3.5.0",
+            "resolved": "https://registry.npmjs.org/needle/-/needle-3.5.0.tgz",
+            "integrity": "sha512-jaQyPKKk2YokHrEg+vFDYxXIHTCBgiZwSHOoVx/8V3GIBS8/VN6NdVRmg8q1ERtPkMvmOvebsgga4sAj5hls/w==",
+            "license": "MIT",
+            "dependencies": {
+                "iconv-lite": "^0.6.3",
+                "sax": "^1.2.4"
+            },
+            "bin": {
+                "needle": "bin/needle"
+            },
+            "engines": {
+                "node": ">= 4.4.x"
+            }
+        },
+        "node_modules/brighterscript/node_modules/roku-deploy": {
+            "version": "3.18.2",
+            "resolved": "https://registry.npmjs.org/roku-deploy/-/roku-deploy-3.18.2.tgz",
+            "integrity": "sha512-O0nO/hzhax6nhcwsk40Vdoq7RKm4n3OCJfc+Vr5OcV1YfSg5qeFt6gY3RG74QjZ+KrTO1A51XO0Oe1e4qV4O8w==",
+            "license": "MIT",
+            "dependencies": {
+                "@rokucommunity/logger": "^0.4.1",
+                "chalk": "^2.4.2",
+                "fast-glob": "^3.2.12",
+                "fs-extra": "^7.0.1",
+                "is-glob": "^4.0.3",
+                "jsonc-parser": "^2.3.0",
+                "jszip": "^3.6.0",
+                "micromatch": "^4.0.4",
+                "needle": "^3.5.0",
+                "picomatch": "^2.3.2",
+                "semver": "^7.7.3",
+                "xml2js": "^0.5.0"
+            },
+            "bin": {
+                "roku-deploy": "dist/cli.js"
+            }
+        },
+        "node_modules/brighterscript/node_modules/roku-deploy/node_modules/fs-extra": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+            "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+            "license": "MIT",
+            "dependencies": {
+                "graceful-fs": "^4.1.2",
+                "jsonfile": "^4.0.0",
+                "universalify": "^0.1.0"
+            },
+            "engines": {
+                "node": ">=6 <7 || >=8"
             }
         },
         "node_modules/brighterscript/node_modules/supports-color": {
@@ -10523,6 +10588,47 @@
                 "roku-debug": "dist/cli.js"
             }
         },
+        "node_modules/roku-debug/node_modules/ansi-styles": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+            "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+            "license": "MIT",
+            "dependencies": {
+                "color-convert": "^1.9.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/roku-debug/node_modules/chalk": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+            "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/roku-debug/node_modules/color-convert": {
+            "version": "1.9.3",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+            "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+            "license": "MIT",
+            "dependencies": {
+                "color-name": "1.1.3"
+            }
+        },
+        "node_modules/roku-debug/node_modules/color-name": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+            "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+            "license": "MIT"
+        },
         "node_modules/roku-debug/node_modules/dateformat": {
             "version": "4.6.3",
             "resolved": "https://registry.npmjs.org/dateformat/-/dateformat-4.6.3.tgz",
@@ -10530,6 +10636,15 @@
             "license": "MIT",
             "engines": {
                 "node": "*"
+            }
+        },
+        "node_modules/roku-debug/node_modules/escape-string-regexp": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.8.0"
             }
         },
         "node_modules/roku-debug/node_modules/eventemitter3": {
@@ -10550,6 +10665,27 @@
                 "node": ">=12"
             }
         },
+        "node_modules/roku-debug/node_modules/has-flag": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+            "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/roku-debug/node_modules/iconv-lite": {
+            "version": "0.6.3",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+            "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+            "license": "MIT",
+            "dependencies": {
+                "safer-buffer": ">= 2.1.2 < 3.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/roku-debug/node_modules/jsonfile": {
             "version": "6.2.1",
             "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
@@ -10559,6 +10695,89 @@
             },
             "optionalDependencies": {
                 "graceful-fs": "^4.1.6"
+            }
+        },
+        "node_modules/roku-debug/node_modules/needle": {
+            "version": "3.5.0",
+            "resolved": "https://registry.npmjs.org/needle/-/needle-3.5.0.tgz",
+            "integrity": "sha512-jaQyPKKk2YokHrEg+vFDYxXIHTCBgiZwSHOoVx/8V3GIBS8/VN6NdVRmg8q1ERtPkMvmOvebsgga4sAj5hls/w==",
+            "license": "MIT",
+            "dependencies": {
+                "iconv-lite": "^0.6.3",
+                "sax": "^1.2.4"
+            },
+            "bin": {
+                "needle": "bin/needle"
+            },
+            "engines": {
+                "node": ">= 4.4.x"
+            }
+        },
+        "node_modules/roku-debug/node_modules/roku-deploy": {
+            "version": "3.18.2",
+            "resolved": "https://registry.npmjs.org/roku-deploy/-/roku-deploy-3.18.2.tgz",
+            "integrity": "sha512-O0nO/hzhax6nhcwsk40Vdoq7RKm4n3OCJfc+Vr5OcV1YfSg5qeFt6gY3RG74QjZ+KrTO1A51XO0Oe1e4qV4O8w==",
+            "license": "MIT",
+            "dependencies": {
+                "@rokucommunity/logger": "^0.4.1",
+                "chalk": "^2.4.2",
+                "fast-glob": "^3.2.12",
+                "fs-extra": "^7.0.1",
+                "is-glob": "^4.0.3",
+                "jsonc-parser": "^2.3.0",
+                "jszip": "^3.6.0",
+                "micromatch": "^4.0.4",
+                "needle": "^3.5.0",
+                "picomatch": "^2.3.2",
+                "semver": "^7.7.3",
+                "xml2js": "^0.5.0"
+            },
+            "bin": {
+                "roku-deploy": "dist/cli.js"
+            }
+        },
+        "node_modules/roku-debug/node_modules/roku-deploy/node_modules/fs-extra": {
+            "version": "7.0.1",
+            "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-7.0.1.tgz",
+            "integrity": "sha512-YJDaCJZEnBmcbw13fvdAM9AwNOJwOzrE4pqMqBq5nFiEqXUqHwlK4B+3pUw6JNvfSPtX05xFHtYy/1ni01eGCw==",
+            "license": "MIT",
+            "dependencies": {
+                "graceful-fs": "^4.1.2",
+                "jsonfile": "^4.0.0",
+                "universalify": "^0.1.0"
+            },
+            "engines": {
+                "node": ">=6 <7 || >=8"
+            }
+        },
+        "node_modules/roku-debug/node_modules/roku-deploy/node_modules/jsonfile": {
+            "version": "4.0.0",
+            "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-4.0.0.tgz",
+            "integrity": "sha512-m6F1R3z8jjlf2imQHS2Qez5sjKWQzbuuhuJ/FKYFRZvPE3PuHcSMVZzfsLhGVOkfd20obL5SWEBew5ShlquNxg==",
+            "license": "MIT",
+            "optionalDependencies": {
+                "graceful-fs": "^4.1.6"
+            }
+        },
+        "node_modules/roku-debug/node_modules/roku-deploy/node_modules/universalify": {
+            "version": "0.1.2",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.1.2.tgz",
+            "integrity": "sha512-rBJeI5CXAlmy1pV+617WB9J63U6XcazHHF2f2dbJix4XzpUF0RS3Zbj0FGIOCAva5P/d/GBOYaACQ1w+0azUkg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 4.0.0"
+            }
+        },
+        "node_modules/roku-debug/node_modules/supports-color": {
+            "version": "5.5.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+            "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+            "license": "MIT",
+            "dependencies": {
+                "has-flag": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=4"
             }
         },
         "node_modules/roku-debug/node_modules/universalify": {
@@ -10582,25 +10801,37 @@
             }
         },
         "node_modules/roku-deploy": {
-            "version": "3.17.7",
-            "resolved": "https://registry.npmjs.org/roku-deploy/-/roku-deploy-3.17.7.tgz",
-            "integrity": "sha512-aEgi9Vq8/D0NhJzY97CtEUUgUwfR0/F20QR/JIMKXKDxAYt8alfgV217WShTbnFMyYYnJflTMRCHP2bJBbriGQ==",
+            "version": "4.0.0-alpha.3",
+            "resolved": "https://registry.npmjs.org/roku-deploy/-/roku-deploy-4.0.0-alpha.3.tgz",
+            "integrity": "sha512-WpQSPD5m1cuxV80aSiDtu5oVAS1V2ouKGHDusKk/FWJznBrPReGk9TDkZZ2BDo3iK3wqmxRpC918DgXQ1lFVtA==",
+            "license": "MIT",
             "dependencies": {
-                "@types/request": "^2.48.13",
+                "@rokucommunity/logger": "^0.4.1",
                 "chalk": "^2.4.2",
                 "fast-glob": "^3.2.12",
                 "fs-extra": "^7.0.1",
                 "is-glob": "^4.0.3",
                 "jsonc-parser": "^2.3.0",
-                "jszip": "^3.6.0",
+                "jszip": "^3.10.1",
                 "micromatch": "^4.0.4",
+                "needle": "^3.5.0",
                 "picomatch": "^2.3.2",
-                "postman-request": "^2.88.1-postman.48",
                 "semver": "^7.7.3",
-                "xml2js": "^0.5.0"
+                "ws": "^8.21.1",
+                "xml2js": "^0.5.0",
+                "yargs": "^17.7.2"
             },
             "bin": {
                 "roku-deploy": "dist/cli.js"
+            }
+        },
+        "node_modules/roku-deploy/node_modules/ansi-regex": {
+            "version": "5.0.1",
+            "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+            "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/roku-deploy/node_modules/ansi-styles": {
@@ -10629,6 +10860,20 @@
                 "node": ">=4"
             }
         },
+        "node_modules/roku-deploy/node_modules/cliui": {
+            "version": "8.0.1",
+            "resolved": "https://registry.npmjs.org/cliui/-/cliui-8.0.1.tgz",
+            "integrity": "sha512-BSeNnyus75C4//NQ9gQt1/csTXyo/8Sb+afLAkzAptFuMsod9HFokGNudZpi/oQV73hnVK+sR+5PVRMd+Dr7YQ==",
+            "license": "ISC",
+            "dependencies": {
+                "string-width": "^4.2.0",
+                "strip-ansi": "^6.0.1",
+                "wrap-ansi": "^7.0.0"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
         "node_modules/roku-deploy/node_modules/color-convert": {
             "version": "1.9.3",
             "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
@@ -10642,6 +10887,12 @@
             "version": "1.1.3",
             "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
             "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+            "license": "MIT"
+        },
+        "node_modules/roku-deploy/node_modules/emoji-regex": {
+            "version": "8.0.0",
+            "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+            "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A==",
             "license": "MIT"
         },
         "node_modules/roku-deploy/node_modules/escape-string-regexp": {
@@ -10660,6 +10911,69 @@
             "license": "MIT",
             "engines": {
                 "node": ">=4"
+            }
+        },
+        "node_modules/roku-deploy/node_modules/iconv-lite": {
+            "version": "0.6.3",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+            "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+            "license": "MIT",
+            "dependencies": {
+                "safer-buffer": ">= 2.1.2 < 3.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/roku-deploy/node_modules/is-fullwidth-code-point": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-3.0.0.tgz",
+            "integrity": "sha512-zymm5+u+sCsSWyD9qNaejV3DFvhCKclKdizYaJUuHA83RLjb7nSuGnddCHGv0hk+KY7BMAlsWeK4Ueg6EV6XQg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/roku-deploy/node_modules/needle": {
+            "version": "3.5.0",
+            "resolved": "https://registry.npmjs.org/needle/-/needle-3.5.0.tgz",
+            "integrity": "sha512-jaQyPKKk2YokHrEg+vFDYxXIHTCBgiZwSHOoVx/8V3GIBS8/VN6NdVRmg8q1ERtPkMvmOvebsgga4sAj5hls/w==",
+            "license": "MIT",
+            "dependencies": {
+                "iconv-lite": "^0.6.3",
+                "sax": "^1.2.4"
+            },
+            "bin": {
+                "needle": "bin/needle"
+            },
+            "engines": {
+                "node": ">= 4.4.x"
+            }
+        },
+        "node_modules/roku-deploy/node_modules/string-width": {
+            "version": "4.2.3",
+            "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+            "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+            "license": "MIT",
+            "dependencies": {
+                "emoji-regex": "^8.0.0",
+                "is-fullwidth-code-point": "^3.0.0",
+                "strip-ansi": "^6.0.1"
+            },
+            "engines": {
+                "node": ">=8"
+            }
+        },
+        "node_modules/roku-deploy/node_modules/strip-ansi": {
+            "version": "6.0.1",
+            "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+            "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+            "license": "MIT",
+            "dependencies": {
+                "ansi-regex": "^5.0.1"
+            },
+            "engines": {
+                "node": ">=8"
             }
         },
         "node_modules/roku-deploy/node_modules/supports-color": {
@@ -10687,6 +11001,33 @@
                 "node": ">=4.0.0"
             }
         },
+        "node_modules/roku-deploy/node_modules/yargs": {
+            "version": "17.7.3",
+            "resolved": "https://registry.npmjs.org/yargs/-/yargs-17.7.3.tgz",
+            "integrity": "sha512-GZtjxm/J/4TSxuL3FNYjCmLktBTnIw/rVmKSIyKeYAZpmJB2ig9VauCC5xsa82GNKVKDAqpOn3KVzNt0zmrU0g==",
+            "license": "MIT",
+            "dependencies": {
+                "cliui": "^8.0.1",
+                "escalade": "^3.1.1",
+                "get-caller-file": "^2.0.5",
+                "require-directory": "^2.1.1",
+                "string-width": "^4.2.3",
+                "y18n": "^5.0.5",
+                "yargs-parser": "^21.1.1"
+            },
+            "engines": {
+                "node": ">=12"
+            }
+        },
+        "node_modules/roku-deploy/node_modules/yargs-parser": {
+            "version": "21.1.1",
+            "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-21.1.1.tgz",
+            "integrity": "sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==",
+            "license": "ISC",
+            "engines": {
+                "node": ">=12"
+            }
+        },
         "node_modules/roku-test-automation": {
             "version": "2.2.2",
             "resolved": "https://registry.npmjs.org/roku-test-automation/-/roku-test-automation-2.2.2.tgz",
@@ -10704,6 +11045,141 @@
                 "postman-request": "^2.88.1-postman.40",
                 "roku-deploy": "^3.10.2",
                 "stoppable": "^1.1.0"
+            }
+        },
+        "node_modules/roku-test-automation/node_modules/ansi-styles": {
+            "version": "3.2.1",
+            "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.1.tgz",
+            "integrity": "sha512-VT0ZI6kZRdTh8YyJw3SMbYm/u+NqfsAxEpWO0Pf9sq8/e94WxxOpPKx9FR1FlyCtOVDNOQ+8ntlqFxiRc+r5qA==",
+            "license": "MIT",
+            "dependencies": {
+                "color-convert": "^1.9.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/roku-test-automation/node_modules/chalk": {
+            "version": "2.4.2",
+            "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.4.2.tgz",
+            "integrity": "sha512-Mti+f9lpJNcwF4tWV8/OrTTtF1gZi+f8FqlyAdouralcFWFQWF2+NgCHShjkCb+IFBLq9buZwE1xckQU4peSuQ==",
+            "license": "MIT",
+            "dependencies": {
+                "ansi-styles": "^3.2.1",
+                "escape-string-regexp": "^1.0.5",
+                "supports-color": "^5.3.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/roku-test-automation/node_modules/color-convert": {
+            "version": "1.9.3",
+            "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.3.tgz",
+            "integrity": "sha512-QfAUtd+vFdAtFQcC8CCyYt1fYWxSqAiK2cSD6zDB8N3cpsEBAvRxp9zOGg6G/SHHJYAT88/az/IuDGALsNVbGg==",
+            "license": "MIT",
+            "dependencies": {
+                "color-name": "1.1.3"
+            }
+        },
+        "node_modules/roku-test-automation/node_modules/color-name": {
+            "version": "1.1.3",
+            "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.3.tgz",
+            "integrity": "sha512-72fSenhMw2HZMTVHeCA9KCmpEIbzWiQsjN+BHcBbS9vr1mtt+vJjPdksIBNUmKAW8TFUDPJK5SUU3QhE9NEXDw==",
+            "license": "MIT"
+        },
+        "node_modules/roku-test-automation/node_modules/escape-string-regexp": {
+            "version": "1.0.5",
+            "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
+            "integrity": "sha512-vbRorB5FUQWvla16U8R/qgaFIya2qGzwDrNmCZuYKrbdSUMG6I1ZCGQRefkRVhuOkIGVne7BQ35DSfo1qvJqFg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=0.8.0"
+            }
+        },
+        "node_modules/roku-test-automation/node_modules/has-flag": {
+            "version": "3.0.0",
+            "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-3.0.0.tgz",
+            "integrity": "sha512-sKJf1+ceQBr4SMkvQnBDNDtf4TXpVhVGateu0t918bl30FnbE2m4vNLX+VWe/dpjlb+HugGYzW7uQXH98HPEYw==",
+            "license": "MIT",
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/roku-test-automation/node_modules/iconv-lite": {
+            "version": "0.6.3",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+            "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+            "license": "MIT",
+            "dependencies": {
+                "safer-buffer": ">= 2.1.2 < 3.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
+        "node_modules/roku-test-automation/node_modules/roku-deploy": {
+            "version": "3.18.2",
+            "resolved": "https://registry.npmjs.org/roku-deploy/-/roku-deploy-3.18.2.tgz",
+            "integrity": "sha512-O0nO/hzhax6nhcwsk40Vdoq7RKm4n3OCJfc+Vr5OcV1YfSg5qeFt6gY3RG74QjZ+KrTO1A51XO0Oe1e4qV4O8w==",
+            "license": "MIT",
+            "dependencies": {
+                "@rokucommunity/logger": "^0.4.1",
+                "chalk": "^2.4.2",
+                "fast-glob": "^3.2.12",
+                "fs-extra": "^7.0.1",
+                "is-glob": "^4.0.3",
+                "jsonc-parser": "^2.3.0",
+                "jszip": "^3.6.0",
+                "micromatch": "^4.0.4",
+                "needle": "^3.5.0",
+                "picomatch": "^2.3.2",
+                "semver": "^7.7.3",
+                "xml2js": "^0.5.0"
+            },
+            "bin": {
+                "roku-deploy": "dist/cli.js"
+            }
+        },
+        "node_modules/roku-test-automation/node_modules/roku-deploy/node_modules/needle": {
+            "version": "3.5.0",
+            "resolved": "https://registry.npmjs.org/needle/-/needle-3.5.0.tgz",
+            "integrity": "sha512-jaQyPKKk2YokHrEg+vFDYxXIHTCBgiZwSHOoVx/8V3GIBS8/VN6NdVRmg8q1ERtPkMvmOvebsgga4sAj5hls/w==",
+            "license": "MIT",
+            "dependencies": {
+                "iconv-lite": "^0.6.3",
+                "sax": "^1.2.4"
+            },
+            "bin": {
+                "needle": "bin/needle"
+            },
+            "engines": {
+                "node": ">= 4.4.x"
+            }
+        },
+        "node_modules/roku-test-automation/node_modules/supports-color": {
+            "version": "5.5.0",
+            "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.5.0.tgz",
+            "integrity": "sha512-QjVjwdXIt408MIiAqCX4oUKsgU2EqAGzs2Ppkm4aQYbjm+ZEWEcW4SfFNTr4uMNZma0ey4f5lgLrkB0aX0QMow==",
+            "license": "MIT",
+            "dependencies": {
+                "has-flag": "^3.0.0"
+            },
+            "engines": {
+                "node": ">=4"
+            }
+        },
+        "node_modules/roku-test-automation/node_modules/xml2js": {
+            "version": "0.5.0",
+            "resolved": "https://registry.npmjs.org/xml2js/-/xml2js-0.5.0.tgz",
+            "integrity": "sha512-drPFnkQJik/O+uPKpqSgr22mpuFHqKdbS835iAQrUC73L2F5WkboIRd63ai/2Yg6I1jzifPFKH2NTK+cfglkIA==",
+            "license": "MIT",
+            "dependencies": {
+                "sax": ">=0.6.0",
+                "xmlbuilder": "~11.0.0"
+            },
+            "engines": {
+                "node": ">=4.0.0"
             }
         },
         "node_modules/run-applescript": {
@@ -12892,9 +13368,9 @@
             }
         },
         "node_modules/ws": {
-            "version": "8.21.0",
-            "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
-            "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+            "version": "8.21.3",
+            "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.3.tgz",
+            "integrity": "sha512-201TZ/kPWxoPr/OKWjquZR1SWKXcvxdH+e1xrx89b3YbmzLMFCLfnaG1HFIgWzJOEWZ7MvpK++odZufgYR50Rw==",
             "license": "MIT",
             "engines": {
                 "node": ">=10.0.0"

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
         "pretty-bytes": "^5.6.0",
         "resolve": "^1.22.8",
         "roku-debug": "^0.23.16",
-        "roku-deploy": "^3.17.7",
+        "roku-deploy": "^4.0.0-alpha.3",
         "roku-test-automation": "^2.2.2",
         "semver": "^7.1.3",
         "source-map": "^0.7.3",

--- a/src/BrightScriptCommands.spec.ts
+++ b/src/BrightScriptCommands.spec.ts
@@ -319,7 +319,7 @@ describe('BrightScriptFileUtils ', () => {
             await localCommands.restartDevice('1.2.3.4');
 
             assert.isTrue(rebootStub.calledOnce);
-            assert.equal(rebootStub.firstCall.args[0].host, '1.2.3.4');
+            assert.equal(rebootStub.firstCall.args[0].device.host, '1.2.3.4');
             assert.equal(rebootStub.firstCall.args[0].password, 'pw');
             assert.isFalse(showErrorStub.called);
         });
@@ -368,7 +368,7 @@ describe('BrightScriptFileUtils ', () => {
 
             assert.isTrue(userInputManager.promptForHost.calledOnce);
             assert.isTrue(rebootStub.calledOnce);
-            assert.equal(rebootStub.firstCall.args[0].host, '1.2.3.4');
+            assert.equal(rebootStub.firstCall.args[0].device.host, '1.2.3.4');
         });
 
         it('cancels when the device picker is dismissed', async () => {
@@ -387,7 +387,7 @@ describe('BrightScriptFileUtils ', () => {
             await localCommands.checkForUpdates('1.2.3.4');
 
             assert.isTrue(checkForUpdateStub.calledOnce);
-            assert.equal(checkForUpdateStub.firstCall.args[0].host, '1.2.3.4');
+            assert.equal(checkForUpdateStub.firstCall.args[0].device.host, '1.2.3.4');
             assert.equal(checkForUpdateStub.firstCall.args[0].password, 'pw');
         });
 

--- a/src/BrightScriptCommands.ts
+++ b/src/BrightScriptCommands.ts
@@ -799,7 +799,7 @@ export class BrightScriptCommands {
             await vscode.window.withProgress({
                 location: vscode.ProgressLocation.Notification,
                 title: `Requesting restarting ${target.label}`
-            }, () => rokuDeploy.rebootDevice({ host: target.host, password: password, timeout: 10000 }));
+            }, () => rokuDeploy.rebootDevice({ device: { host: target.host }, password: password, timeout: 10000 }));
         } catch (e) {
             void vscode.window.showErrorMessage(`Failed to restart device: ${e.message}`);
         }
@@ -836,7 +836,7 @@ export class BrightScriptCommands {
             await vscode.window.withProgress({
                 location: vscode.ProgressLocation.Notification,
                 title: `Checking for updates: ${target.label}`
-            }, () => rokuDeploy.checkForUpdate({ host: target.host, password: password, timeout: 10000 }));
+            }, () => rokuDeploy.checkForUpdate({ device: { host: target.host }, password: password, timeout: 10000 }));
         } catch (e) {
             void vscode.window.showErrorMessage(`Failed to check for updates: ${e.message}`);
         }

--- a/src/LogDocumentLinkProvider.ts
+++ b/src/LogDocumentLinkProvider.ts
@@ -1,5 +1,5 @@
 import * as path from 'path';
-import * as rokuDeploy from 'roku-deploy';
+import { rokuDeploy } from 'roku-deploy';
 import { DocumentLink, Position, Range } from 'vscode';
 import * as vscode from 'vscode';
 import BrightscriptFileUtils from './BrightScriptFileUtils';
@@ -42,7 +42,7 @@ export class LogDocumentLinkProvider implements vscode.DocumentLinkProvider {
         let sourceRootDir = launchConfig.sourceDirs ? launchConfig.sourceDirs : [launchConfig.rootDir];
         let paths = [];
         for (const rootDir of sourceRootDir) {
-            let pathsFromRoot = await this.rokuDeploy.getFilePaths(launchConfig.files, rootDir);
+            let pathsFromRoot = await this.rokuDeploy.getFilePaths({ files: launchConfig.files, rootDir: rootDir });
             paths = paths.concat(pathsFromRoot);
         }
         //get every file used in this project

--- a/src/commands/CaptureScreenshotCommand.spec.ts
+++ b/src/commands/CaptureScreenshotCommand.spec.ts
@@ -2,7 +2,7 @@ import { vscode } from '../mockVscode.spec';
 import { createSandbox } from 'sinon';
 import { CaptureScreenshotCommand } from './CaptureScreenshotCommand';
 import { BrightScriptCommands } from '../BrightScriptCommands';
-import * as rokuDeploy from 'roku-deploy';
+import { rokuDeploy } from 'roku-deploy';
 import { expect } from 'chai';
 import URI from 'vscode-uri';
 import { standardizePath as s } from 'brighterscript';
@@ -59,7 +59,7 @@ describe('CaptureScreenshotCommand', () => {
 
     it('shows error message when captureScreenshot fails', async () => {
         const stub = sinon.stub(command as any, 'getHostAndPassword').callsFake(() => Promise.resolve({ host: '1.1.1.1', password: 'password' }));
-        sinon.stub(rokuDeploy, 'takeScreenshot').rejects(new Error('Screenshot failed'));
+        sinon.stub(rokuDeploy, 'captureScreenshot').rejects(new Error('Screenshot failed'));
         const stubError = sinon.stub(vscode.window, 'showErrorMessage');
 
         await command['captureScreenshot']('1.1.1.1');
@@ -70,16 +70,16 @@ describe('CaptureScreenshotCommand', () => {
 
     it('uses temp dir when screenshotDir is not defined', async () => {
         sinon.stub(command as any, 'getHostAndPassword').callsFake(() => Promise.resolve({ host: '1.1.1.1', password: 'password' }));
-        const stub = sinon.stub(rokuDeploy, 'takeScreenshot').returns(Promise.resolve('screenshot.png'));
+        const stub = sinon.stub(rokuDeploy, 'captureScreenshot').returns(Promise.resolve({ buffer: Buffer.alloc(0), filePath: 'screenshot.png' }));
 
         await command['captureScreenshot']();
 
-        expect(stub.getCall(0).args[0]).to.eql({ host: '1.1.1.1', password: 'password' });
+        expect(stub.getCall(0).args[0]).to.eql({ device: { host: '1.1.1.1' }, password: 'password', out: true });
     });
 
     it('uses screenshotDir with single workspace', async () => {
         sinon.stub(command as any, 'getHostAndPassword').callsFake(() => Promise.resolve({ host: '1.1.1.1', password: 'password' }));
-        const stub = sinon.stub(rokuDeploy, 'takeScreenshot').returns(Promise.resolve('screenshot.png'));
+        const stub = sinon.stub(rokuDeploy, 'captureScreenshot').returns(Promise.resolve({ buffer: Buffer.alloc(0), filePath: 'screenshot.png' }));
         workspace._configuration = {
             'brightscript.screenshotDir': '${workspaceFolder}/screenshots'
         };
@@ -93,12 +93,12 @@ describe('CaptureScreenshotCommand', () => {
 
         await command['captureScreenshot']();
 
-        expect(stub.getCall(0).args[0]).to.eql({ host: '1.1.1.1', password: 'password', outDir: s`${cwd}/workspace/screenshots` });
+        expect(stub.getCall(0).args[0]).to.eql({ device: { host: '1.1.1.1' }, password: 'password', out: true, screenshotDir: s`${cwd}/workspace/screenshots` });
     });
 
     it('uses relative screenshotDir with single workspace', async () => {
         sinon.stub(command as any, 'getHostAndPassword').callsFake(() => Promise.resolve({ host: '1.1.1.1', password: 'password' }));
-        const stub = sinon.stub(rokuDeploy, 'takeScreenshot').returns(Promise.resolve('screenshot.png'));
+        const stub = sinon.stub(rokuDeploy, 'captureScreenshot').returns(Promise.resolve({ buffer: Buffer.alloc(0), filePath: 'screenshot.png' }));
         workspace._configuration = {
             'brightscript.screenshotDir': 'screenshots'
         };
@@ -112,12 +112,12 @@ describe('CaptureScreenshotCommand', () => {
 
         await command['captureScreenshot']();
 
-        expect(stub.getCall(0).args[0]).to.eql({ host: '1.1.1.1', password: 'password', outDir: s`${cwd}/workspace/screenshots` });
+        expect(stub.getCall(0).args[0]).to.eql({ device: { host: '1.1.1.1' }, password: 'password', out: true, screenshotDir: s`${cwd}/workspace/screenshots` });
     });
 
     it('uses screenshotDir with multiple workspace', async () => {
         sinon.stub(command as any, 'getHostAndPassword').callsFake(() => Promise.resolve({ host: '1.1.1.1', password: 'password' }));
-        const stub = sinon.stub(rokuDeploy, 'takeScreenshot').returns(Promise.resolve('screenshot.png'));
+        const stub = sinon.stub(rokuDeploy, 'captureScreenshot').returns(Promise.resolve({ buffer: Buffer.alloc(0), filePath: 'screenshot.png' }));
         const workspaceFolders = [
             {
                 uri: URI.file(s`${cwd}/workspace1`),
@@ -138,12 +138,12 @@ describe('CaptureScreenshotCommand', () => {
 
         await command['captureScreenshot']();
 
-        expect(stub.getCall(0).args[0]).to.eql({ host: '1.1.1.1', password: 'password', outDir: s`${cwd}/workspace2/screenshots` });
+        expect(stub.getCall(0).args[0]).to.eql({ device: { host: '1.1.1.1' }, password: 'password', out: true, screenshotDir: s`${cwd}/workspace2/screenshots` });
     });
 
     it('uses relative screenshotDir with multiple workspace', async () => {
         sinon.stub(command as any, 'getHostAndPassword').callsFake(() => Promise.resolve({ host: '1.1.1.1', password: 'password' }));
-        const stub = sinon.stub(rokuDeploy, 'takeScreenshot').returns(Promise.resolve('screenshot.png'));
+        const stub = sinon.stub(rokuDeploy, 'captureScreenshot').returns(Promise.resolve({ buffer: Buffer.alloc(0), filePath: 'screenshot.png' }));
         const workspaceFolders = [
             {
                 uri: URI.file(s`${cwd}/workspace1`),
@@ -164,6 +164,6 @@ describe('CaptureScreenshotCommand', () => {
 
         await command['captureScreenshot']();
 
-        expect(stub.getCall(0).args[0]).to.eql({ host: '1.1.1.1', password: 'password', outDir: s`${cwd}/workspace2/screenshots` });
+        expect(stub.getCall(0).args[0]).to.eql({ device: { host: '1.1.1.1' }, password: 'password', out: true, screenshotDir: s`${cwd}/workspace2/screenshots` });
     });
 });

--- a/src/commands/CaptureScreenshotCommand.ts
+++ b/src/commands/CaptureScreenshotCommand.ts
@@ -1,6 +1,6 @@
 import * as vscode from 'vscode';
 import * as path from 'path';
-import * as rokuDeploy from 'roku-deploy';
+import { rokuDeploy } from 'roku-deploy';
 import type { BrightScriptCommands } from '../BrightScriptCommands';
 import { util } from '../util';
 
@@ -77,13 +77,15 @@ export class CaptureScreenshotCommand {
             }, async (options) => {
                 const screenshotDir = await this.getScreenshotDir();
 
-                let screenshotPath = await rokuDeploy.takeScreenshot({
-                    host: host,
+                let screenshotResult = await rokuDeploy.captureScreenshot({
+                    device: { host: host },
                     password: password,
-                    ...(screenshotDir && { outDir: screenshotDir })
+                    //save the screenshot to disk (in screenshotDir when configured, otherwise the OS temp directory)
+                    out: true,
+                    ...(screenshotDir && { screenshotDir: screenshotDir })
                 });
 
-                return screenshotPath;
+                return screenshotResult.filePath;
             });
 
             if (screenshotPath) {

--- a/src/commands/RekeyAndPackageCommand.ts
+++ b/src/commands/RekeyAndPackageCommand.ts
@@ -1,5 +1,6 @@
 import * as vscode from 'vscode';
-import * as rokuDeploy from 'roku-deploy';
+import { rokuDeploy, RokuDeploy } from 'roku-deploy';
+import type { FileEntry } from 'roku-deploy';
 import type { BrightScriptCommands } from '../BrightScriptCommands';
 import * as path from 'path';
 import { readFileSync } from 'fs-extra';
@@ -58,7 +59,12 @@ export class RekeyAndPackageCommand {
             }
         }
 
-        await rokuDeploy.rekeyDevice(rekeyConfig);
+        await rokuDeploy.rekeyDevice({
+            device: { host: rekeyConfig.host },
+            password: rekeyConfig.password,
+            signingPassword: rekeyConfig.signingPassword,
+            pkg: rekeyConfig.rekeySignedPackage
+        });
         void vscode.window.showInformationMessage(`Device successfully rekeyed!`);
     }
 
@@ -257,20 +263,23 @@ export class RekeyAndPackageCommand {
             }
 
             //normalize a few options
-            rokuDeployOptions.outFile ??= rokuDeploy.getOptions(rokuDeployOptions).outFile;
+            rokuDeployOptions.outFile ??= RokuDeploy.defaults.outFile;
             rokuDeployOptions.outDir = standardizePath(rokuDeployOptions.outDir ?? `${workspaceFolder}/out`);
             rokuDeployOptions.rootDir = standardizePath(rokuDeployOptions.rootDir);
-            rokuDeployOptions.retainStagingDir = true;
             if (rokuDeployOptions.rekeySignedPackage?.length > 0) {
                 rokuDeployOptions.rekeySignedPackage = standardizePath(rokuDeployOptions.rekeySignedPackage);
             }
+
+            const stagingDir = rokuDeploy.getStagingDir({ outDir: rokuDeployOptions.outDir });
+            const zipPath = rokuDeploy.getOutputZipPath({ outDir: rokuDeployOptions.outDir, outFile: rokuDeployOptions.outFile });
+            const pkgPath = rokuDeploy.getOutputPkgPath({ outDir: rokuDeployOptions.outDir, outFile: rokuDeployOptions.outFile });
 
             let details = [
                 `host: ${rokuDeployOptions.host}`,
                 `password: ${rokuDeployOptions.password}`,
                 `signing password: ${rokuDeployOptions.signingPassword}`,
                 `outDir: ${rokuDeployOptions.outDir}`,
-                `outFile: ${rokuDeployOptions.outFile}.pkg`,
+                `outFile: ${path.basename(pkgPath)}`,
                 `rootDir: ${rokuDeployOptions.rootDir}`
             ];
 
@@ -287,17 +296,38 @@ export class RekeyAndPackageCommand {
             }, confirmText, changeText);
 
             if (response === confirmText) {
+                const device = { host: rokuDeployOptions.host };
+
                 if (rekeyFlag) {
                     //rekey device
-                    await rokuDeploy.rekeyDevice(rokuDeployOptions);
+                    await rokuDeploy.rekeyDevice({
+                        device: device,
+                        password: rokuDeployOptions.password,
+                        signingPassword: rokuDeployOptions.signingPassword,
+                        pkg: rokuDeployOptions.rekeySignedPackage
+                    });
                 }
 
-                //create a zip and pkg file of the app based on the selected launch config
-                await rokuDeploy.createPackage(rokuDeployOptions);
-                let remotePkgPath = await rokuDeploy.signExistingPackage(rokuDeployOptions);
-                await rokuDeploy.retrieveSignedPackage(remotePkgPath, rokuDeployOptions);
-                const outPath = standardizePath(`${rokuDeployOptions.outDir}/${rokuDeployOptions.outFile}`);
-                let successfulMessage = `Package successfully created at ${outPath}`;
+                //create a zip of the app based on the selected launch config
+                await rokuDeploy.stage({
+                    rootDir: rokuDeployOptions.rootDir,
+                    files: rokuDeployOptions.files,
+                    out: stagingDir
+                });
+                await rokuDeploy.zip({
+                    dir: stagingDir,
+                    out: zipPath
+                });
+
+                //sign the app installed on the device and download the signed package
+                await rokuDeploy.createSignedPackage({
+                    device: device,
+                    password: rokuDeployOptions.password,
+                    signingPassword: rokuDeployOptions.signingPassword,
+                    manifestPath: standardizePath(`${stagingDir}/manifest`),
+                    out: pkgPath
+                });
+                let successfulMessage = `Package successfully created at ${pkgPath}`;
                 void vscode.window.showInformationMessage(successfulMessage, 'View in folder').then(() => {
                     return open(rokuDeployOptions.outDir);
                 });
@@ -435,7 +465,7 @@ interface RokuDeployOptions {
     rootDir: string;
     outDir: string;
     outFile: string;
-    retainStagingDir: boolean;
+    files?: FileEntry[];
     host: string;
     password: string;
     signingPassword: string;

--- a/src/commands/RekeyAndPackageCommand.ts
+++ b/src/commands/RekeyAndPackageCommand.ts
@@ -1,5 +1,5 @@
 import * as vscode from 'vscode';
-import { rokuDeploy, RokuDeploy } from 'roku-deploy';
+import { rokuDeploy } from 'roku-deploy';
 import type { FileEntry } from 'roku-deploy';
 import type { BrightScriptCommands } from '../BrightScriptCommands';
 import * as path from 'path';
@@ -263,16 +263,21 @@ export class RekeyAndPackageCommand {
             }
 
             //normalize a few options
-            rokuDeployOptions.outFile ??= RokuDeploy.defaults.outFile;
+            rokuDeployOptions.outFile ??= 'roku-deploy.zip';
             rokuDeployOptions.outDir = standardizePath(rokuDeployOptions.outDir ?? `${workspaceFolder}/out`);
             rokuDeployOptions.rootDir = standardizePath(rokuDeployOptions.rootDir);
             if (rokuDeployOptions.rekeySignedPackage?.length > 0) {
                 rokuDeployOptions.rekeySignedPackage = standardizePath(rokuDeployOptions.rekeySignedPackage);
             }
 
-            const stagingDir = rokuDeploy.getStagingDir({ outDir: rokuDeployOptions.outDir });
-            const zipPath = rokuDeploy.getOutputZipPath({ outDir: rokuDeployOptions.outDir, outFile: rokuDeployOptions.outFile });
-            const pkgPath = rokuDeploy.getOutputPkgPath({ outDir: rokuDeployOptions.outDir, outFile: rokuDeployOptions.outFile });
+            //resolve the same paths roku-deploy's stage/zip/createSignedPackage will produce (roku-deploy
+            //does not expose this resolution, so it is rolled here and must stay in step with its defaults)
+            const stagingDir = standardizePath(`${rokuDeployOptions.outDir}/.roku-deploy-staging`);
+            let zipPath = standardizePath(`${rokuDeployOptions.outDir}/${rokuDeployOptions.outFile}`);
+            if (!zipPath.toLowerCase().endsWith('.zip')) {
+                zipPath += '.zip';
+            }
+            const pkgPath = zipPath.replace(/\.zip$/i, '.pkg');
 
             let details = [
                 `host: ${rokuDeployOptions.host}`,

--- a/src/deviceDiscovery/DeviceManager.spec.ts
+++ b/src/deviceDiscovery/DeviceManager.spec.ts
@@ -1126,7 +1126,7 @@ describe('DeviceManager', () => {
             validateStub.resolves(true);
             const result = await manager.validateDevicePassword('192.168.1.100', 'rokudev');
             expect(result).to.equal('ok');
-            expect(validateStub.firstCall.args[0]).to.deep.equal({ host: '192.168.1.100', password: 'rokudev' });
+            expect(validateStub.firstCall.args[0]).to.deep.equal({ device: { host: '192.168.1.100' }, password: 'rokudev' });
         });
 
         it(`returns 'bad-password' when the device rejects the credentials`, async () => {
@@ -3233,8 +3233,8 @@ describe('DeviceManager', () => {
 
                 // Stub: IP .100 fails (wrong IP), IP .50 succeeds (correct IP)
                 const getDeviceInfoStub = sinon.stub(rokuDeploy, 'getDeviceInfo');
-                getDeviceInfoStub.withArgs(sinon.match({ host: '192.168.1.100' })).rejects(new Error('Unreachable'));
-                getDeviceInfoStub.withArgs(sinon.match({ host: '192.168.1.50' })).resolves({
+                getDeviceInfoStub.withArgs(sinon.match({ device: { host: '192.168.1.100' } })).rejects(new Error('Unreachable'));
+                getDeviceInfoStub.withArgs(sinon.match({ device: { host: '192.168.1.50' } })).resolves({
                     'serial-number': 'XYZ',
                     'device-id': 'XYZ',
                     'default-device-name': 'Roku Express'
@@ -3275,8 +3275,8 @@ describe('DeviceManager', () => {
                 }));
 
                 const getDeviceInfoStub = sinon.stub(rokuDeploy, 'getDeviceInfo');
-                getDeviceInfoStub.withArgs(sinon.match({ host: '192.168.1.100' })).rejects(new Error('Unreachable'));
-                getDeviceInfoStub.withArgs(sinon.match({ host: '192.168.1.50' })).resolves({
+                getDeviceInfoStub.withArgs(sinon.match({ device: { host: '192.168.1.100' } })).rejects(new Error('Unreachable'));
+                getDeviceInfoStub.withArgs(sinon.match({ device: { host: '192.168.1.50' } })).resolves({
                     'serial-number': 'XYZ',
                     'device-id': 'XYZ',
                     'default-device-name': 'Roku Express'
@@ -3292,8 +3292,8 @@ describe('DeviceManager', () => {
 
                 // Now test the reverse order: correct IP first, then wrong IP
                 getDeviceInfoStub.reset();
-                getDeviceInfoStub.withArgs(sinon.match({ host: '192.168.1.100' })).rejects(new Error('Unreachable'));
-                getDeviceInfoStub.withArgs(sinon.match({ host: '192.168.1.50' })).resolves({
+                getDeviceInfoStub.withArgs(sinon.match({ device: { host: '192.168.1.100' } })).rejects(new Error('Unreachable'));
+                getDeviceInfoStub.withArgs(sinon.match({ device: { host: '192.168.1.50' } })).resolves({
                     'serial-number': 'XYZ',
                     'device-id': 'XYZ',
                     'default-device-name': 'Roku Express'

--- a/src/deviceDiscovery/DeviceManager.ts
+++ b/src/deviceDiscovery/DeviceManager.ts
@@ -602,7 +602,7 @@ export class DeviceManager {
      */
     public async validateDevicePassword(host: string, password: string): Promise<PasswordValidationResult> {
         try {
-            const accepted = await rokuDeploy.validateDeveloperPassword({ host: host, password: password });
+            const accepted = await rokuDeploy.validateDeveloperPassword({ device: { host: host }, password: password });
             return accepted ? 'ok' : 'bad-password';
         } catch (e) {
             if (e instanceof DeviceUnreachableError) {
@@ -1020,8 +1020,8 @@ export class DeviceManager {
     private async fetchDeviceInfo(ip: string, port: number): Promise<DeviceInfoRaw> {
         try {
             const info = await rokuDeploy.getDeviceInfo({
-                host: ip,
-                remotePort: port,
+                device: { host: ip },
+                ecpPort: port,
                 timeout: DeviceManager.HEALTH_CHECK_TIMEOUT_MS
             });
             if (info['serial-number']) {

--- a/src/managers/RokuProject/BrsConfigProjectProvider.spec.ts
+++ b/src/managers/RokuProject/BrsConfigProjectProvider.spec.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { createSandbox } from 'sinon';
 import * as path from 'path';
 import * as fs from 'fs';
-import { rokuDeploy } from 'roku-deploy';
+import { util as rokuDeployUtil } from 'roku-deploy';
 import { vscode } from '../../mockVscode.spec';
 
 let Module = require('module');
@@ -189,7 +189,7 @@ describe('BrsConfigProjectProvider', () => {
                 rootDir: projectDir
             });
 
-            sinon.stub(rokuDeploy, 'getDestPath').returns('source/main.brs');
+            sinon.stub(rokuDeployUtil, 'getDestPath').returns('source/main.brs');
 
             const results = await provider.findProjectConfigFromFile(fileUri);
 
@@ -199,7 +199,7 @@ describe('BrsConfigProjectProvider', () => {
 
         it('returns an empty array when no indexed config owns the file', async () => {
             const fileUri = makeUri('/project/src/main.brs');
-            sinon.stub(rokuDeploy, 'getDestPath').returns(undefined as any);
+            sinon.stub(rokuDeployUtil, 'getDestPath').returns(undefined as any);
 
             const results = await provider.findProjectConfigFromFile(fileUri);
 
@@ -219,7 +219,7 @@ describe('BrsConfigProjectProvider', () => {
                 configUri: configUri2, files: [], rootDir: projectDir
             });
 
-            sinon.stub(rokuDeploy, 'getDestPath').returns('source/main.brs');
+            sinon.stub(rokuDeployUtil, 'getDestPath').returns('source/main.brs');
 
             const results = await provider.findProjectConfigFromFile(fileUri);
 

--- a/src/managers/RokuProject/BrsConfigProjectProvider.ts
+++ b/src/managers/RokuProject/BrsConfigProjectProvider.ts
@@ -3,7 +3,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 import { util as bsUtil } from 'brighterscript';
 import { util } from '../../util';
-import { rokuDeploy } from 'roku-deploy';
+import { util as rokuDeployUtil } from 'roku-deploy';
 import type { FileEntry } from 'roku-deploy';
 import type { DiscoveredRokuProject, ProjectBuildResult, ProjectConfigProvider } from './RokuProjectManager';
 
@@ -54,14 +54,14 @@ export class BrsConfigProjectProvider implements ProjectConfigProvider {
     }
 
     /**
-     * Uses rokuDeploy.getDestPath against each indexed config's files/rootDir.
+     * Uses roku-deploy's getDestPath against each indexed config's files/rootDir.
      * Returns undefined (not owned) when getDestPath returns undefined for all configs.
      */
     public findProjectConfigFromFile(fileUri: vscode.Uri): Promise<vscode.Uri[]> {
         const filePath = bsUtil.driveLetterToLower(fileUri.fsPath);
         const matches: vscode.Uri[] = [];
         for (const entry of this.configByPath.values()) {
-            if (rokuDeploy.getDestPath(filePath, entry.files, entry.rootDir)) {
+            if (rokuDeployUtil.getDestPath(filePath, entry.files, entry.rootDir)) {
                 matches.push(entry.configUri);
             }
         }

--- a/src/managers/RokuProject/BsConfigProjectProvider.spec.ts
+++ b/src/managers/RokuProject/BsConfigProjectProvider.spec.ts
@@ -2,7 +2,7 @@ import { expect } from 'chai';
 import { createSandbox } from 'sinon';
 import * as path from 'path';
 import { util } from 'brighterscript';
-import { rokuDeploy } from 'roku-deploy';
+import { util as rokuDeployUtil } from 'roku-deploy';
 import { vscode } from '../../mockVscode.spec';
 
 let Module = require('module');
@@ -197,7 +197,7 @@ describe('BsConfigProjectProvider', () => {
                 stagingDir: path.join(projectDir, 'out')
             });
 
-            sinon.stub(rokuDeploy, 'getDestPath').returns('source/main.brs');
+            sinon.stub(rokuDeployUtil, 'getDestPath').returns('source/main.brs');
 
             const results = await provider.findProjectConfigFromFile(fileUri);
 
@@ -207,7 +207,7 @@ describe('BsConfigProjectProvider', () => {
 
         it('returns an empty array when no indexed config owns the file', async () => {
             const fileUri = makeUri('/project/src/main.brs');
-            sinon.stub(rokuDeploy, 'getDestPath').returns(undefined as any);
+            sinon.stub(rokuDeployUtil, 'getDestPath').returns(undefined as any);
 
             const results = await provider.findProjectConfigFromFile(fileUri);
 
@@ -227,7 +227,7 @@ describe('BsConfigProjectProvider', () => {
                 configUri: configUri2, files: [], rootDir: projectDir, stagingDir: ''
             });
 
-            sinon.stub(rokuDeploy, 'getDestPath').returns('source/main.brs');
+            sinon.stub(rokuDeployUtil, 'getDestPath').returns('source/main.brs');
 
             const results = await provider.findProjectConfigFromFile(fileUri);
 

--- a/src/managers/RokuProject/BsConfigProjectProvider.ts
+++ b/src/managers/RokuProject/BsConfigProjectProvider.ts
@@ -2,7 +2,7 @@ import * as path from 'path';
 import * as vscode from 'vscode';
 import { util as bsUtil } from 'brighterscript';
 import { util } from '../../util';
-import { rokuDeploy } from 'roku-deploy';
+import { util as rokuDeployUtil } from 'roku-deploy';
 import type { FileEntry } from 'roku-deploy';
 import type { TaskConfig } from '../../BrightScriptTaskProvider';
 import type { DiscoveredRokuProject, ProjectBuildResult, ProjectConfigProvider } from './RokuProjectManager';
@@ -58,7 +58,7 @@ export class BsConfigProjectProvider implements ProjectConfigProvider {
     }
 
     /**
-     * Uses rokuDeploy.getDestPath against each indexed config's files/rootDir.
+     * Uses roku-deploy's getDestPath against each indexed config's files/rootDir.
      * Returns undefined (not owned) when getDestPath returns undefined for all configs.
      */
     public findProjectConfigFromFile(fileUri: vscode.Uri): Promise<vscode.Uri[]> {
@@ -67,7 +67,7 @@ export class BsConfigProjectProvider implements ProjectConfigProvider {
         for (const entry of this.configByPath.values()) {
             // getDestPath returns undefined at runtime when the file doesn't match
             // (TypeScript types the return as string, but the implementation returns undefined for no match)
-            if (rokuDeploy.getDestPath(filePath, entry.files, entry.rootDir)) {
+            if (rokuDeployUtil.getDestPath(filePath, entry.files, entry.rootDir)) {
                 matches.push(entry.configUri);
             }
         }

--- a/src/managers/RokuProject/ManifestProjectProvider.ts
+++ b/src/managers/RokuProject/ManifestProjectProvider.ts
@@ -2,7 +2,7 @@ import * as fs from 'fs';
 import * as path from 'path';
 import * as vscode from 'vscode';
 import { util as bsUtil } from 'brighterscript';
-import { rokuDeploy } from 'roku-deploy';
+import { util as rokuDeployUtil } from 'roku-deploy';
 import { util } from '../../util';
 import { BrightScriptDebugConfigurationProvider } from '../../DebugConfigurationProvider';
 import type { DiscoveredRokuProject, ProjectBuildResult, ProjectConfigProvider } from './RokuProjectManager';
@@ -48,7 +48,7 @@ export class ManifestProjectProvider implements ProjectConfigProvider {
         for (const [projectDir, configUri] of this.configByProjectDir) {
             // Drive letters must be normalized on both sides — getDestPath does a case-sensitive
             // comparison and Windows uri.fsPath casing isn't always consistent with path.dirname output.
-            if (rokuDeploy.getDestPath(filePath, files, bsUtil.driveLetterToLower(projectDir))) {
+            if (rokuDeployUtil.getDestPath(filePath, files, bsUtil.driveLetterToLower(projectDir))) {
                 matches.push(configUri);
             }
         }


### PR DESCRIPTION
Moves every roku-deploy call to the v4 named-options API and the unified `device` option (roku-deploy PR rokucommunity/roku-deploy#323, plus the defaults/resolvers from rokucommunity/roku-deploy#330). Companion to rokucommunity/roku-debug#398.

- `host` call sites now pass a `device` option (`rebootDevice`, `checkForUpdate`, `getDeviceInfo`, `validateDeveloperPassword`; `remotePort` -> `ecpPort`)
- `takeScreenshot` -> `captureScreenshot` (`out: true`, returns `{ buffer, filePath }`)
- the rekey/package command is rebuilt on `rekeyDevice({ pkg })` + `stage` + `zip` + `createSignedPackage({ manifestPath, out })`, with paths resolved through `RokuDeploy.defaults` and the `getStagingDir`/`getOutputZipPath`/`getOutputPkgPath` resolvers
- `getFilePaths` named options; `getDestPath` now comes from roku-deploy's `util` singleton

Draft: builds against local checkouts of roku-deploy (unified-device-option) and roku-debug (rokucommunity/roku-debug#398); the package.json bumps will follow separately once published versions exist.