### PR TITLE
chore: Give fork PRs a clear create-vsix failure message

### DIFF
--- a/.github/workflows/create-vsix.yml
+++ b/.github/workflows/create-vsix.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Reject fork PRs
         if: true || github.event.pull_request.head.repo.fork
         run: |
-          echo "::error::Could not build a .vsix because fork PRs can't access the required secrets. Ask a maintainer to dispatch it manually: https://github.com/${{ github.repository }}/actions/workflows/create-vsix.yml"
+          echo "::error::Could not build a .vsix because fork PRs can't access the required secrets. Ask a maintainer to dispatch it manually for PR #${{ github.event.pull_request.number }}: https://github.com/${{ github.repository }}/actions/workflows/create-vsix.yml"
           exit 1
       - run: npm ci
       - run: npx ts-node scripts/create-vsix.ts ${{ steps.info.outputs.branch }}

--- a/.github/workflows/create-vsix.yml
+++ b/.github/workflows/create-vsix.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Reject fork PRs
         if: true || github.event.pull_request.head.repo.fork
         run: |
-          echo "::error::Fork PRs can't access the required secrets. A maintainer must build PR #${{ github.event.pull_request.number }} manually: https://github.com/${{ github.repository }}/actions/workflows/create-vsix.yml"
+          echo "::error::Could not build a .vsix because fork PRs can't access the required secrets. Ask a maintainer to dispatch it manually: https://github.com/${{ github.repository }}/actions/workflows/create-vsix.yml"
           exit 1
       - run: npm ci
       - run: npx ts-node scripts/create-vsix.ts ${{ steps.info.outputs.branch }}

--- a/.github/workflows/create-vsix.yml
+++ b/.github/workflows/create-vsix.yml
@@ -71,6 +71,12 @@ jobs:
             }
             core.setOutput('branch', branch);
             console.log(`branch: "${branch}"`);
+      # GitHub withholds repository secrets from fork-triggered runs, so fail fast with a clear message
+      - name: Reject fork PRs
+        if: github.event.pull_request.head.repo.fork
+        run: |
+          echo "::error::Could not build a .vsix because forked PRs don't have access to the necessary github secrets. A maintainer must run this workflow manually: https://github.com/${{ github.repository }}/actions/workflows/create-vsix.yml"
+          exit 1
       - run: npm ci
       - run: npx ts-node scripts/create-vsix.ts ${{ steps.info.outputs.branch }}
       # upload the production .vsix (archive: false only supports a single file, so

--- a/.github/workflows/create-vsix.yml
+++ b/.github/workflows/create-vsix.yml
@@ -73,7 +73,7 @@ jobs:
             console.log(`branch: "${branch}"`);
       # GitHub withholds repository secrets from fork-triggered runs, so fail fast with a clear message
       - name: Reject fork PRs
-        if: true || github.event.pull_request.head.repo.fork
+        if: github.event.pull_request.head.repo.fork
         run: |
           echo "::error::Could not build a .vsix because fork PRs can't access the required secrets. Ask a maintainer to dispatch it manually for PR #${{ github.event.pull_request.number }}: https://github.com/${{ github.repository }}/actions/workflows/create-vsix.yml"
           exit 1

--- a/.github/workflows/create-vsix.yml
+++ b/.github/workflows/create-vsix.yml
@@ -73,7 +73,7 @@ jobs:
             console.log(`branch: "${branch}"`);
       # GitHub withholds repository secrets from fork-triggered runs, so fail fast with a clear message
       - name: Reject fork PRs
-        if: github.event.pull_request.head.repo.fork
+        if: true || github.event.pull_request.head.repo.fork
         run: |
           echo "::error::Could not build a .vsix because forked PRs don't have access to the necessary github secrets. A maintainer must run this workflow manually: https://github.com/${{ github.repository }}/actions/workflows/create-vsix.yml"
           exit 1

--- a/.github/workflows/create-vsix.yml
+++ b/.github/workflows/create-vsix.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Reject fork PRs
         if: true || github.event.pull_request.head.repo.fork
         run: |
-          echo "::error::Could not build a .vsix because forked PRs don't have access to the necessary github secrets. A maintainer must run this workflow manually for ${{ github.event.pull_request.html_url }} here: https://github.com/${{ github.repository }}/actions/workflows/create-vsix.yml"
+          echo "::error::Fork PRs can't access the required secrets. A maintainer must build PR #${{ github.event.pull_request.number }} manually: https://github.com/${{ github.repository }}/actions/workflows/create-vsix.yml"
           exit 1
       - run: npm ci
       - run: npx ts-node scripts/create-vsix.ts ${{ steps.info.outputs.branch }}

--- a/.github/workflows/create-vsix.yml
+++ b/.github/workflows/create-vsix.yml
@@ -75,7 +75,7 @@ jobs:
       - name: Reject fork PRs
         if: true || github.event.pull_request.head.repo.fork
         run: |
-          echo "::error::Could not build a .vsix because forked PRs don't have access to the necessary github secrets. A maintainer must run this workflow manually: https://github.com/${{ github.repository }}/actions/workflows/create-vsix.yml"
+          echo "::error::Could not build a .vsix because forked PRs don't have access to the necessary github secrets. A maintainer must run this workflow manually for ${{ github.event.pull_request.html_url }} here: https://github.com/${{ github.repository }}/actions/workflows/create-vsix.yml"
           exit 1
       - run: npm ci
       - run: npx ts-node scripts/create-vsix.ts ${{ steps.info.outputs.branch }}


### PR DESCRIPTION
### Problem

Applying the `create-vsix` label to a PR opened from a fork starts the job, but GitHub withholds repository secrets from fork-triggered runs. The run then got most of the way through (including a full `npm ci` + build) before dying at the `tibdex/github-app-token` step with a cryptic:

```
Input required and not supplied: app_id
```

Nothing in that message says "this is a fork" or "here's what to do instead", so it reads like a broken workflow rather than an expected limitation.

### Change

Detect the fork up front and fail immediately with an actionable message:

```yaml
# GitHub withholds repository secrets from fork-triggered runs, so fail fast with a clear message
- name: Reject fork PRs
  if: github.event.pull_request.head.repo.fork
  run: |
    echo "::error::Could not build a .vsix because forked PRs don't have access to the necessary github secrets. A maintainer must run this workflow manually: https://github.com/${{ github.repository }}/actions/workflows/create-vsix.yml"
    exit 1
```

Notes:

- Uses `::error::` so the text surfaces as an annotation in the Actions UI, not just in the log.
- The link is built from `${{ github.repository }}`, so this step is copy-pasteable into the other rokucommunity repos unchanged — the only repo-specific token is the `create-vsix.yml` filename in the URL.
- On `workflow_dispatch` there's no `pull_request` payload, so the `if` is falsy and the step skips. That's the intended path for building a fork PR's .vsix, and it's the only path in the dispatch-only repos.
- Fails before `npm ci` and the build steps, so a fork PR now fails in seconds instead of after a full build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
