### PR TITLE
DeviceManager rewrite: order-based discovery

### DIFF
--- a/src/BrightScriptCommands.spec.ts
+++ b/src/BrightScriptCommands.spec.ts
@@ -150,6 +150,46 @@ describe('BrightScriptFileUtils ', () => {
         });
     });
 
+    describe('refreshDeviceList / rescanDevices', () => {
+        let capturedCommands: Record<string, (...args: any[]) => any>;
+        let deviceManager: any;
+
+        beforeEach(() => {
+            deviceManager = {
+                submitBroadcast: sinon.stub(),
+                submitReconcile: sinon.stub(),
+                broadcast: sinon.stub(),
+                reconcile: sinon.stub()
+            };
+            const localCommands = new BrightScriptCommands({} as any, {} as any, vscode.context, deviceManager, {} as any, {} as any, {} as any);
+            capturedCommands = {};
+            sinon.stub(vscode.commands as any, 'registerCommand').callsFake((name: any, cb: any) => {
+                capturedCommands[name] = cb;
+            });
+            localCommands.registerCommands();
+        });
+
+        afterEach(() => {
+            (vscode.commands.registerCommand as any).restore();
+        });
+
+        it('refreshDeviceList submits refresh-clicked orders instead of scanning directly', () => {
+            capturedCommands['extension.brightscript.refreshDeviceList']();
+            assert.isTrue(deviceManager.submitBroadcast.calledOnceWith('refresh-clicked'));
+            assert.isTrue(deviceManager.submitReconcile.calledOnceWith('refresh-clicked'));
+            assert.isTrue(deviceManager.broadcast.notCalled);
+            assert.isTrue(deviceManager.reconcile.notCalled);
+        });
+
+        it('rescanDevices submits refresh-clicked orders instead of scanning directly', () => {
+            capturedCommands['extension.brightscript.rescanDevices']();
+            assert.isTrue(deviceManager.submitBroadcast.calledOnceWith('refresh-clicked'));
+            assert.isTrue(deviceManager.submitReconcile.calledOnceWith('refresh-clicked'));
+            assert.isTrue(deviceManager.broadcast.notCalled);
+            assert.isTrue(deviceManager.reconcile.notCalled);
+        });
+    });
+
     describe('refreshDevice', () => {
         let capturedCommands: Record<string, (...args: any[]) => any>;
         let deviceManager: any;

--- a/src/BrightScriptCommands.spec.ts
+++ b/src/BrightScriptCommands.spec.ts
@@ -150,6 +150,46 @@ describe('BrightScriptFileUtils ', () => {
         });
     });
 
+    describe('refreshDevice', () => {
+        let capturedCommands: Record<string, (...args: any[]) => any>;
+        let deviceManager: any;
+
+        beforeEach(() => {
+            deviceManager = {
+                getDevice: sinon.stub(),
+                healthCheckDevice: sinon.stub().resolves(true)
+            };
+            const localCommands = new BrightScriptCommands({} as any, {} as any, vscode.context, deviceManager, {} as any, {} as any, {} as any);
+            capturedCommands = {};
+            sinon.stub(vscode.commands as any, 'registerCommand').callsFake((name: any, cb: any) => {
+                capturedCommands[name] = cb;
+            });
+            localCommands.registerCommands();
+        });
+
+        afterEach(() => {
+            (vscode.commands.registerCommand as any).restore();
+        });
+
+        it('decodes the encoded tree key via getDevice before health checking', async () => {
+            const device = { ip: '192.168.1.100', serialNumber: 'ABC123', key: 's:ABC123' };
+            deviceManager.getDevice.returns(device);
+
+            await capturedCommands['extension.brightscript.refreshDevice']({ key: 's:ABC123' });
+
+            assert.isTrue(deviceManager.getDevice.calledOnceWith('s:ABC123'));
+            assert.isTrue(deviceManager.healthCheckDevice.calledOnceWith(device, true));
+        });
+
+        it('does nothing when the key does not resolve to a device', async () => {
+            deviceManager.getDevice.returns(undefined);
+
+            await capturedCommands['extension.brightscript.refreshDevice']({ key: 's:GONE' });
+
+            assert.isTrue(deviceManager.healthCheckDevice.notCalled);
+        });
+    });
+
     describe('clearDefaultDevicePassword', () => {
         let localCommands: BrightScriptCommands;
         let capturedCommands: Record<string, (...args: any[]) => any>;

--- a/src/BrightScriptCommands.spec.ts
+++ b/src/BrightScriptCommands.spec.ts
@@ -193,7 +193,7 @@ describe('BrightScriptFileUtils ', () => {
 
         beforeEach(() => {
             deviceManager = {
-                deviceEngaged: sinon.stub().resolves(true)
+                healthCheckDevice: sinon.stub().resolves(true)
             };
             const localCommands = new BrightScriptCommands({} as any, {} as any, vscode.context, deviceManager, {} as any, {} as any, {} as any);
             capturedCommands = {};
@@ -210,7 +210,7 @@ describe('BrightScriptFileUtils ', () => {
         it('engages the device by its encoded tree key (the manager resolves the key)', async () => {
             await capturedCommands['extension.brightscript.refreshDevice']({ key: 's:ABC123' });
 
-            assert.isTrue(deviceManager.deviceEngaged.calledOnceWith('s:ABC123'));
+            assert.isTrue(deviceManager.healthCheckDevice.calledOnceWith('s:ABC123'));
         });
     });
 
@@ -516,8 +516,7 @@ describe('BrightScriptFileUtils ', () => {
         beforeEach(() => {
             sandbox = sinon.createSandbox();
             deviceManager = {
-                deviceEngaged: sandbox.stub().resolves(true),
-                getDevice: sandbox.stub().returns({ ip: '1.2.3.4', deviceInfo: { 'serial-number': 'SN123' } })
+                getDeviceInfo: sandbox.stub().resolves({ 'serial-number': 'SN123' })
             };
             localCommands = new BrightScriptCommands({} as any, {} as any, vscode.context, deviceManager, {} as any, {} as any, {} as any);
             sandbox.stub(vscodeContextManager, 'get').returns('1.2.3.4');
@@ -527,9 +526,10 @@ describe('BrightScriptFileUtils ', () => {
             sandbox.restore();
         });
 
-        it('returns the host with its device info when the active host is healthy', async () => {
+        it('returns the host with its freshly-fetched device info when the active host is reachable', async () => {
             const result = await localCommands.getHealthyActiveHost();
             assert.deepEqual(result, { host: '1.2.3.4', deviceInfo: { 'serial-number': 'SN123' } });
+            assert.isTrue(deviceManager.getDeviceInfo.calledOnceWith({ ip: '1.2.3.4' }));
         });
 
         it('returns undefined when no active host is set', async () => {
@@ -538,14 +538,8 @@ describe('BrightScriptFileUtils ', () => {
             assert.isUndefined(result);
         });
 
-        it('returns undefined when the active host fails the health check', async () => {
-            deviceManager.deviceEngaged.resolves(false);
-            const result = await localCommands.getHealthyActiveHost();
-            assert.isUndefined(result);
-        });
-
-        it('returns undefined when no device info could be read back', async () => {
-            deviceManager.getDevice.returns(undefined);
+        it('returns undefined when the active host is unreachable or unknown', async () => {
+            deviceManager.getDeviceInfo.resolves(undefined);
             const result = await localCommands.getHealthyActiveHost();
             assert.isUndefined(result);
         });

--- a/src/BrightScriptCommands.spec.ts
+++ b/src/BrightScriptCommands.spec.ts
@@ -156,7 +156,7 @@ describe('BrightScriptFileUtils ', () => {
 
         beforeEach(() => {
             deviceManager = {
-                submitRefreshOrders: sinon.stub(),
+                submitOrder: sinon.stub(),
                 broadcast: sinon.stub(),
                 reconcile: sinon.stub()
             };
@@ -174,14 +174,14 @@ describe('BrightScriptFileUtils ', () => {
 
         it('refreshDeviceList submits refresh orders instead of scanning directly', () => {
             capturedCommands['extension.brightscript.refreshDeviceList']();
-            assert.isTrue(deviceManager.submitRefreshOrders.calledOnce);
+            assert.isTrue(deviceManager.submitOrder.calledOnceWith('refresh-clicked'));
             assert.isTrue(deviceManager.broadcast.notCalled);
             assert.isTrue(deviceManager.reconcile.notCalled);
         });
 
         it('rescanDevices submits refresh orders instead of scanning directly', () => {
             capturedCommands['extension.brightscript.rescanDevices']();
-            assert.isTrue(deviceManager.submitRefreshOrders.calledOnce);
+            assert.isTrue(deviceManager.submitOrder.calledOnceWith('refresh-clicked'));
             assert.isTrue(deviceManager.broadcast.notCalled);
             assert.isTrue(deviceManager.reconcile.notCalled);
         });

--- a/src/BrightScriptCommands.spec.ts
+++ b/src/BrightScriptCommands.spec.ts
@@ -193,7 +193,6 @@ describe('BrightScriptFileUtils ', () => {
 
         beforeEach(() => {
             deviceManager = {
-                getDevice: sinon.stub(),
                 deviceEngaged: sinon.stub().resolves(true)
             };
             const localCommands = new BrightScriptCommands({} as any, {} as any, vscode.context, deviceManager, {} as any, {} as any, {} as any);
@@ -208,22 +207,10 @@ describe('BrightScriptFileUtils ', () => {
             (vscode.commands.registerCommand as any).restore();
         });
 
-        it('decodes the encoded tree key via getDevice before engaging the device', async () => {
-            const device = { ip: '192.168.1.100', serialNumber: 'ABC123', key: 's:ABC123' };
-            deviceManager.getDevice.returns(device);
-
+        it('engages the device by its encoded tree key (the manager resolves the key)', async () => {
             await capturedCommands['extension.brightscript.refreshDevice']({ key: 's:ABC123' });
 
-            assert.isTrue(deviceManager.getDevice.calledOnceWith('s:ABC123'));
-            assert.isTrue(deviceManager.deviceEngaged.calledOnceWith(device));
-        });
-
-        it('does nothing when the key does not resolve to a device', async () => {
-            deviceManager.getDevice.returns(undefined);
-
-            await capturedCommands['extension.brightscript.refreshDevice']({ key: 's:GONE' });
-
-            assert.isTrue(deviceManager.deviceEngaged.notCalled);
+            assert.isTrue(deviceManager.deviceEngaged.calledOnceWith('s:ABC123'));
         });
     });
 

--- a/src/BrightScriptCommands.spec.ts
+++ b/src/BrightScriptCommands.spec.ts
@@ -516,7 +516,8 @@ describe('BrightScriptFileUtils ', () => {
         beforeEach(() => {
             sandbox = sinon.createSandbox();
             deviceManager = {
-                getDeviceInfo: sandbox.stub().resolves({ 'serial-number': 'SN123' })
+                healthCheckDevice: sandbox.stub().resolves(true),
+                getDevice: sandbox.stub().returns({ ip: '1.2.3.4', deviceInfo: { 'serial-number': 'SN123' } })
             };
             localCommands = new BrightScriptCommands({} as any, {} as any, vscode.context, deviceManager, {} as any, {} as any, {} as any);
             sandbox.stub(vscodeContextManager, 'get').returns('1.2.3.4');
@@ -526,10 +527,10 @@ describe('BrightScriptFileUtils ', () => {
             sandbox.restore();
         });
 
-        it('returns the host with its freshly-fetched device info when the active host is reachable', async () => {
+        it('returns the host with its device info when the active host is healthy', async () => {
             const result = await localCommands.getHealthyActiveHost();
             assert.deepEqual(result, { host: '1.2.3.4', deviceInfo: { 'serial-number': 'SN123' } });
-            assert.isTrue(deviceManager.getDeviceInfo.calledOnceWith({ ip: '1.2.3.4' }));
+            assert.isTrue(deviceManager.healthCheckDevice.calledOnceWith({ ip: '1.2.3.4' }));
         });
 
         it('returns undefined when no active host is set', async () => {
@@ -538,8 +539,14 @@ describe('BrightScriptFileUtils ', () => {
             assert.isUndefined(result);
         });
 
-        it('returns undefined when the active host is unreachable or unknown', async () => {
-            deviceManager.getDeviceInfo.resolves(undefined);
+        it('returns undefined when the active host fails the health check', async () => {
+            deviceManager.healthCheckDevice.resolves(false);
+            const result = await localCommands.getHealthyActiveHost();
+            assert.isUndefined(result);
+        });
+
+        it('returns undefined when no device info could be read back', async () => {
+            deviceManager.getDevice.returns(undefined);
             const result = await localCommands.getHealthyActiveHost();
             assert.isUndefined(result);
         });

--- a/src/BrightScriptCommands.spec.ts
+++ b/src/BrightScriptCommands.spec.ts
@@ -156,7 +156,7 @@ describe('BrightScriptFileUtils ', () => {
 
         beforeEach(() => {
             deviceManager = {
-                submitOrder: sinon.stub(),
+                submitOrders: sinon.stub(),
                 broadcast: sinon.stub(),
                 reconcile: sinon.stub()
             };
@@ -174,14 +174,14 @@ describe('BrightScriptFileUtils ', () => {
 
         it('refreshDeviceList submits refresh orders instead of scanning directly', () => {
             capturedCommands['extension.brightscript.refreshDeviceList']();
-            assert.isTrue(deviceManager.submitOrder.calledOnceWith('refresh-clicked'));
+            assert.isTrue(deviceManager.submitOrders.calledOnceWith([{ type: 'broadcast', reason: 'refresh-clicked' }, { type: 'reconcile', reason: 'refresh-clicked' }]));
             assert.isTrue(deviceManager.broadcast.notCalled);
             assert.isTrue(deviceManager.reconcile.notCalled);
         });
 
         it('rescanDevices submits refresh orders instead of scanning directly', () => {
             capturedCommands['extension.brightscript.rescanDevices']();
-            assert.isTrue(deviceManager.submitOrder.calledOnceWith('refresh-clicked'));
+            assert.isTrue(deviceManager.submitOrders.calledOnceWith([{ type: 'broadcast', reason: 'refresh-clicked' }, { type: 'reconcile', reason: 'refresh-clicked' }]));
             assert.isTrue(deviceManager.broadcast.notCalled);
             assert.isTrue(deviceManager.reconcile.notCalled);
         });

--- a/src/BrightScriptCommands.spec.ts
+++ b/src/BrightScriptCommands.spec.ts
@@ -156,8 +156,7 @@ describe('BrightScriptFileUtils ', () => {
 
         beforeEach(() => {
             deviceManager = {
-                submitBroadcast: sinon.stub(),
-                submitReconcile: sinon.stub(),
+                submitRefreshOrders: sinon.stub(),
                 broadcast: sinon.stub(),
                 reconcile: sinon.stub()
             };
@@ -173,18 +172,16 @@ describe('BrightScriptFileUtils ', () => {
             (vscode.commands.registerCommand as any).restore();
         });
 
-        it('refreshDeviceList submits refresh-clicked orders instead of scanning directly', () => {
+        it('refreshDeviceList submits refresh orders instead of scanning directly', () => {
             capturedCommands['extension.brightscript.refreshDeviceList']();
-            assert.isTrue(deviceManager.submitBroadcast.calledOnceWith('refresh-clicked'));
-            assert.isTrue(deviceManager.submitReconcile.calledOnceWith('refresh-clicked'));
+            assert.isTrue(deviceManager.submitRefreshOrders.calledOnce);
             assert.isTrue(deviceManager.broadcast.notCalled);
             assert.isTrue(deviceManager.reconcile.notCalled);
         });
 
-        it('rescanDevices submits refresh-clicked orders instead of scanning directly', () => {
+        it('rescanDevices submits refresh orders instead of scanning directly', () => {
             capturedCommands['extension.brightscript.rescanDevices']();
-            assert.isTrue(deviceManager.submitBroadcast.calledOnceWith('refresh-clicked'));
-            assert.isTrue(deviceManager.submitReconcile.calledOnceWith('refresh-clicked'));
+            assert.isTrue(deviceManager.submitRefreshOrders.calledOnce);
             assert.isTrue(deviceManager.broadcast.notCalled);
             assert.isTrue(deviceManager.reconcile.notCalled);
         });
@@ -197,7 +194,7 @@ describe('BrightScriptFileUtils ', () => {
         beforeEach(() => {
             deviceManager = {
                 getDevice: sinon.stub(),
-                healthCheckDevice: sinon.stub().resolves(true)
+                deviceEngaged: sinon.stub().resolves(true)
             };
             const localCommands = new BrightScriptCommands({} as any, {} as any, vscode.context, deviceManager, {} as any, {} as any, {} as any);
             capturedCommands = {};
@@ -211,14 +208,14 @@ describe('BrightScriptFileUtils ', () => {
             (vscode.commands.registerCommand as any).restore();
         });
 
-        it('decodes the encoded tree key via getDevice before health checking', async () => {
+        it('decodes the encoded tree key via getDevice before engaging the device', async () => {
             const device = { ip: '192.168.1.100', serialNumber: 'ABC123', key: 's:ABC123' };
             deviceManager.getDevice.returns(device);
 
             await capturedCommands['extension.brightscript.refreshDevice']({ key: 's:ABC123' });
 
             assert.isTrue(deviceManager.getDevice.calledOnceWith('s:ABC123'));
-            assert.isTrue(deviceManager.healthCheckDevice.calledOnceWith(device, true));
+            assert.isTrue(deviceManager.deviceEngaged.calledOnceWith(device));
         });
 
         it('does nothing when the key does not resolve to a device', async () => {
@@ -226,7 +223,7 @@ describe('BrightScriptFileUtils ', () => {
 
             await capturedCommands['extension.brightscript.refreshDevice']({ key: 's:GONE' });
 
-            assert.isTrue(deviceManager.healthCheckDevice.notCalled);
+            assert.isTrue(deviceManager.deviceEngaged.notCalled);
         });
     });
 
@@ -532,7 +529,7 @@ describe('BrightScriptFileUtils ', () => {
         beforeEach(() => {
             sandbox = sinon.createSandbox();
             deviceManager = {
-                healthCheckDevice: sandbox.stub().resolves(true),
+                deviceEngaged: sandbox.stub().resolves(true),
                 getDevice: sandbox.stub().returns({ ip: '1.2.3.4', deviceInfo: { 'serial-number': 'SN123' } })
             };
             localCommands = new BrightScriptCommands({} as any, {} as any, vscode.context, deviceManager, {} as any, {} as any, {} as any);
@@ -555,7 +552,7 @@ describe('BrightScriptFileUtils ', () => {
         });
 
         it('returns undefined when the active host fails the health check', async () => {
-            deviceManager.healthCheckDevice.resolves(false);
+            deviceManager.deviceEngaged.resolves(false);
             const result = await localCommands.getHealthyActiveHost();
             assert.isUndefined(result);
         });

--- a/src/BrightScriptCommands.ts
+++ b/src/BrightScriptCommands.ts
@@ -72,7 +72,7 @@ export class BrightScriptCommands {
         // Refresh a single device (inline button on hover in devices panel).
         // item.key is the encoded tree key ("s:{serial}" or "i:{ip}")
         this.registerCommand('refreshDevice', async (item: { key: string }) => {
-            await this.deviceManager.deviceEngaged(item.key);
+            await this.deviceManager.healthCheckDevice(item.key);
         });
 
         this.registerCommand('sendRemoteText', async () => {
@@ -1087,21 +1087,17 @@ export class BrightScriptCommands {
     }
 
     /**
-     * Return the active host (paired with its raw device-info) if one is set and passes a health
-     * check; otherwise undefined. The health check refreshes the device in the device manager, so
-     * the device-info is read back from there without an extra request.
+     * Return the active host (paired with its raw device-info) if one is set and reachable;
+     * otherwise undefined. getDeviceInfo fetches fresh info and updates the device manager's
+     * cache along the way, so every view renders the same data this launch will use.
      */
     public async getHealthyActiveHost(): Promise<HostWithDeviceInfo | undefined> {
         const activeHost = vscodeContextManager.get<string>('activeHost');
         if (!activeHost) {
             return undefined;
         }
-        const isHealthy = await this.deviceManager.deviceEngaged({ ip: activeHost });
-        if (!isHealthy) {
-            return undefined;
-        }
-        const deviceInfo = this.deviceManager.getDevice({ ip: activeHost })?.deviceInfo;
-        //deviceInfo is required on HostWithDeviceInfo, so if we couldn't read it back, report no healthy active host
+        const deviceInfo = await this.deviceManager.getDeviceInfo({ ip: activeHost });
+        //deviceInfo is required on HostWithDeviceInfo — unreachable or unknown devices report no healthy active host
         if (!deviceInfo) {
             return undefined;
         }

--- a/src/BrightScriptCommands.ts
+++ b/src/BrightScriptCommands.ts
@@ -62,11 +62,11 @@ export class BrightScriptCommands {
         //(spec: "Clicking refresh... always submits a broadcast order and a reconcile order") —
         //a visible view fulfills them immediately
         this.registerCommand('refreshDeviceList', (key: string) => {
-            this.deviceManager.submitOrder('refresh-clicked');
+            this.deviceManager.submitOrders([{ type: 'broadcast', reason: 'refresh-clicked' }, { type: 'reconcile', reason: 'refresh-clicked' }]);
         });
 
         this.registerCommand('rescanDevices', () => {
-            this.deviceManager.submitOrder('refresh-clicked');
+            this.deviceManager.submitOrders([{ type: 'broadcast', reason: 'refresh-clicked' }, { type: 'reconcile', reason: 'refresh-clicked' }]);
         });
 
         // Refresh a single device (inline button on hover in devices panel).

--- a/src/BrightScriptCommands.ts
+++ b/src/BrightScriptCommands.ts
@@ -70,12 +70,9 @@ export class BrightScriptCommands {
         });
 
         // Refresh a single device (inline button on hover in devices panel).
-        // item.key is the encoded tree key ("s:{serial}" or "i:{ip}") — decode it via getDevice
+        // item.key is the encoded tree key ("s:{serial}" or "i:{ip}")
         this.registerCommand('refreshDevice', async (item: { key: string }) => {
-            const device = this.deviceManager.getDevice(item.key);
-            if (device) {
-                await this.deviceManager.deviceEngaged(device);
-            }
+            await this.deviceManager.deviceEngaged(item.key);
         });
 
         this.registerCommand('sendRemoteText', async () => {

--- a/src/BrightScriptCommands.ts
+++ b/src/BrightScriptCommands.ts
@@ -67,9 +67,13 @@ export class BrightScriptCommands {
             this.deviceManager.refresh(true);
         });
 
-        // Refresh a single device (inline button on hover in devices panel)
+        // Refresh a single device (inline button on hover in devices panel).
+        // item.key is the encoded tree key ("s:{serial}" or "i:{ip}") — decode it via getDevice
         this.registerCommand('refreshDevice', async (item: { key: string }) => {
-            await this.deviceManager.healthCheckDevice({ serialNumber: item.key }, true);
+            const device = this.deviceManager.getDevice(item.key);
+            if (device) {
+                await this.deviceManager.healthCheckDevice(device, true);
+            }
         });
 
         this.registerCommand('sendRemoteText', async () => {

--- a/src/BrightScriptCommands.ts
+++ b/src/BrightScriptCommands.ts
@@ -1093,17 +1093,21 @@ export class BrightScriptCommands {
     }
 
     /**
-     * Return the active host (paired with its raw device-info) if one is set and reachable;
-     * otherwise undefined. getDeviceInfo fetches fresh info and updates the device manager's
-     * cache along the way, so every view renders the same data this launch will use.
+     * Return the active host (paired with its raw device-info) if one is set and passes a
+     * health check; otherwise undefined. The health check refreshes the device in the device
+     * manager, so the device-info is read back from there without an extra request.
      */
     public async getHealthyActiveHost(): Promise<HostWithDeviceInfo | undefined> {
         const activeHost = vscodeContextManager.get<string>('activeHost');
         if (!activeHost) {
             return undefined;
         }
-        const deviceInfo = await this.deviceManager.getDeviceInfo({ ip: activeHost });
-        //deviceInfo is required on HostWithDeviceInfo — unreachable or unknown devices report no healthy active host
+        const isHealthy = await this.deviceManager.healthCheckDevice({ ip: activeHost });
+        if (!isHealthy) {
+            return undefined;
+        }
+        const deviceInfo = this.deviceManager.getDevice({ ip: activeHost })?.deviceInfo;
+        //deviceInfo is required on HostWithDeviceInfo, so if we couldn't read it back, report no healthy active host
         if (!deviceInfo) {
             return undefined;
         }

--- a/src/BrightScriptCommands.ts
+++ b/src/BrightScriptCommands.ts
@@ -62,11 +62,11 @@ export class BrightScriptCommands {
         //(spec: "Clicking refresh... always submits a broadcast order and a reconcile order") —
         //a visible view fulfills them immediately
         this.registerCommand('refreshDeviceList', (key: string) => {
-            this.deviceManager.submitRefreshOrders();
+            this.deviceManager.submitOrder('refresh-clicked');
         });
 
         this.registerCommand('rescanDevices', () => {
-            this.deviceManager.submitRefreshOrders();
+            this.deviceManager.submitOrder('refresh-clicked');
         });
 
         // Refresh a single device (inline button on hover in devices panel).

--- a/src/BrightScriptCommands.ts
+++ b/src/BrightScriptCommands.ts
@@ -62,11 +62,17 @@ export class BrightScriptCommands {
         //(spec: "Clicking refresh... always submits a broadcast order and a reconcile order") —
         //a visible view fulfills them immediately
         this.registerCommand('refreshDeviceList', (key: string) => {
-            this.deviceManager.submitOrders([{ type: 'broadcast', reason: 'refresh-clicked' }, { type: 'reconcile', reason: 'refresh-clicked' }]);
+            this.deviceManager.submitOrders([
+                { type: 'broadcast', reason: 'refresh-clicked' },
+                { type: 'reconcile', reason: 'refresh-clicked' }
+            ]);
         });
 
         this.registerCommand('rescanDevices', () => {
-            this.deviceManager.submitOrders([{ type: 'broadcast', reason: 'refresh-clicked' }, { type: 'reconcile', reason: 'refresh-clicked' }]);
+            this.deviceManager.submitOrders([
+                { type: 'broadcast', reason: 'refresh-clicked' },
+                { type: 'reconcile', reason: 'refresh-clicked' }
+            ]);
         });
 
         // Refresh a single device (inline button on hover in devices panel).

--- a/src/BrightScriptCommands.ts
+++ b/src/BrightScriptCommands.ts
@@ -60,15 +60,13 @@ export class BrightScriptCommands {
 
         //the "Refresh" button in the Devices list. Submits orders rather than scanning directly
         //(spec: "Clicking refresh... always submits a broadcast order and a reconcile order") —
-        //a visible view fulfills them immediately, forced since the reason is refresh-clicked
+        //a visible view fulfills them immediately
         this.registerCommand('refreshDeviceList', (key: string) => {
-            this.deviceManager.submitBroadcast('refresh-clicked');
-            this.deviceManager.submitReconcile('refresh-clicked');
+            this.deviceManager.submitRefreshOrders();
         });
 
         this.registerCommand('rescanDevices', () => {
-            this.deviceManager.submitBroadcast('refresh-clicked');
-            this.deviceManager.submitReconcile('refresh-clicked');
+            this.deviceManager.submitRefreshOrders();
         });
 
         // Refresh a single device (inline button on hover in devices panel).
@@ -76,7 +74,7 @@ export class BrightScriptCommands {
         this.registerCommand('refreshDevice', async (item: { key: string }) => {
             const device = this.deviceManager.getDevice(item.key);
             if (device) {
-                await this.deviceManager.healthCheckDevice(device, true);
+                await this.deviceManager.deviceEngaged(device);
             }
         });
 
@@ -1101,7 +1099,7 @@ export class BrightScriptCommands {
         if (!activeHost) {
             return undefined;
         }
-        const isHealthy = await this.deviceManager.healthCheckDevice({ ip: activeHost }, true, false);
+        const isHealthy = await this.deviceManager.deviceEngaged({ ip: activeHost });
         if (!isHealthy) {
             return undefined;
         }

--- a/src/BrightScriptCommands.ts
+++ b/src/BrightScriptCommands.ts
@@ -58,13 +58,17 @@ export class BrightScriptCommands {
             await this.sendRemoteCommand(key);
         });
 
-        //the "Refresh" button in the Devices list
+        //the "Refresh" button in the Devices list. Submits orders rather than scanning directly
+        //(spec: "Clicking refresh... always submits a broadcast order and a reconcile order") —
+        //a visible view fulfills them immediately, forced since the reason is refresh-clicked
         this.registerCommand('refreshDeviceList', (key: string) => {
-            this.deviceManager.refresh(true);
+            this.deviceManager.submitBroadcast('refresh-clicked');
+            this.deviceManager.submitReconcile('refresh-clicked');
         });
 
         this.registerCommand('rescanDevices', () => {
-            this.deviceManager.refresh(true);
+            this.deviceManager.submitBroadcast('refresh-clicked');
+            this.deviceManager.submitReconcile('refresh-clicked');
         });
 
         // Refresh a single device (inline button on hover in devices panel).
@@ -347,7 +351,7 @@ export class BrightScriptCommands {
 
         this.registerCommand('clearCurrentDeviceList', async () => {
             const toatsPromise = util.showTimedNotification('Clearing device list');
-            await this.deviceManager.clearCurrentDeviceList();
+            this.deviceManager.clearCurrentDeviceList();
             await toatsPromise;
         });
 

--- a/src/BrightScriptCommands.ts
+++ b/src/BrightScriptCommands.ts
@@ -58,9 +58,7 @@ export class BrightScriptCommands {
             await this.sendRemoteCommand(key);
         });
 
-        //the "Refresh" button in the Devices list. Submits orders rather than scanning directly
-        //(spec: "Clicking refresh... always submits a broadcast order and a reconcile order") —
-        //a visible view fulfills them immediately
+        //the "Refresh" button in the Devices list
         this.registerCommand('refreshDeviceList', (key: string) => {
             this.deviceManager.submitOrders([
                 { type: 'broadcast', reason: 'refresh-clicked' },
@@ -75,8 +73,7 @@ export class BrightScriptCommands {
             ]);
         });
 
-        // Refresh a single device (inline button on hover in devices panel).
-        // item.key is the encoded tree key ("s:{serial}" or "i:{ip}")
+        //refresh a single device (inline button on hover in devices panel)
         this.registerCommand('refreshDevice', async (item: { key: string }) => {
             await this.deviceManager.healthCheckDevice(item.key);
         });

--- a/src/deviceDiscovery/DeviceManager.spec.ts
+++ b/src/deviceDiscovery/DeviceManager.spec.ts
@@ -1780,9 +1780,9 @@ describe('DeviceManager', () => {
             expect(showTimedStub.calledTwice).to.be.true;
         });
 
-        //NOTE: ssdp:alive deliberately does NOT trigger eager health checks — lazy hydration
+        //NOTE: ssdp:alive deliberately does NOT trigger eager health checks — the background refresh
         //on read covers uncached devices when a view actually asks for the list (spec:
-        //"Passive SSDP announcements" / "Lazy hydration on read")
+        //"Passive SSDP announcements" / "Lazy hydration on read" in the design doc)
     });
 
     describe('notifyFocusGained', () => {
@@ -1800,20 +1800,20 @@ describe('DeviceManager', () => {
         });
     });
 
-    describe('scan responder hydration (spec: "responds to an M-SEARCH — hydrate it immediately", via read)', () => {
+    describe('scan responders refresh via the read path (spec: "responds to an M-SEARCH — hydrate it immediately")', () => {
         function flush(): Promise<void> {
             return new Promise(resolve => {
                 setTimeout(resolve, 5);
             });
         }
 
-        it('an unknown responder with cache in the 5min–8h dead zone hydrates on the next read', async () => {
+        it('an unknown responder with cache in the 5min–8h dead zone is refreshed on the next read', async () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
             const rokuDeployStub = sinon.stub(rokuDeploy, 'getDeviceInfo').resolves({ 'serial-number': 'SCAN70' } as any);
             sinon.stub(manager as any, 'randomDelay').resolves();
 
             //cache aged past the 5-min freshness check (so the responder lands `unknown`) but
-            //younger than the 8-hour hydration threshold — the exact gap that used to strand
+            //younger than the 8-hour read trust window — the exact gap that used to strand
             //the device grey forever
             mockGlobalStateManager.setCachedDevice('SCAN70', {
                 serialNumber: 'SCAN70',
@@ -1830,7 +1830,7 @@ describe('DeviceManager', () => {
             expect(manager.getDevice({ ip: '192.168.1.70' }).deviceState).to.equal('online');
         });
 
-        it('repeated M-SEARCH answers do not double-hydrate (freshness guard)', async () => {
+        it('repeated M-SEARCH answers do not double-fetch (freshness guard)', async () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
             const rokuDeployStub = sinon.stub(rokuDeploy, 'getDeviceInfo').resolves({ 'serial-number': 'SCAN70' } as any);
             sinon.stub(manager as any, 'randomDelay').resolves();
@@ -1846,14 +1846,14 @@ describe('DeviceManager', () => {
         });
     });
 
-    describe('lazy hydration on read', () => {
+    describe('background refresh on read', () => {
         function flush(): Promise<void> {
             return new Promise(resolve => {
                 setTimeout(resolve, 5);
             });
         }
 
-        it('queues a background resolve for an unknown device with no cached deviceInfo', async () => {
+        it('starts a background refresh for an unknown device with no cached deviceInfo', async () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
             const resolveStub = sinon.stub(manager as any, 'ensureDeviceFresh').returns(Promise.resolve(true) as any);
 
@@ -1867,7 +1867,7 @@ describe('DeviceManager', () => {
             expect(resolveStub.calledOnce).to.be.true;
             expect(resolveStub.firstCall.args[0]).to.include({ ip: '192.168.1.50', serialNumber: 'no-cache-1' });
             //silent background refresh: no synthetic delay, cache trusted
-            expect(resolveStub.firstCall.args[1]).to.eql({ maxAgeMs: manager['HYDRATION_MAX_CACHE_AGE_MS'], syntheticDelay: false });
+            expect(resolveStub.firstCall.args[1]).to.eql({ maxAgeMs: manager['ON_READ_TRUST_MS'], syntheticDelay: false });
         });
 
         it('does not fetch for a device whose knowledge is fresh', async () => {
@@ -1884,13 +1884,13 @@ describe('DeviceManager', () => {
             expect(rokuDeployStub.called).to.be.false;
         });
 
-        it('hydrates a device whose cache is older than 8 hours, regardless of state', async () => {
+        it('refreshes a device whose knowledge is older than the read trust window, regardless of state', async () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
             const resolveStub = sinon.stub(manager as any, 'ensureDeviceFresh').returns(Promise.resolve(true) as any);
 
             const device = createMockDevice({ serialNumber: 'old-1', ip: '192.168.1.52', deviceInfo: { 'default-device-name': 'Roku Express' } });
             addDevice(device);
-            //age the cache past the 8h hydration threshold
+            //age the cache past the read trust window
             mockGlobalStateManager.setCachedDevice('old-1', {
                 serialNumber: 'old-1',
                 deviceInfo: { 'serial-number': 'old-1' },
@@ -1936,7 +1936,7 @@ describe('DeviceManager', () => {
             expect(rokuDeployStub.calledOnce).to.be.true;
         });
 
-        it('getDevice (single lookup) also triggers hydration', async () => {
+        it('getDevice (single lookup) also triggers the background refresh', async () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
             const resolveStub = sinon.stub(manager as any, 'ensureDeviceFresh').returns(Promise.resolve(true) as any);
 

--- a/src/deviceDiscovery/DeviceManager.spec.ts
+++ b/src/deviceDiscovery/DeviceManager.spec.ts
@@ -167,11 +167,11 @@ describe('DeviceManager', () => {
     });
 
     describe('orders (submit + pending sets)', () => {
-        it('a broadcast order lands in the pending set and emits broadcast-ordered with the reason', () => {
+        it('a broadcast order lands in the pending set and emits order-submitted with type + reason', () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
             const eventSpy = sinon.spy();
-            manager.on('broadcast-ordered', eventSpy);
+            manager.on('order-submitted', eventSpy);
 
             manager.submitOrders([{ type: 'broadcast', reason: 'network' }]);
 
@@ -180,11 +180,11 @@ describe('DeviceManager', () => {
             expect(manager.getPendingBroadcastReasons()).to.include('network');
         });
 
-        it('a reconcile order lands in the pending set and emits reconcile-ordered with the reason', () => {
+        it('a reconcile order lands in the pending set and emits order-submitted with type + reason', () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
             const eventSpy = sinon.spy();
-            manager.on('reconcile-ordered', eventSpy);
+            manager.on('order-submitted', eventSpy);
 
             manager.submitOrders([{ type: 'reconcile', reason: 'config-changed' }]);
 
@@ -251,7 +251,7 @@ describe('DeviceManager', () => {
         });
     });
 
-    describe('fulfillPendingBroadcast / fulfillPendingReconcile', () => {
+    describe('fulfillOrders', () => {
         beforeEach(() => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
         });
@@ -260,7 +260,7 @@ describe('DeviceManager', () => {
             const broadcastStub = sinon.stub(manager as any, 'broadcast').returns(true);
             manager.submitOrders([{ type: 'broadcast', reason: 'network' }]);
 
-            const result = manager.fulfillPendingBroadcast();
+            const result = manager.fulfillOrders({ types: ['broadcast'] }).scanStarted;
 
             expect(result).to.be.true;
             expect(broadcastStub.calledOnceWith(['network'])).to.be.true;
@@ -272,7 +272,7 @@ describe('DeviceManager', () => {
             manager.submitOrders([{ type: 'broadcast', reason: 'sleep' }]);
             manager.submitOrders([{ type: 'broadcast', reason: 'network' }]);
 
-            const result = manager.fulfillPendingBroadcast();
+            const result = manager.fulfillOrders({ types: ['broadcast'] }).scanStarted;
 
             expect(result).to.be.true;
             expect(broadcastStub.calledOnce).to.be.true;
@@ -284,7 +284,7 @@ describe('DeviceManager', () => {
             const broadcastStub = sinon.stub(manager as any, 'broadcast').returns(false);
             manager.submitOrders([{ type: 'broadcast', reason: 'stale' }]);
 
-            manager.fulfillPendingBroadcast();
+            manager.fulfillOrders({ types: ['broadcast'] });
 
             expect(broadcastStub.calledOnceWith(['stale'])).to.be.true;
         });
@@ -293,7 +293,7 @@ describe('DeviceManager', () => {
             const broadcastStub = sinon.stub(manager as any, 'broadcast').returns(true);
             manager.submitOrders([{ type: 'broadcast', reason: 'stale' }]);
 
-            const result = manager.fulfillPendingBroadcast({ except: ['stale'] });
+            const result = manager.fulfillOrders({ types: ['broadcast'], except: ['stale'] }).scanStarted;
 
             expect(result).to.be.false;
             expect(broadcastStub.called).to.be.false;
@@ -305,7 +305,7 @@ describe('DeviceManager', () => {
             manager.submitOrders([{ type: 'broadcast', reason: 'stale' }]);
             manager.submitOrders([{ type: 'broadcast', reason: 'network' }]);
 
-            const result = manager.fulfillPendingBroadcast({ except: ['stale'] });
+            const result = manager.fulfillOrders({ types: ['broadcast'], except: ['stale'] }).scanStarted;
 
             //the scan satisfies the stale want too, so it rides along instead of staying queued
             expect(result).to.be.true;
@@ -317,7 +317,7 @@ describe('DeviceManager', () => {
         it('returns false and does nothing when no order is pending', () => {
             const broadcastStub = sinon.stub(manager as any, 'broadcast').returns(true);
 
-            expect(manager.fulfillPendingBroadcast()).to.be.false;
+            expect(manager.fulfillOrders({ types: ['broadcast'] }).scanStarted).to.be.false;
             expect(broadcastStub.called).to.be.false;
         });
 
@@ -325,8 +325,8 @@ describe('DeviceManager', () => {
             const broadcastStub = sinon.stub(manager as any, 'broadcast').returns(true);
             manager.submitOrders([{ type: 'broadcast', reason: 'network' }]);
 
-            expect(manager.fulfillPendingBroadcast()).to.be.true;
-            expect(manager.fulfillPendingBroadcast()).to.be.false;
+            expect(manager.fulfillOrders({ types: ['broadcast'] }).scanStarted).to.be.true;
+            expect(manager.fulfillOrders({ types: ['broadcast'] }).scanStarted).to.be.false;
             expect(broadcastStub.calledOnce).to.be.true;
         });
 
@@ -334,12 +334,12 @@ describe('DeviceManager', () => {
             const reconcileStub = sinon.stub(manager as any, 'reconcile');
 
             manager.submitOrders([{ type: 'reconcile', reason: 'config-changed' }]);
-            expect(manager.fulfillPendingReconcile()).to.be.true;
+            expect(manager.fulfillOrders({ types: ['reconcile'] }).reconciled).to.be.true;
             expect(reconcileStub.calledOnceWith(['config-changed'])).to.be.true;
 
             reconcileStub.resetHistory();
             manager.submitOrders([{ type: 'reconcile', reason: 'refresh-clicked' }]);
-            expect(manager.fulfillPendingReconcile()).to.be.true;
+            expect(manager.fulfillOrders({ types: ['reconcile'] }).reconciled).to.be.true;
             expect(reconcileStub.calledOnceWith(['refresh-clicked'])).to.be.true;
         });
 
@@ -347,17 +347,17 @@ describe('DeviceManager', () => {
             const reconcileStub = sinon.stub(manager as any, 'reconcile');
             manager.submitOrders([{ type: 'reconcile', reason: 'stale' }]);
 
-            expect(manager.fulfillPendingReconcile({ except: ['stale'] })).to.be.false;
+            expect(manager.fulfillOrders({ types: ['reconcile'], except: ['stale'] }).reconciled).to.be.false;
             expect(reconcileStub.called).to.be.false;
             expect(manager.getPendingReconcileReasons()).to.include('stale');
         });
 
-        it('fulfillPendingOrders fulfills both order types in one call', () => {
+        it('fulfills both order types in one call by default', () => {
             const broadcastStub = sinon.stub(manager as any, 'broadcast').returns(true);
             const reconcileStub = sinon.stub(manager as any, 'reconcile');
             manager.submitOrders([{ type: 'broadcast', reason: 'refresh-clicked' }, { type: 'reconcile', reason: 'refresh-clicked' }]);
 
-            const result = manager.fulfillPendingOrders();
+            const result = manager.fulfillOrders();
 
             expect(result).to.eql({ scanStarted: true, reconciled: true });
             expect(broadcastStub.calledOnceWith(['refresh-clicked'])).to.be.true;
@@ -366,13 +366,13 @@ describe('DeviceManager', () => {
             expect(manager.getPendingReconcileReasons()).to.be.empty;
         });
 
-        it('fulfillPendingOrders passes the except list to both order types', () => {
+        it('passes the except list to both order types', () => {
             const broadcastStub = sinon.stub(manager as any, 'broadcast').returns(true);
             const reconcileStub = sinon.stub(manager as any, 'reconcile');
             manager.submitOrders([{ type: 'broadcast', reason: 'stale' }]);
             manager.submitOrders([{ type: 'reconcile', reason: 'stale' }]);
 
-            const result = manager.fulfillPendingOrders({ except: ['stale'] });
+            const result = manager.fulfillOrders({ except: ['stale'] });
 
             expect(result).to.eql({ scanStarted: false, reconciled: false });
             expect(broadcastStub.called).to.be.false;
@@ -685,7 +685,7 @@ describe('DeviceManager', () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
             const handler = sinon.spy();
-            const unsubscribe = manager.on('broadcast-ordered', handler);
+            const unsubscribe = manager.on('order-submitted', handler);
 
             manager.submitOrders([{ type: 'broadcast', reason: 'network' }]);
             expect(handler.calledOnce).to.be.true;
@@ -700,7 +700,7 @@ describe('DeviceManager', () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
             const disposables: any[] = [];
-            manager.on('broadcast-ordered', () => { }, disposables);
+            manager.on('order-submitted', () => { }, disposables);
 
             expect(disposables.length).to.equal(1);
             expect(disposables[0]).to.have.property('dispose');

--- a/src/deviceDiscovery/DeviceManager.spec.ts
+++ b/src/deviceDiscovery/DeviceManager.spec.ts
@@ -1786,6 +1786,51 @@ describe('DeviceManager', () => {
         });
     });
 
+    describe('scan responder hydration (spec: "responds to an M-SEARCH — hydrate it immediately", via read)', () => {
+        function flush(): Promise<void> {
+            return new Promise(resolve => {
+                setTimeout(resolve, 5);
+            });
+        }
+
+        it('an unknown responder with cache in the 5min–8h dead zone hydrates on the next read', async () => {
+            manager = new DeviceManager(vscode.context, mockGlobalStateManager);
+            const resolveStub = sinon.stub(manager as any, 'resolveDevice').returns(Promise.resolve(true) as any);
+
+            //cache aged past the 5-min freshness check (so the responder lands `unknown`) but
+            //younger than the 8-hour hydration threshold — the exact gap that used to strand
+            //the device grey forever
+            mockGlobalStateManager.setCachedDevice('SCAN70', {
+                serialNumber: 'SCAN70',
+                deviceInfo: { 'serial-number': 'SCAN70' },
+                createdAt: Date.now() - (10 * 60 * 1_000)
+            });
+            manager['finder'].emit('found', '192.168.1.70', { serialNumber: 'SCAN70' });
+            expect(manager.getDevice({ ip: '192.168.1.70' }).deviceState).to.equal('unknown');
+
+            //the emit above makes a visible view re-read; simulate that read
+            manager.getAllDevices();
+            await flush();
+
+            expect(resolveStub.calledOnce).to.be.true;
+            expect(resolveStub.firstCall.args[0]).to.include({ ip: '192.168.1.70' });
+        });
+
+        it('repeated M-SEARCH answers do not double-hydrate (in-flight + cooldown guards)', async () => {
+            manager = new DeviceManager(vscode.context, mockGlobalStateManager);
+            const resolveStub = sinon.stub(manager as any, 'resolveDevice').returns(Promise.resolve(true) as any);
+
+            manager['finder'].emit('found', '192.168.1.70', { serialNumber: 'SCAN70' });
+            manager.getAllDevices();
+            await flush();
+            manager['finder'].emit('found', '192.168.1.70', { serialNumber: 'SCAN70' });
+            manager.getAllDevices();
+            await flush();
+
+            expect(resolveStub.calledOnce).to.be.true;
+        });
+    });
+
     describe('lazy hydration on read', () => {
         function flush(): Promise<void> {
             return new Promise(resolve => {
@@ -3014,14 +3059,18 @@ describe('DeviceManager', () => {
             });
 
             describe('scan state handling', () => {
-                it('calls finder.stop() to handle any in-progress scan', () => {
+                it('ends any in-progress scan WITHOUT stopping the passive SSDP listener', () => {
                     manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
-                    const finderStopSpy = sinon.spy(manager['finder'], 'stop');
+                    const stopScanSpy = sinon.spy(manager['finder'], 'stopScan');
+                    const stopSpy = sinon.spy(manager['finder'], 'stop');
 
                     manager.clearAllCache();
 
-                    expect(finderStopSpy.calledOnce).to.be.true;
+                    expect(stopScanSpy.calledOnce).to.be.true;
+                    //stopping the listener would leave the device list empty until the next
+                    //explicit scan — alive/byebye announcements must keep flowing after a clear
+                    expect(stopSpy.called).to.be.false;
                 });
             });
 

--- a/src/deviceDiscovery/DeviceManager.spec.ts
+++ b/src/deviceDiscovery/DeviceManager.spec.ts
@@ -166,8 +166,8 @@ describe('DeviceManager', () => {
         sinon.restore();
     });
 
-    describe('orders (submit + pending slots)', () => {
-        it('submitBroadcast fills the pending slot and emits broadcast-ordered with the reason', () => {
+    describe('orders (submit + pending sets)', () => {
+        it('submitBroadcast adds to the pending set and emits broadcast-ordered with the reason', () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
             const eventSpy = sinon.spy();
@@ -177,10 +177,10 @@ describe('DeviceManager', () => {
 
             expect(eventSpy.calledOnce).to.be.true;
             expect(eventSpy.firstCall.args[0].reason).to.equal('network');
-            expect(manager.getPendingBroadcast()).to.include({ reason: 'network' });
+            expect(manager.getPendingBroadcastReasons()).to.include('network');
         });
 
-        it('submitReconcile fills the pending slot and emits reconcile-ordered with the reason', () => {
+        it('submitReconcile adds to the pending set and emits reconcile-ordered with the reason', () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
             const eventSpy = sinon.spy();
@@ -190,36 +190,37 @@ describe('DeviceManager', () => {
 
             expect(eventSpy.calledOnce).to.be.true;
             expect(eventSpy.firstCall.args[0].reason).to.equal('config-changed');
-            expect(manager.getPendingReconcile()).to.include({ reason: 'config-changed' });
+            expect(manager.getPendingReconcileReasons()).to.include('config-changed');
         });
 
-        it('a newer order replaces the pending slot', () => {
+        it('different reasons accumulate instead of replacing each other', () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
             manager.submitBroadcast('sleep');
             manager.submitBroadcast('network');
-
-            expect(manager.getPendingBroadcast()).to.include({ reason: 'network' });
-        });
-
-        it('a stale order never downgrades a pending real trigger', () => {
-            manager = new DeviceManager(vscode.context, mockGlobalStateManager);
-
-            manager.submitBroadcast('network');
             manager.submitBroadcast('stale');
 
-            //the real trigger keeps the slot (but the stale event still fired for live views)
-            expect(manager.getPendingBroadcast()).to.include({ reason: 'network' });
+            expect(manager.getPendingBroadcastReasons()).to.have.members(['sleep', 'network', 'stale']);
         });
 
-        it('broadcast and reconcile pending slots are independent', () => {
+        it('the same reason never queues twice', () => {
+            manager = new DeviceManager(vscode.context, mockGlobalStateManager);
+
+            manager.submitBroadcast('stale');
+            manager.submitBroadcast('stale');
+            manager.submitBroadcast('stale');
+
+            expect(manager.getPendingBroadcastReasons()).to.eql(['stale']);
+        });
+
+        it('broadcast and reconcile pending sets are independent', () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
             manager.submitBroadcast('network');
             manager.submitReconcile('config-changed');
 
-            expect(manager.getPendingBroadcast()).to.include({ reason: 'network' });
-            expect(manager.getPendingReconcile()).to.include({ reason: 'config-changed' });
+            expect(manager.getPendingBroadcastReasons()).to.include('network');
+            expect(manager.getPendingReconcileReasons()).to.include('config-changed');
         });
     });
 
@@ -235,8 +236,21 @@ describe('DeviceManager', () => {
             const result = manager.fulfillPendingBroadcast();
 
             expect(result).to.be.true;
-            expect(broadcastStub.calledOnceWith('network')).to.be.true;
-            expect(manager.getPendingBroadcast()).to.be.null;
+            expect(broadcastStub.calledOnceWith(['network'])).to.be.true;
+            expect(manager.getPendingBroadcastReasons()).to.be.empty;
+        });
+
+        it('consumes all accumulated reasons in a single execution', () => {
+            const broadcastStub = sinon.stub(manager as any, 'broadcast').returns(true);
+            manager.submitBroadcast('sleep');
+            manager.submitBroadcast('network');
+
+            const result = manager.fulfillPendingBroadcast();
+
+            expect(result).to.be.true;
+            expect(broadcastStub.calledOnce).to.be.true;
+            expect(broadcastStub.firstCall.args[0]).to.have.members(['sleep', 'network']);
+            expect(manager.getPendingBroadcastReasons()).to.be.empty;
         });
 
         it('passes a stale reason through (broadcast applies the staleness gate itself)', () => {
@@ -245,7 +259,7 @@ describe('DeviceManager', () => {
 
             manager.fulfillPendingBroadcast();
 
-            expect(broadcastStub.calledOnceWith('stale')).to.be.true;
+            expect(broadcastStub.calledOnceWith(['stale'])).to.be.true;
         });
 
         it('leaves except-listed reasons QUEUED instead of consuming them', () => {
@@ -256,7 +270,19 @@ describe('DeviceManager', () => {
 
             expect(result).to.be.false;
             expect(broadcastStub.called).to.be.false;
-            expect(manager.getPendingBroadcast()).to.include({ reason: 'stale' });
+            expect(manager.getPendingBroadcastReasons()).to.include('stale');
+        });
+
+        it('takes the real reasons and leaves the except-listed ones queued', () => {
+            const broadcastStub = sinon.stub(manager as any, 'broadcast').returns(true);
+            manager.submitBroadcast('stale');
+            manager.submitBroadcast('network');
+
+            const result = manager.fulfillPendingBroadcast({ except: ['stale'] });
+
+            expect(result).to.be.true;
+            expect(broadcastStub.calledOnceWith(['network'])).to.be.true;
+            expect(manager.getPendingBroadcastReasons()).to.eql(['stale']);
         });
 
         it('returns false and does nothing when no order is pending', () => {
@@ -266,7 +292,7 @@ describe('DeviceManager', () => {
             expect(broadcastStub.called).to.be.false;
         });
 
-        it('is atomic: a second fulfillment finds the slot empty', () => {
+        it('is atomic: a second fulfillment finds the set empty', () => {
             const broadcastStub = sinon.stub(manager as any, 'broadcast').returns(true);
             manager.submitBroadcast('network');
 
@@ -280,12 +306,12 @@ describe('DeviceManager', () => {
 
             manager.submitReconcile('config-changed');
             expect(manager.fulfillPendingReconcile()).to.be.true;
-            expect(reconcileStub.calledOnceWith('config-changed')).to.be.true;
+            expect(reconcileStub.calledOnceWith(['config-changed'])).to.be.true;
 
             reconcileStub.resetHistory();
             manager.submitReconcile('refresh-clicked');
             expect(manager.fulfillPendingReconcile()).to.be.true;
-            expect(reconcileStub.calledOnceWith('refresh-clicked')).to.be.true;
+            expect(reconcileStub.calledOnceWith(['refresh-clicked'])).to.be.true;
         });
 
         it('leaves an except-listed reconcile queued', () => {
@@ -294,7 +320,7 @@ describe('DeviceManager', () => {
 
             expect(manager.fulfillPendingReconcile({ except: ['stale'] })).to.be.false;
             expect(reconcileStub.called).to.be.false;
-            expect(manager.getPendingReconcile()).to.include({ reason: 'stale' });
+            expect(manager.getPendingReconcileReasons()).to.include('stale');
         });
     });
 
@@ -310,19 +336,19 @@ describe('DeviceManager', () => {
                 await manager['activateMonitoring']();
 
                 clock.tick(manager['STALE_RECONCILE_INTERVAL_MS']);
-                expect(manager.getPendingReconcile()).to.include({ reason: 'stale' });
+                expect(manager.getPendingReconcileReasons()).to.include('stale');
 
                 clock.tick(manager['STALE_SCAN_THRESHOLD_MS']);
-                expect(manager.getPendingBroadcast()).to.include({ reason: 'stale' });
+                expect(manager.getPendingBroadcastReasons()).to.include('stale');
 
                 //consume the pending orders, stop monitoring, and verify no new stale orders arrive
-                manager['pendingBroadcast'] = null;
-                manager['pendingReconcile'] = null;
+                manager['pendingBroadcastReasons'].clear();
+                manager['pendingReconcileReasons'].clear();
                 manager['deactivateMonitoring']();
 
                 clock.tick(manager['STALE_SCAN_THRESHOLD_MS'] * 2);
-                expect(manager.getPendingBroadcast()).to.be.null;
-                expect(manager.getPendingReconcile()).to.be.null;
+                expect(manager.getPendingBroadcastReasons()).to.be.empty;
+                expect(manager.getPendingReconcileReasons()).to.be.empty;
             } finally {
                 clock.restore();
             }
@@ -340,7 +366,7 @@ describe('DeviceManager', () => {
             try {
                 manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
-                manager['broadcast']('refresh-clicked');
+                manager['broadcast'](['refresh-clicked']);
 
                 clock.tick(5_000);
 
@@ -632,7 +658,7 @@ describe('DeviceManager', () => {
 
             expect(manager['timeSinceLastScan']).to.equal(Infinity);
 
-            manager['broadcast']('refresh-clicked');
+            manager['broadcast'](['refresh-clicked']);
 
             // After a broadcast, timeSinceLastScan should be very small (just happened)
             expect(manager['timeSinceLastScan']).to.be.lessThan(100);
@@ -643,13 +669,13 @@ describe('DeviceManager', () => {
 
             const healthCheckAllDevicesSpy = sinon.stub(manager as any, 'healthCheckAllDevices').resolves();
 
-            manager['reconcile']('refresh-clicked');
+            manager['reconcile'](['refresh-clicked']);
             expect(healthCheckAllDevicesSpy.calledWith(true)).to.be.true;
 
-            manager['reconcile']('config-changed');
+            manager['reconcile'](['config-changed']);
             expect(healthCheckAllDevicesSpy.calledWith(false)).to.be.true;
 
-            manager['reconcile']('network');
+            manager['reconcile'](['network']);
             expect(healthCheckAllDevicesSpy.lastCall.args[0]).to.equal(false);
         });
     });
@@ -661,7 +687,7 @@ describe('DeviceManager', () => {
             const finderScanSpy = sinon.stub(manager['finder'], 'scan');
             const healthCheckAllDevicesSpy = sinon.spy(manager as any, 'healthCheckAllDevices');
 
-            manager['broadcast']('refresh-clicked');
+            manager['broadcast'](['refresh-clicked']);
 
             expect(finderScanSpy.calledOnce).to.be.true;
             expect(healthCheckAllDevicesSpy.called).to.be.false;
@@ -673,7 +699,7 @@ describe('DeviceManager', () => {
 
             const finderScanSpy = sinon.stub(manager['finder'], 'scan');
 
-            const result = manager['broadcast']('stale');
+            const result = manager['broadcast'](['stale']);
 
             expect(result).to.be.false;
             expect(finderScanSpy.called).to.be.false;
@@ -685,7 +711,7 @@ describe('DeviceManager', () => {
 
             const finderScanSpy = sinon.stub(manager['finder'], 'scan');
 
-            const result = manager['broadcast']('refresh-clicked');
+            const result = manager['broadcast'](['refresh-clicked']);
 
             expect(result).to.be.true;
             expect(finderScanSpy.calledOnce).to.be.true;
@@ -695,8 +721,16 @@ describe('DeviceManager', () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
             sinon.stub(manager['finder'], 'scan');
 
-            expect(manager['broadcast']('refresh-clicked')).to.be.true; //sets lastScanDate
-            expect(manager['broadcast']('stale')).to.be.false; //fresh — gate closed
+            expect(manager['broadcast'](['refresh-clicked'])).to.be.true; //sets lastScanDate
+            expect(manager['broadcast'](['stale'])).to.be.false; //fresh — gate closed
+        });
+
+        it('the gate only applies when stale is the ONLY reason: stale + a real reason scans', () => {
+            manager = new DeviceManager(vscode.context, mockGlobalStateManager);
+            sinon.stub(manager['finder'], 'scan');
+
+            expect(manager['broadcast'](['refresh-clicked'])).to.be.true; //sets lastScanDate
+            expect(manager['broadcast'](['stale', 'network'])).to.be.true; //the real reason wins
         });
 
         it('a stale reason scans when the last scan is older than the threshold', () => {
@@ -708,7 +742,7 @@ describe('DeviceManager', () => {
             //backdate the last scan past the staleness threshold
             manager['lastScanDate'] = new Date(Date.now() - manager['STALE_SCAN_THRESHOLD_MS'] - 1);
 
-            expect(manager['broadcast']('stale')).to.be.true;
+            expect(manager['broadcast'](['stale'])).to.be.true;
         });
 
         it('emits scan-started event', () => {
@@ -719,7 +753,7 @@ describe('DeviceManager', () => {
                 const scanStartedSpy = sinon.spy();
                 manager.on('scan-started', scanStartedSpy);
 
-                manager['broadcast']('refresh-clicked');
+                manager['broadcast'](['refresh-clicked']);
 
                 expect(scanStartedSpy.calledOnce).to.be.true;
             } finally {
@@ -896,7 +930,7 @@ describe('DeviceManager', () => {
                 const scanStartedSpy = sinon.spy();
                 manager.on('scan-started', scanStartedSpy);
 
-                manager['broadcast']('refresh-clicked');
+                manager['broadcast'](['refresh-clicked']);
 
                 expect(scanStartedSpy.calledOnce).to.be.true;
             } finally {
@@ -912,7 +946,7 @@ describe('DeviceManager', () => {
                 const scanEndedSpy = sinon.spy();
                 manager.on('scan-ended', scanEndedSpy);
 
-                manager['broadcast']('refresh-clicked');
+                manager['broadcast'](['refresh-clicked']);
 
                 // Not ended yet - neither timer has fired
                 expect(scanEndedSpy.called).to.be.false;
@@ -937,11 +971,11 @@ describe('DeviceManager', () => {
                 const scanStartedSpy = sinon.spy();
                 manager.on('scan-started', scanStartedSpy);
 
-                manager['broadcast']('refresh-clicked');
+                manager['broadcast'](['refresh-clicked']);
                 expect(scanStartedSpy.calledOnce).to.be.true;
 
                 // Try to start another scan while one is in progress
-                manager['broadcast']('refresh-clicked');
+                manager['broadcast'](['refresh-clicked']);
                 expect(scanStartedSpy.calledOnce).to.be.true; // Still just one call
             } finally {
                 clock.restore();
@@ -958,7 +992,7 @@ describe('DeviceManager', () => {
                 manager.on('scan-started', scanStartedSpy);
                 manager.on('scan-ended', scanEndedSpy);
 
-                manager['broadcast']('refresh-clicked');
+                manager['broadcast'](['refresh-clicked']);
                 expect(scanStartedSpy.calledOnce).to.be.true;
 
                 // Complete the scan
@@ -966,7 +1000,7 @@ describe('DeviceManager', () => {
                 expect(scanEndedSpy.calledOnce).to.be.true;
 
                 // Now can start a new scan
-                manager['broadcast']('refresh-clicked');
+                manager['broadcast'](['refresh-clicked']);
                 expect(scanStartedSpy.calledTwice).to.be.true;
             } finally {
                 clock.restore();
@@ -2046,8 +2080,8 @@ describe('DeviceManager', () => {
             // Trigger the network change callback directly
             manager['networkChangeMonitor']['onNetworkChanged']();
 
-            expect(manager.getPendingBroadcast()).to.include({ reason: 'network' });
-            expect(manager.getPendingReconcile()).to.include({ reason: 'network' });
+            expect(manager.getPendingBroadcastReasons()).to.include('network');
+            expect(manager.getPendingReconcileReasons()).to.include('network');
         });
 
         it('clears discovered devices when network changes', () => {
@@ -2908,14 +2942,14 @@ describe('DeviceManager', () => {
                     sinon.stub(manager['finder'], 'scan');
 
                     // a stale broadcast is gated: the last scan is too recent
-                    let scanStarted = manager['broadcast']('stale');
+                    let scanStarted = manager['broadcast'](['stale']);
                     expect(scanStarted).to.be.false;
 
                     // Clear cache
                     manager.clearAllCache();
 
                     // Now scan should be allowed (lastScanDate is null, timeSinceLastScan is Infinity)
-                    scanStarted = manager['broadcast']('stale');
+                    scanStarted = manager['broadcast'](['stale']);
                     expect(scanStarted).to.be.true;
                 });
 

--- a/src/deviceDiscovery/DeviceManager.spec.ts
+++ b/src/deviceDiscovery/DeviceManager.spec.ts
@@ -385,13 +385,15 @@ describe('DeviceManager', () => {
     describe('deviceEngaged', () => {
         it('freshens the device with the cache trust window bypassed and reports health', async () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
-            const healthCheckStub = sinon.stub(manager as any, 'healthCheckDevice').returns(Promise.resolve(true) as any);
+            manager['discoveredDevices'].push({ ip: '192.168.1.50', serialNumber: 'ENG50', state: 'online' } as any);
+            const resolveStub = sinon.stub(manager as any, 'resolveDevice').returns(Promise.resolve(true) as any);
 
-            const device = { ip: '192.168.1.50' };
-            const isHealthy = await manager.deviceEngaged(device);
+            const isHealthy = await manager.deviceEngaged({ ip: '192.168.1.50' });
 
             expect(isHealthy).to.be.true;
-            expect(healthCheckStub.calledOnceWith(device, true, false)).to.be.true;
+            //engagement policy: no synthetic delay, cache trust window bypassed
+            expect(resolveStub.calledOnce).to.be.true;
+            expect(resolveStub.firstCall.args.slice(1)).to.eql([false, true]);
         });
 
         it('resolves an encoded tree key itself', async () => {
@@ -560,7 +562,7 @@ describe('DeviceManager', () => {
                 manager['setDeviceState']({ ip: '192.168.1.100', serialNumber: 'ABC123' }, 'online');
 
                 // Looking up the same IP with a different serial must NOT inherit the ABC123 online state
-                expect(manager.getDeviceState({ ip: '192.168.1.100', serialNumber: 'ZZZZZ' }).state).to.equal('unknown');
+                expect(manager['getDeviceState']({ ip: '192.168.1.100', serialNumber: 'ZZZZZ' }).state).to.equal('unknown');
             });
 
             it('falls back to a serial-only match when the IP-match is filtered by serial conflict', () => {
@@ -575,7 +577,7 @@ describe('DeviceManager', () => {
                 manager['setDeviceState']({ ip: '192.168.1.5', serialNumber: 'ZZZZZ' }, 'offline');
 
                 // Lookup with ABC123 + the stale IP should still resolve to the online entry via serial
-                expect(manager.getDeviceState({ ip: '192.168.1.5', serialNumber: 'ABC123' }).state).to.equal('online');
+                expect(manager['getDeviceState']({ ip: '192.168.1.5', serialNumber: 'ABC123' }).state).to.equal('online');
             });
 
             it('matches by IP alone when no serial is supplied in the lookup', () => {
@@ -584,7 +586,7 @@ describe('DeviceManager', () => {
                 manager['setDeviceState']({ ip: '192.168.1.100', serialNumber: 'ABC123' }, 'online');
 
                 // No serial in the lookup → conflict guard is a no-op
-                expect(manager.getDeviceState({ ip: '192.168.1.100' }).state).to.equal('online');
+                expect(manager['getDeviceState']({ ip: '192.168.1.100' }).state).to.equal('online');
             });
 
             it('applies the conflict guard to configured entries', () => {
@@ -592,7 +594,7 @@ describe('DeviceManager', () => {
                 manager['configuredDevices'].push({ host: '192.168.1.100', serialNumber: 'ABC123' } as any);
                 manager['setDeviceState']({ ip: '192.168.1.100', serialNumber: 'ABC123' }, 'online');
 
-                expect(manager.getDeviceState({ ip: '192.168.1.100', serialNumber: 'ZZZZZ' }).state).to.equal('unknown');
+                expect(manager['getDeviceState']({ ip: '192.168.1.100', serialNumber: 'ZZZZZ' }).state).to.equal('unknown');
             });
 
             it('does not flash a configured device online when its serial is changed to a value not present at that IP', async () => {
@@ -932,7 +934,7 @@ describe('DeviceManager', () => {
         });
     });
 
-    describe('healthCheckDevice with force=false (cooldown)', () => {
+    describe('resolveDevice cooldown (force=false)', () => {
         it('skips network fetch if within cooldown period (uses cached data)', async () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
@@ -949,11 +951,11 @@ describe('DeviceManager', () => {
             sinon.stub(manager as any, 'randomDelay').resolves();
 
             // First call - should fetch from network
-            await manager['healthCheckDevice'](device);
+            await manager['resolveDevice'](device);
             expect(getDeviceInfoStub.calledOnce).to.be.true;
 
             // Second call immediately - should use cache, no new network call
-            await manager['healthCheckDevice'](device);
+            await manager['resolveDevice'](device);
             expect(getDeviceInfoStub.calledOnce).to.be.true; // Still just one call
         });
 
@@ -975,21 +977,21 @@ describe('DeviceManager', () => {
                 sinon.stub(manager as any, 'randomDelay').resolves();
 
                 // First call
-                await manager['healthCheckDevice'](device);
+                await manager['resolveDevice'](device);
                 expect(getDeviceInfoStub.calledOnce).to.be.true;
 
                 // Advance past cooldown (5 minutes)
                 clock.tick((5 * 60 * 1_000) + 1);
 
                 // Second call - cache expired, should fetch again
-                await manager['healthCheckDevice'](device);
+                await manager['resolveDevice'](device);
                 expect(getDeviceInfoStub.calledTwice).to.be.true;
             } finally {
                 clock.restore();
             }
         });
 
-        it('always fetches when force=true regardless of cooldown', async () => {
+        it('deviceEngaged always fetches regardless of cooldown (engagement forces)', async () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
             const device = createMockDevice();
@@ -1005,11 +1007,11 @@ describe('DeviceManager', () => {
             sinon.stub(manager as any, 'randomDelay').resolves();
 
             // First call with force
-            await manager['healthCheckDevice'](device, true);
+            await manager.deviceEngaged(device);
             expect(getDeviceInfoStub.calledOnce).to.be.true;
 
             // Second call immediately with force - should still fetch
-            await manager['healthCheckDevice'](device, true);
+            await manager.deviceEngaged(device);
             expect(getDeviceInfoStub.calledTwice).to.be.true;
         });
     });
@@ -1185,7 +1187,7 @@ describe('DeviceManager', () => {
         });
     });
 
-    describe('healthCheckDevice', () => {
+    describe('deviceEngaged (single-device check)', () => {
         it('sets device to pending during health check', async () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
             (vscode.window as any).state = { focused: true };
@@ -1200,7 +1202,7 @@ describe('DeviceManager', () => {
             });
             sinon.stub(rokuDeploy, 'getDeviceInfo').returns(healthPromise);
 
-            const checkPromise = manager['healthCheckDevice'](device, true);
+            const checkPromise = manager.deviceEngaged(device);
 
             // Device should be pending during check
             expect(manager.getAllDevices()[0].deviceState).to.equal('pending');
@@ -1226,7 +1228,7 @@ describe('DeviceManager', () => {
 
             sinon.stub(rokuDeploy, 'getDeviceInfo').rejects(new Error('Device not responding'));
 
-            const result = await manager['healthCheckDevice'](device, true);
+            const result = await manager.deviceEngaged(device);
 
             expect(result).to.be.false;
             expect(manager.getAllDevices().length).to.equal(0);
@@ -1301,7 +1303,7 @@ describe('DeviceManager', () => {
 
             // First health check fails (device offline)
             sinon.stub(rokuDeploy, 'getDeviceInfo').rejects(new Error('Device not responding'));
-            await manager['healthCheckDevice'](device, true);
+            await manager.deviceEngaged(device);
 
             // Cache should still exist with device info preserved for offline display
             const cached = mockGlobalStateManager.getCachedDevice('device-123');
@@ -1309,7 +1311,7 @@ describe('DeviceManager', () => {
             expect(cached.deviceInfo['default-device-name']).to.equal('My Roku');
 
             // Device should be offline (configured devices persist with state)
-            expect(manager.getDeviceState({ serialNumber: 'device-123' }).state).to.equal('offline');
+            expect(manager['getDeviceState']({ serialNumber: 'device-123' }).state).to.equal('offline');
         });
 
         it('returns true when device is healthy', async () => {
@@ -1324,7 +1326,7 @@ describe('DeviceManager', () => {
                 'default-device-name': 'Roku Express'
             });
 
-            const result = await manager['healthCheckDevice'](device, true);
+            const result = await manager.deviceEngaged(device);
 
             expect(result).to.be.true;
         });
@@ -1348,8 +1350,8 @@ describe('DeviceManager', () => {
                 resolveFetch = resolve;
             }) as any);
 
-            const first = manager['healthCheckDevice'](device, true, false);
-            const second = manager['healthCheckDevice'](device, true, false);
+            const first = manager.deviceEngaged(device);
+            const second = manager.deviceEngaged(device);
 
             resolveFetch({
                 'device-id': 'device-123',
@@ -1391,8 +1393,8 @@ describe('DeviceManager', () => {
             getDeviceInfoStub.onSecondCall().returns(device2Promise);
 
             // Start health checks for both devices
-            const result1 = manager['healthCheckDevice'](device1, true);
-            const result2 = manager['healthCheckDevice'](device2, true);
+            const result1 = manager.deviceEngaged(device1);
+            const result2 = manager.deviceEngaged(device2);
 
             // Device 2 completes first (healthy)
             resolveDevice2({
@@ -1775,12 +1777,12 @@ describe('DeviceManager', () => {
 
             manager['discoveredDevices'].push({ ip: '192.168.1.100' });
             const startStub = sinon.stub(manager['networkChangeMonitor'], 'start');
-            const healthCheckStub = sinon.stub(manager as any, 'healthCheckDevice').returns(Promise.resolve(true) as any);
+            const resolveStub = sinon.stub(manager as any, 'resolveDevice').returns(Promise.resolve(true) as any);
 
             manager['notifyFocusGained']();
 
             expect(startStub.calledOnce).to.be.true;
-            expect(healthCheckStub.called).to.be.false;
+            expect(resolveStub.called).to.be.false;
         });
     });
 
@@ -2505,7 +2507,7 @@ describe('DeviceManager', () => {
             });
         });
 
-        describe('healthCheckDevice with failed network calls', () => {
+        describe('deviceEngaged with failed network calls', () => {
             it('marks configured device as offline when health check fails and cache exists', async () => {
                 manager = new DeviceManager(vscode.context, mockGlobalStateManager);
                 sinon.stub(manager as any, 'randomDelay').resolves();
@@ -2527,7 +2529,7 @@ describe('DeviceManager', () => {
                 // Stub to simulate network failure
                 sinon.stub(rokuDeploy, 'getDeviceInfo').rejects(new Error('Device not responding'));
 
-                const result = await manager['healthCheckDevice'](device, true);
+                const result = await manager.deviceEngaged(device);
 
                 expect(result).to.be.false;
                 expect(manager.getAllDevices().length).to.equal(1);
@@ -2551,7 +2553,7 @@ describe('DeviceManager', () => {
                 // Stub to simulate network failure
                 sinon.stub(rokuDeploy, 'getDeviceInfo').rejects(new Error('Device not responding'));
 
-                const result = await manager['healthCheckDevice'](device, true);
+                const result = await manager.deviceEngaged(device);
 
                 expect(result).to.be.false;
                 expect(manager.getAllDevices().length).to.equal(1);
@@ -2575,7 +2577,7 @@ describe('DeviceManager', () => {
                 // Stub to simulate network failure
                 sinon.stub(rokuDeploy, 'getDeviceInfo').rejects(new Error('Device not responding'));
 
-                const result = await manager['healthCheckDevice'](device, true);
+                const result = await manager.deviceEngaged(device);
 
                 expect(result).to.be.false;
                 expect(manager.getAllDevices().length).to.equal(0);
@@ -2608,7 +2610,7 @@ describe('DeviceManager', () => {
 
                 sinon.stub(rokuDeploy, 'getDeviceInfo').rejects(new Error('Offline'));
 
-                await manager['healthCheckDevice'](device, true);
+                await manager.deviceEngaged(device);
 
                 // Device kept (configured) but not discovered
                 expect(manager.getAllDevices().length).to.equal(1);
@@ -2631,7 +2633,7 @@ describe('DeviceManager', () => {
 
                 sinon.stub(rokuDeploy, 'getDeviceInfo').rejects(new Error('Offline'));
 
-                await manager['healthCheckDevice'](device, true);
+                await manager.deviceEngaged(device);
 
                 // Device removed (not configured, not discovered)
                 expect(manager.getAllDevices().length).to.equal(0);
@@ -2979,11 +2981,11 @@ describe('DeviceManager', () => {
                     sinon.stub(manager as any, 'randomDelay').resolves();
 
                     // Perform health check to populate cache
-                    await manager['healthCheckDevice'](device);
+                    await manager['resolveDevice'](device);
                     expect(getDeviceInfoStub.calledOnce).to.be.true;
 
                     // Second call should use cache (no new network call)
-                    await manager['healthCheckDevice'](device);
+                    await manager['resolveDevice'](device);
                     expect(getDeviceInfoStub.calledOnce).to.be.true; // Still just one call
 
                     // Clear cache (clears globalStateManager.deviceCache and IP→serial mappings)
@@ -2993,7 +2995,7 @@ describe('DeviceManager', () => {
                     addDevice(device);
 
                     // Now health check should hit network again (cache was cleared)
-                    await manager['healthCheckDevice'](device);
+                    await manager['resolveDevice'](device);
                     expect(getDeviceInfoStub.calledTwice).to.be.true;
                 });
 
@@ -3053,14 +3055,14 @@ describe('DeviceManager', () => {
                     const resolveDeviceSpy = sinon.stub(manager as any, 'resolveDevice').returns(Promise.resolve(true));
 
                     // First health check
-                    await manager['healthCheckDevice'](device);
+                    await manager['resolveDevice'](device);
                     expect(resolveDeviceSpy.calledOnce).to.be.true;
 
                     // Clear cache (should clear cooldown)
                     manager.clearAllCache();
 
                     // Health check should run immediately (no cooldown)
-                    await manager['healthCheckDevice'](device);
+                    await manager['resolveDevice'](device);
                     expect(resolveDeviceSpy.calledTwice).to.be.true;
                 });
 
@@ -3076,7 +3078,7 @@ describe('DeviceManager', () => {
                     });
                     sinon.stub(manager as any, 'resolveDevice').returns(healthCheckPromise);
 
-                    const healthCheckCall = manager['healthCheckDevice'](device);
+                    const healthCheckCall = manager['resolveDevice'](device);
 
                     // Clear cache while health check is in flight
                     manager.clearAllCache();

--- a/src/deviceDiscovery/DeviceManager.spec.ts
+++ b/src/deviceDiscovery/DeviceManager.spec.ts
@@ -260,7 +260,7 @@ describe('DeviceManager', () => {
             const broadcastStub = sinon.stub(manager as any, 'broadcast').returns(true);
             manager.submitOrders([{ type: 'broadcast', reason: 'network' }]);
 
-            const result = manager.fulfillOrders({ types: ['broadcast'] }).scanStarted;
+            const result = manager.fulfillOrders({ types: ['broadcast'] }).length > 0;
 
             expect(result).to.be.true;
             expect(broadcastStub.calledOnceWith(['network'])).to.be.true;
@@ -272,7 +272,7 @@ describe('DeviceManager', () => {
             manager.submitOrders([{ type: 'broadcast', reason: 'sleep' }]);
             manager.submitOrders([{ type: 'broadcast', reason: 'network' }]);
 
-            const result = manager.fulfillOrders({ types: ['broadcast'] }).scanStarted;
+            const result = manager.fulfillOrders({ types: ['broadcast'] }).length > 0;
 
             expect(result).to.be.true;
             expect(broadcastStub.calledOnce).to.be.true;
@@ -293,7 +293,7 @@ describe('DeviceManager', () => {
             const broadcastStub = sinon.stub(manager as any, 'broadcast').returns(true);
             manager.submitOrders([{ type: 'broadcast', reason: 'stale' }]);
 
-            const result = manager.fulfillOrders({ types: ['broadcast'], except: ['stale'] }).scanStarted;
+            const result = manager.fulfillOrders({ types: ['broadcast'], except: ['stale'] }).length > 0;
 
             expect(result).to.be.false;
             expect(broadcastStub.called).to.be.false;
@@ -305,7 +305,7 @@ describe('DeviceManager', () => {
             manager.submitOrders([{ type: 'broadcast', reason: 'stale' }]);
             manager.submitOrders([{ type: 'broadcast', reason: 'network' }]);
 
-            const result = manager.fulfillOrders({ types: ['broadcast'], except: ['stale'] }).scanStarted;
+            const result = manager.fulfillOrders({ types: ['broadcast'], except: ['stale'] }).length > 0;
 
             //the scan satisfies the stale want too, so it rides along instead of staying queued
             expect(result).to.be.true;
@@ -317,7 +317,7 @@ describe('DeviceManager', () => {
         it('returns false and does nothing when no order is pending', () => {
             const broadcastStub = sinon.stub(manager as any, 'broadcast').returns(true);
 
-            expect(manager.fulfillOrders({ types: ['broadcast'] }).scanStarted).to.be.false;
+            expect(manager.fulfillOrders({ types: ['broadcast'] })).to.be.empty;
             expect(broadcastStub.called).to.be.false;
         });
 
@@ -325,8 +325,8 @@ describe('DeviceManager', () => {
             const broadcastStub = sinon.stub(manager as any, 'broadcast').returns(true);
             manager.submitOrders([{ type: 'broadcast', reason: 'network' }]);
 
-            expect(manager.fulfillOrders({ types: ['broadcast'] }).scanStarted).to.be.true;
-            expect(manager.fulfillOrders({ types: ['broadcast'] }).scanStarted).to.be.false;
+            expect(manager.fulfillOrders({ types: ['broadcast'] })).to.not.be.empty;
+            expect(manager.fulfillOrders({ types: ['broadcast'] })).to.be.empty;
             expect(broadcastStub.calledOnce).to.be.true;
         });
 
@@ -334,12 +334,12 @@ describe('DeviceManager', () => {
             const reconcileStub = sinon.stub(manager as any, 'reconcile');
 
             manager.submitOrders([{ type: 'reconcile', reason: 'config-changed' }]);
-            expect(manager.fulfillOrders({ types: ['reconcile'] }).reconciled).to.be.true;
+            expect(manager.fulfillOrders({ types: ['reconcile'] })).to.not.be.empty;
             expect(reconcileStub.calledOnceWith(['config-changed'])).to.be.true;
 
             reconcileStub.resetHistory();
             manager.submitOrders([{ type: 'reconcile', reason: 'refresh-clicked' }]);
-            expect(manager.fulfillOrders({ types: ['reconcile'] }).reconciled).to.be.true;
+            expect(manager.fulfillOrders({ types: ['reconcile'] })).to.not.be.empty;
             expect(reconcileStub.calledOnceWith(['refresh-clicked'])).to.be.true;
         });
 
@@ -347,19 +347,22 @@ describe('DeviceManager', () => {
             const reconcileStub = sinon.stub(manager as any, 'reconcile');
             manager.submitOrders([{ type: 'reconcile', reason: 'stale' }]);
 
-            expect(manager.fulfillOrders({ types: ['reconcile'], except: ['stale'] }).reconciled).to.be.false;
+            expect(manager.fulfillOrders({ types: ['reconcile'], except: ['stale'] })).to.be.empty;
             expect(reconcileStub.called).to.be.false;
             expect(manager.getPendingReconcileReasons()).to.include('stale');
         });
 
-        it('fulfills both order types in one call by default', () => {
+        it('fulfills both order types in one call, returning what was taken', () => {
             const broadcastStub = sinon.stub(manager as any, 'broadcast').returns(true);
             const reconcileStub = sinon.stub(manager as any, 'reconcile');
             manager.submitOrders([{ type: 'broadcast', reason: 'refresh-clicked' }, { type: 'reconcile', reason: 'refresh-clicked' }]);
 
             const result = manager.fulfillOrders({ types: ['broadcast', 'reconcile'] });
 
-            expect(result).to.eql({ scanStarted: true, reconciled: true });
+            expect(result).to.eql([
+                { type: 'broadcast', reasons: ['refresh-clicked'] },
+                { type: 'reconcile', reasons: ['refresh-clicked'] }
+            ]);
             expect(broadcastStub.calledOnceWith(['refresh-clicked'])).to.be.true;
             expect(reconcileStub.calledOnceWith(['refresh-clicked'])).to.be.true;
             expect(manager.getPendingBroadcastReasons()).to.be.empty;
@@ -374,7 +377,7 @@ describe('DeviceManager', () => {
 
             const result = manager.fulfillOrders({ types: ['broadcast', 'reconcile'], except: ['stale'] });
 
-            expect(result).to.eql({ scanStarted: false, reconciled: false });
+            expect(result).to.be.empty;
             expect(broadcastStub.called).to.be.false;
             expect(reconcileStub.called).to.be.false;
             expect(manager.getPendingBroadcastReasons()).to.include('stale');
@@ -465,8 +468,7 @@ describe('DeviceManager', () => {
                 expect(manager.getPendingBroadcastReasons()).to.include('stale');
 
                 //consume the pending orders, stop monitoring, and verify no new stale orders arrive
-                manager['orders'].take('broadcast');
-                manager['orders'].take('reconcile');
+                manager['orders'].take({ types: ['broadcast', 'reconcile'] });
                 manager['deactivateMonitoring']();
 
                 clock.tick(manager['STALE_SCAN_THRESHOLD_MS'] * 2);

--- a/src/deviceDiscovery/DeviceManager.spec.ts
+++ b/src/deviceDiscovery/DeviceManager.spec.ts
@@ -167,26 +167,26 @@ describe('DeviceManager', () => {
     });
 
     describe('orders (submit + pending sets)', () => {
-        it('submitBroadcast adds to the pending set and emits broadcast-ordered with the reason', () => {
+        it('a broadcast order lands in the pending set and emits broadcast-ordered with the reason', () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
             const eventSpy = sinon.spy();
             manager.on('broadcast-ordered', eventSpy);
 
-            manager['submitBroadcast']('network');
+            manager.submitOrders([{ type: 'broadcast', reason: 'network' }]);
 
             expect(eventSpy.calledOnce).to.be.true;
             expect(eventSpy.firstCall.args[0].reason).to.equal('network');
             expect(manager.getPendingBroadcastReasons()).to.include('network');
         });
 
-        it('submitReconcile adds to the pending set and emits reconcile-ordered with the reason', () => {
+        it('a reconcile order lands in the pending set and emits reconcile-ordered with the reason', () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
             const eventSpy = sinon.spy();
             manager.on('reconcile-ordered', eventSpy);
 
-            manager['submitReconcile']('config-changed');
+            manager.submitOrders([{ type: 'reconcile', reason: 'config-changed' }]);
 
             expect(eventSpy.calledOnce).to.be.true;
             expect(eventSpy.firstCall.args[0].reason).to.equal('config-changed');
@@ -196,9 +196,9 @@ describe('DeviceManager', () => {
         it('different reasons accumulate instead of replacing each other', () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
-            manager['submitBroadcast']('sleep');
-            manager['submitBroadcast']('network');
-            manager['submitBroadcast']('stale');
+            manager.submitOrders([{ type: 'broadcast', reason: 'sleep' }]);
+            manager.submitOrders([{ type: 'broadcast', reason: 'network' }]);
+            manager.submitOrders([{ type: 'broadcast', reason: 'stale' }]);
 
             expect(manager.getPendingBroadcastReasons()).to.have.members(['sleep', 'network', 'stale']);
         });
@@ -206,9 +206,9 @@ describe('DeviceManager', () => {
         it('the same reason never queues twice', () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
-            manager['submitBroadcast']('stale');
-            manager['submitBroadcast']('stale');
-            manager['submitBroadcast']('stale');
+            manager.submitOrders([{ type: 'broadcast', reason: 'stale' }]);
+            manager.submitOrders([{ type: 'broadcast', reason: 'stale' }]);
+            manager.submitOrders([{ type: 'broadcast', reason: 'stale' }]);
 
             expect(manager.getPendingBroadcastReasons()).to.eql(['stale']);
         });
@@ -216,35 +216,35 @@ describe('DeviceManager', () => {
         it('broadcast and reconcile pending sets are independent', () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
-            manager['submitBroadcast']('network');
-            manager['submitReconcile']('config-changed');
+            manager.submitOrders([{ type: 'broadcast', reason: 'network' }]);
+            manager.submitOrders([{ type: 'reconcile', reason: 'config-changed' }]);
 
             expect(manager.getPendingBroadcastReasons()).to.include('network');
             expect(manager.getPendingReconcileReasons()).to.include('config-changed');
         });
 
-        it('submitOrder submits both order types for most reasons', () => {
+        it('submitOrders accepts multiple orders at once', () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
-            manager.submitOrder('refresh-clicked');
+            manager.submitOrders([{ type: 'broadcast', reason: 'refresh-clicked' }, { type: 'reconcile', reason: 'refresh-clicked' }]);
 
             expect(manager.getPendingBroadcastReasons()).to.eql(['refresh-clicked']);
             expect(manager.getPendingReconcileReasons()).to.eql(['refresh-clicked']);
         });
 
-        it('submitOrder submits only a reconcile for config-changed (a config edit cannot add network devices)', () => {
+        it('a reconcile-only submission leaves the broadcast set untouched', () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
-            manager.submitOrder('config-changed');
+            manager.submitOrders([{ type: 'reconcile', reason: 'config-changed' }]);
 
             expect(manager.getPendingBroadcastReasons()).to.be.empty;
             expect(manager.getPendingReconcileReasons()).to.eql(['config-changed']);
         });
 
-        it('submitOrder submits only a broadcast for unhealthy-device (rescan, do not hammer every device)', () => {
+        it('a broadcast-only submission leaves the reconcile set untouched', () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
-            manager.submitOrder('unhealthy-device');
+            manager.submitOrders([{ type: 'broadcast', reason: 'unhealthy-device' }]);
 
             expect(manager.getPendingBroadcastReasons()).to.eql(['unhealthy-device']);
             expect(manager.getPendingReconcileReasons()).to.be.empty;
@@ -258,7 +258,7 @@ describe('DeviceManager', () => {
 
         it('consumes and executes a pending broadcast, passing its reason through', () => {
             const broadcastStub = sinon.stub(manager as any, 'broadcast').returns(true);
-            manager['submitBroadcast']('network');
+            manager.submitOrders([{ type: 'broadcast', reason: 'network' }]);
 
             const result = manager.fulfillPendingBroadcast();
 
@@ -269,8 +269,8 @@ describe('DeviceManager', () => {
 
         it('consumes all accumulated reasons in a single execution', () => {
             const broadcastStub = sinon.stub(manager as any, 'broadcast').returns(true);
-            manager['submitBroadcast']('sleep');
-            manager['submitBroadcast']('network');
+            manager.submitOrders([{ type: 'broadcast', reason: 'sleep' }]);
+            manager.submitOrders([{ type: 'broadcast', reason: 'network' }]);
 
             const result = manager.fulfillPendingBroadcast();
 
@@ -282,7 +282,7 @@ describe('DeviceManager', () => {
 
         it('passes a stale reason through (broadcast applies the staleness gate itself)', () => {
             const broadcastStub = sinon.stub(manager as any, 'broadcast').returns(false);
-            manager['submitBroadcast']('stale');
+            manager.submitOrders([{ type: 'broadcast', reason: 'stale' }]);
 
             manager.fulfillPendingBroadcast();
 
@@ -291,7 +291,7 @@ describe('DeviceManager', () => {
 
         it('leaves except-listed reasons QUEUED instead of consuming them', () => {
             const broadcastStub = sinon.stub(manager as any, 'broadcast').returns(true);
-            manager['submitBroadcast']('stale');
+            manager.submitOrders([{ type: 'broadcast', reason: 'stale' }]);
 
             const result = manager.fulfillPendingBroadcast({ except: ['stale'] });
 
@@ -302,8 +302,8 @@ describe('DeviceManager', () => {
 
         it('when a real reason triggers execution, the whole set is cleared — excepted reasons included', () => {
             const broadcastStub = sinon.stub(manager as any, 'broadcast').returns(true);
-            manager['submitBroadcast']('stale');
-            manager['submitBroadcast']('network');
+            manager.submitOrders([{ type: 'broadcast', reason: 'stale' }]);
+            manager.submitOrders([{ type: 'broadcast', reason: 'network' }]);
 
             const result = manager.fulfillPendingBroadcast({ except: ['stale'] });
 
@@ -323,7 +323,7 @@ describe('DeviceManager', () => {
 
         it('is atomic: a second fulfillment finds the set empty', () => {
             const broadcastStub = sinon.stub(manager as any, 'broadcast').returns(true);
-            manager['submitBroadcast']('network');
+            manager.submitOrders([{ type: 'broadcast', reason: 'network' }]);
 
             expect(manager.fulfillPendingBroadcast()).to.be.true;
             expect(manager.fulfillPendingBroadcast()).to.be.false;
@@ -333,19 +333,19 @@ describe('DeviceManager', () => {
         it('passes the reconcile reason through (reconcile decides cache bypass itself)', () => {
             const reconcileStub = sinon.stub(manager as any, 'reconcile');
 
-            manager['submitReconcile']('config-changed');
+            manager.submitOrders([{ type: 'reconcile', reason: 'config-changed' }]);
             expect(manager.fulfillPendingReconcile()).to.be.true;
             expect(reconcileStub.calledOnceWith(['config-changed'])).to.be.true;
 
             reconcileStub.resetHistory();
-            manager['submitReconcile']('refresh-clicked');
+            manager.submitOrders([{ type: 'reconcile', reason: 'refresh-clicked' }]);
             expect(manager.fulfillPendingReconcile()).to.be.true;
             expect(reconcileStub.calledOnceWith(['refresh-clicked'])).to.be.true;
         });
 
         it('leaves an except-listed reconcile queued', () => {
             const reconcileStub = sinon.stub(manager as any, 'reconcile');
-            manager['submitReconcile']('stale');
+            manager.submitOrders([{ type: 'reconcile', reason: 'stale' }]);
 
             expect(manager.fulfillPendingReconcile({ except: ['stale'] })).to.be.false;
             expect(reconcileStub.called).to.be.false;
@@ -355,7 +355,7 @@ describe('DeviceManager', () => {
         it('fulfillPendingOrders fulfills both order types in one call', () => {
             const broadcastStub = sinon.stub(manager as any, 'broadcast').returns(true);
             const reconcileStub = sinon.stub(manager as any, 'reconcile');
-            manager.submitOrder('refresh-clicked');
+            manager.submitOrders([{ type: 'broadcast', reason: 'refresh-clicked' }, { type: 'reconcile', reason: 'refresh-clicked' }]);
 
             const result = manager.fulfillPendingOrders();
 
@@ -369,8 +369,8 @@ describe('DeviceManager', () => {
         it('fulfillPendingOrders passes the except list to both order types', () => {
             const broadcastStub = sinon.stub(manager as any, 'broadcast').returns(true);
             const reconcileStub = sinon.stub(manager as any, 'reconcile');
-            manager['submitBroadcast']('stale');
-            manager['submitReconcile']('stale');
+            manager.submitOrders([{ type: 'broadcast', reason: 'stale' }]);
+            manager.submitOrders([{ type: 'reconcile', reason: 'stale' }]);
 
             const result = manager.fulfillPendingOrders({ except: ['stale'] });
 
@@ -465,8 +465,8 @@ describe('DeviceManager', () => {
                 expect(manager.getPendingBroadcastReasons()).to.include('stale');
 
                 //consume the pending orders, stop monitoring, and verify no new stale orders arrive
-                manager['pendingBroadcastReasons'].clear();
-                manager['pendingReconcileReasons'].clear();
+                manager['orders'].take('broadcast');
+                manager['orders'].take('reconcile');
                 manager['deactivateMonitoring']();
 
                 clock.tick(manager['STALE_SCAN_THRESHOLD_MS'] * 2);
@@ -687,12 +687,12 @@ describe('DeviceManager', () => {
             const handler = sinon.spy();
             const unsubscribe = manager.on('broadcast-ordered', handler);
 
-            manager['submitBroadcast']('network');
+            manager.submitOrders([{ type: 'broadcast', reason: 'network' }]);
             expect(handler.calledOnce).to.be.true;
 
             unsubscribe();
 
-            manager['submitBroadcast']('network');
+            manager.submitOrders([{ type: 'broadcast', reason: 'network' }]);
             expect(handler.calledOnce).to.be.true; // Still just one call (unsubscribed)
         });
 

--- a/src/deviceDiscovery/DeviceManager.spec.ts
+++ b/src/deviceDiscovery/DeviceManager.spec.ts
@@ -223,13 +223,31 @@ describe('DeviceManager', () => {
             expect(manager.getPendingReconcileReasons()).to.include('config-changed');
         });
 
-        it('submitRefreshOrders submits a refresh-clicked broadcast AND reconcile', () => {
+        it('submitOrder submits both order types for most reasons', () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
-            manager.submitRefreshOrders();
+            manager.submitOrder('refresh-clicked');
 
             expect(manager.getPendingBroadcastReasons()).to.eql(['refresh-clicked']);
             expect(manager.getPendingReconcileReasons()).to.eql(['refresh-clicked']);
+        });
+
+        it('submitOrder submits only a reconcile for config-changed (a config edit cannot add network devices)', () => {
+            manager = new DeviceManager(vscode.context, mockGlobalStateManager);
+
+            manager.submitOrder('config-changed');
+
+            expect(manager.getPendingBroadcastReasons()).to.be.empty;
+            expect(manager.getPendingReconcileReasons()).to.eql(['config-changed']);
+        });
+
+        it('submitOrder submits only a broadcast for unhealthy-device (rescan, do not hammer every device)', () => {
+            manager = new DeviceManager(vscode.context, mockGlobalStateManager);
+
+            manager.submitOrder('unhealthy-device');
+
+            expect(manager.getPendingBroadcastReasons()).to.eql(['unhealthy-device']);
+            expect(manager.getPendingReconcileReasons()).to.be.empty;
         });
     });
 
@@ -337,7 +355,7 @@ describe('DeviceManager', () => {
         it('fulfillPendingOrders fulfills both order types in one call', () => {
             const broadcastStub = sinon.stub(manager as any, 'broadcast').returns(true);
             const reconcileStub = sinon.stub(manager as any, 'reconcile');
-            manager.submitRefreshOrders();
+            manager.submitOrder('refresh-clicked');
 
             const result = manager.fulfillPendingOrders();
 

--- a/src/deviceDiscovery/DeviceManager.spec.ts
+++ b/src/deviceDiscovery/DeviceManager.spec.ts
@@ -790,19 +790,19 @@ describe('DeviceManager', () => {
             expect(manager['timeSinceLastScan']).to.be.lessThan(100);
         });
 
-        it('bypasses the per-device cache only for refresh-clicked', () => {
+        it('demands maxAgeMs 0 (must fetch) only for refresh-clicked', () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
             const healthCheckAllDevicesSpy = sinon.stub(manager as any, 'healthCheckAllDevices').resolves();
 
             manager['reconcile'](['refresh-clicked']);
-            expect(healthCheckAllDevicesSpy.calledWith(true)).to.be.true;
+            expect(healthCheckAllDevicesSpy.calledWith(0)).to.be.true;
 
             manager['reconcile'](['config-changed']);
-            expect(healthCheckAllDevicesSpy.calledWith(false)).to.be.true;
+            expect(healthCheckAllDevicesSpy.calledWith(undefined)).to.be.true;
 
             manager['reconcile'](['network']);
-            expect(healthCheckAllDevicesSpy.lastCall.args[0]).to.equal(false);
+            expect(healthCheckAllDevicesSpy.lastCall.args[0]).to.equal(undefined);
         });
     });
 
@@ -897,14 +897,14 @@ describe('DeviceManager', () => {
             addDevice(device1);
             addDevice(device2);
 
-            const resolveDeviceSpy = sinon.stub(manager as any, 'resolveDevice').returns(Promise.resolve(true) as any);
+            const resolveDeviceSpy = sinon.stub(manager as any, 'ensureDeviceFresh').returns(Promise.resolve(true) as any);
 
             await (manager as any).healthCheckAllDevices(true);
 
             expect(resolveDeviceSpy.calledTwice).to.be.true;
         });
 
-        it('calls resolveDevice for all devices (caching happens in resolveDevice)', async () => {
+        it('calls ensureDeviceFresh for all devices (caching happens in ensureDeviceFresh)', async () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
             const device1 = createMockDevice({ serialNumber: 'device-1', ip: '192.168.1.101' });
@@ -912,33 +912,15 @@ describe('DeviceManager', () => {
             addDevice(device1);
             addDevice(device2);
 
-            const resolveDeviceSpy = sinon.stub(manager as any, 'resolveDevice').returns(Promise.resolve(true) as any);
+            const resolveDeviceSpy = sinon.stub(manager as any, 'ensureDeviceFresh').returns(Promise.resolve(true) as any);
 
-            await (manager as any).healthCheckAllDevices(false);
+            await (manager as any).healthCheckAllDevices();
 
-            // Both devices should have resolveDevice called (caching is internal to resolveDevice)
+            // Both devices should have ensureDeviceFresh called (caching is internal to ensureDeviceFresh)
             expect(resolveDeviceSpy.calledTwice).to.be.true;
         });
 
-        it('sets devices to pending before checking when the cache is trusted', async () => {
-            manager = new DeviceManager(vscode.context, mockGlobalStateManager);
-
-            const device = createMockDevice();
-            addDevice(device);
-
-            let stateWhenResolveCalled: string;
-            sinon.stub(manager as any, 'resolveDevice').callsFake(() => {
-                // Check the state from getAllDevices() during the health check
-                stateWhenResolveCalled = manager.getAllDevices()[0].deviceState;
-                return Promise.resolve(true);
-            });
-
-            await (manager as any).healthCheckAllDevices(false);
-
-            expect(stateWhenResolveCalled).to.equal('pending');
-        });
-
-        it('resolveDevice uses cached data when recently fetched', async () => {
+        it('ensureDeviceFresh uses cached data when recently fetched', async () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
             const device = createMockDevice();
@@ -953,19 +935,19 @@ describe('DeviceManager', () => {
             // Stub random delay to be instant
             sinon.stub(manager as any, 'randomDelay').resolves();
 
-            // Pre-populate the cache by calling resolveDevice once
-            await manager['resolveDevice'](device, { syntheticDelay: false });
+            // Pre-populate the cache by calling ensureDeviceFresh once
+            await manager['ensureDeviceFresh'](device, { syntheticDelay: false });
             expect(getDeviceInfoStub.calledOnce).to.be.true;
 
             // Now call healthCheckAllDevices - should use cached data
-            await (manager as any).healthCheckAllDevices(false);
+            await (manager as any).healthCheckAllDevices();
 
             // Still only one network call (second used cache)
             expect(getDeviceInfoStub.calledOnce).to.be.true;
         });
     });
 
-    describe('resolveDevice cooldown (cache trusted)', () => {
+    describe('ensureDeviceFresh cooldown (cache trusted)', () => {
         it('skips network fetch if within cooldown period (uses cached data)', async () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
@@ -982,11 +964,11 @@ describe('DeviceManager', () => {
             sinon.stub(manager as any, 'randomDelay').resolves();
 
             // First call - should fetch from network
-            await manager['resolveDevice'](device);
+            await manager['ensureDeviceFresh'](device);
             expect(getDeviceInfoStub.calledOnce).to.be.true;
 
             // Second call immediately - should use cache, no new network call
-            await manager['resolveDevice'](device);
+            await manager['ensureDeviceFresh'](device);
             expect(getDeviceInfoStub.calledOnce).to.be.true; // Still just one call
         });
 
@@ -1008,14 +990,14 @@ describe('DeviceManager', () => {
                 sinon.stub(manager as any, 'randomDelay').resolves();
 
                 // First call
-                await manager['resolveDevice'](device);
+                await manager['ensureDeviceFresh'](device);
                 expect(getDeviceInfoStub.calledOnce).to.be.true;
 
                 // Advance past cooldown (5 minutes)
                 clock.tick((5 * 60 * 1_000) + 1);
 
                 // Second call - cache expired, should fetch again
-                await manager['resolveDevice'](device);
+                await manager['ensureDeviceFresh'](device);
                 expect(getDeviceInfoStub.calledTwice).to.be.true;
             } finally {
                 clock.restore();
@@ -1233,7 +1215,7 @@ describe('DeviceManager', () => {
             });
             sinon.stub(rokuDeploy, 'getDeviceInfo').returns(healthPromise);
 
-            const checkPromise = manager['resolveDevice'](device, { bypassCache: true, syntheticDelay: false });
+            const checkPromise = manager['ensureDeviceFresh'](device, { maxAgeMs: 0, syntheticDelay: false });
 
             // Device should be pending during check
             expect(manager.getAllDevices()[0].deviceState).to.equal('pending');
@@ -1259,7 +1241,7 @@ describe('DeviceManager', () => {
 
             sinon.stub(rokuDeploy, 'getDeviceInfo').rejects(new Error('Device not responding'));
 
-            const result = await manager['resolveDevice'](device, { bypassCache: true, syntheticDelay: false });
+            const result = await manager['ensureDeviceFresh'](device, { maxAgeMs: 0, syntheticDelay: false });
 
             expect(result).to.be.false;
             expect(manager.getAllDevices().length).to.equal(0);
@@ -1293,7 +1275,7 @@ describe('DeviceManager', () => {
             randomDelayStub.onCall(1).resolves();
 
             // Start the first (soon-to-be-stale) check.
-            const firstCheck = manager['resolveDevice'](device);
+            const firstCheck = manager['ensureDeviceFresh'](device);
 
             // Let it reach (and suspend on) its synthetic delay. By that point its own network
             // call has already failed and cleared out of the in-flight map, which is what lets
@@ -1303,8 +1285,9 @@ describe('DeviceManager', () => {
             }
             expect(randomDelayStub.callCount).to.equal(1);
 
-            // Start a second, newer check for the SAME device while the first is still suspended.
-            await manager['resolveDevice'](device);
+            // Start a second, newer check for the SAME device while the first is still
+            // suspended (maxAgeMs 0 so the freshness guard doesn't answer from pending state)
+            await manager['ensureDeviceFresh'](device, { maxAgeMs: 0 });
 
             // The newer check's result (online) is applied.
             expect(manager.getAllDevices()[0].deviceState).to.equal('online');
@@ -1334,7 +1317,7 @@ describe('DeviceManager', () => {
 
             // First health check fails (device offline)
             sinon.stub(rokuDeploy, 'getDeviceInfo').rejects(new Error('Device not responding'));
-            await manager['resolveDevice'](device, { bypassCache: true, syntheticDelay: false });
+            await manager['ensureDeviceFresh'](device, { maxAgeMs: 0, syntheticDelay: false });
 
             // Cache should still exist with device info preserved for offline display
             const cached = mockGlobalStateManager.getCachedDevice('device-123');
@@ -1808,7 +1791,7 @@ describe('DeviceManager', () => {
 
             manager['discoveredDevices'].push({ ip: '192.168.1.100' });
             const startStub = sinon.stub(manager['networkChangeMonitor'], 'start');
-            const resolveStub = sinon.stub(manager as any, 'resolveDevice').returns(Promise.resolve(true) as any);
+            const resolveStub = sinon.stub(manager as any, 'ensureDeviceFresh').returns(Promise.resolve(true) as any);
 
             manager['notifyFocusGained']();
 
@@ -1826,7 +1809,8 @@ describe('DeviceManager', () => {
 
         it('an unknown responder with cache in the 5min–8h dead zone hydrates on the next read', async () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
-            const resolveStub = sinon.stub(manager as any, 'resolveDevice').returns(Promise.resolve(true) as any);
+            const rokuDeployStub = sinon.stub(rokuDeploy, 'getDeviceInfo').resolves({ 'serial-number': 'SCAN70' } as any);
+            sinon.stub(manager as any, 'randomDelay').resolves();
 
             //cache aged past the 5-min freshness check (so the responder lands `unknown`) but
             //younger than the 8-hour hydration threshold — the exact gap that used to strand
@@ -1837,19 +1821,19 @@ describe('DeviceManager', () => {
                 createdAt: Date.now() - (10 * 60 * 1_000)
             });
             manager['finder'].emit('found', '192.168.1.70', { serialNumber: 'SCAN70' });
-            expect(manager.getDevice({ ip: '192.168.1.70' }).deviceState).to.equal('unknown');
 
             //the emit above makes a visible view re-read; simulate that read
             manager.getAllDevices();
             await flush();
 
-            expect(resolveStub.calledOnce).to.be.true;
-            expect(resolveStub.firstCall.args[0]).to.include({ ip: '192.168.1.70' });
+            expect(rokuDeployStub.calledOnce).to.be.true;
+            expect(manager.getDevice({ ip: '192.168.1.70' }).deviceState).to.equal('online');
         });
 
-        it('repeated M-SEARCH answers do not double-hydrate (in-flight + cooldown guards)', async () => {
+        it('repeated M-SEARCH answers do not double-hydrate (freshness guard)', async () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
-            const resolveStub = sinon.stub(manager as any, 'resolveDevice').returns(Promise.resolve(true) as any);
+            const rokuDeployStub = sinon.stub(rokuDeploy, 'getDeviceInfo').resolves({ 'serial-number': 'SCAN70' } as any);
+            sinon.stub(manager as any, 'randomDelay').resolves();
 
             manager['finder'].emit('found', '192.168.1.70', { serialNumber: 'SCAN70' });
             manager.getAllDevices();
@@ -1858,7 +1842,7 @@ describe('DeviceManager', () => {
             manager.getAllDevices();
             await flush();
 
-            expect(resolveStub.calledOnce).to.be.true;
+            expect(rokuDeployStub.calledOnce).to.be.true;
         });
     });
 
@@ -1871,7 +1855,7 @@ describe('DeviceManager', () => {
 
         it('queues a background resolve for an unknown device with no cached deviceInfo', async () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
-            const resolveStub = sinon.stub(manager as any, 'resolveDevice').returns(Promise.resolve(true) as any);
+            const resolveStub = sinon.stub(manager as any, 'ensureDeviceFresh').returns(Promise.resolve(true) as any);
 
             //a bare {ip, serial} entry, e.g. from ssdp:alive — no cache seeded
             manager['discoveredDevices'].push({ ip: '192.168.1.50', serialNumber: 'no-cache-1' });
@@ -1881,27 +1865,28 @@ describe('DeviceManager', () => {
             await flush();
 
             expect(resolveStub.calledOnce).to.be.true;
-            expect(resolveStub.firstCall.args[0]).to.deep.equal({ ip: '192.168.1.50', serialNumber: 'no-cache-1' });
+            expect(resolveStub.firstCall.args[0]).to.include({ ip: '192.168.1.50', serialNumber: 'no-cache-1' });
             //silent background refresh: no synthetic delay, cache trusted
-            expect(resolveStub.firstCall.args[1]).to.eql({ syntheticDelay: false });
+            expect(resolveStub.firstCall.args[1]).to.eql({ maxAgeMs: manager['HYDRATION_MAX_CACHE_AGE_MS'], syntheticDelay: false });
         });
 
-        it('does not hydrate a device whose cache is fresh', async () => {
+        it('does not fetch for a device whose knowledge is fresh', async () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
-            const resolveStub = sinon.stub(manager as any, 'resolveDevice').returns(Promise.resolve(true) as any);
+            const rokuDeployStub = sinon.stub(rokuDeploy, 'getDeviceInfo');
 
             const device = createMockDevice({ serialNumber: 'fresh-1', ip: '192.168.1.51', deviceInfo: { 'default-device-name': 'Roku Express' } });
             addDevice(device);
+            manager['lastCheckedByIp'].set('192.168.1.51', Date.now());
 
             manager.getAllDevices();
             await flush();
 
-            expect(resolveStub.called).to.be.false;
+            expect(rokuDeployStub.called).to.be.false;
         });
 
         it('hydrates a device whose cache is older than 8 hours, regardless of state', async () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
-            const resolveStub = sinon.stub(manager as any, 'resolveDevice').returns(Promise.resolve(true) as any);
+            const resolveStub = sinon.stub(manager as any, 'ensureDeviceFresh').returns(Promise.resolve(true) as any);
 
             const device = createMockDevice({ serialNumber: 'old-1', ip: '192.168.1.52', deviceInfo: { 'default-device-name': 'Roku Express' } });
             addDevice(device);
@@ -1918,39 +1903,42 @@ describe('DeviceManager', () => {
             expect(resolveStub.calledOnce).to.be.true;
         });
 
-        it('does not re-queue a pending device (converges instead of looping)', async () => {
+        it('does not re-check a pending device (a check is already in flight)', async () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
-            const resolveStub = sinon.stub(manager as any, 'resolveDevice').returns(Promise.resolve(true) as any);
+            const rokuDeployStub = sinon.stub(rokuDeploy, 'getDeviceInfo');
 
             manager['discoveredDevices'].push({ ip: '192.168.1.53', serialNumber: 'pending-1' });
             manager['setDeviceState']({ ip: '192.168.1.53', serialNumber: 'pending-1' }, 'pending');
+            //a pending device always carries a fresh attempt stamp (set right before pending)
+            manager['lastCheckedByIp'].set('192.168.1.53', Date.now());
 
             manager.getAllDevices();
             await flush();
 
-            expect(resolveStub.called).to.be.false;
+            expect(rokuDeployStub.called).to.be.false;
         });
 
         it('rate-limits repeated attempts per IP (a failing device is not hammered on every read)', async () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
-            const resolveStub = sinon.stub(manager as any, 'resolveDevice').returns(Promise.resolve(false) as any);
+            const rokuDeployStub = sinon.stub(rokuDeploy, 'getDeviceInfo').rejects(new Error('Unreachable'));
 
-            manager['discoveredDevices'].push({ ip: '192.168.1.54', serialNumber: 'flaky-1' });
-            manager['setDeviceState']({ ip: '192.168.1.54', serialNumber: 'flaky-1' }, 'unknown');
+            //configured so the failing device persists in the list instead of being removed
+            addConfiguredDevice(createMockDevice({ serialNumber: 'flaky-1', ip: '192.168.1.54', isConfigured: true, deviceState: 'unknown' }));
 
-            //views re-read on every devices-changed — simulate several rapid reads
+            //views re-read on every devices-changed - simulate several rapid reads
             manager.getAllDevices();
             await flush();
             manager.getAllDevices();
             manager.getAllDevices();
             await flush();
 
-            expect(resolveStub.calledOnce).to.be.true;
+            //the failed attempt counts as knowledge, so re-reads stay off the network
+            expect(rokuDeployStub.calledOnce).to.be.true;
         });
 
         it('getDevice (single lookup) also triggers hydration', async () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
-            const resolveStub = sinon.stub(manager as any, 'resolveDevice').returns(Promise.resolve(true) as any);
+            const resolveStub = sinon.stub(manager as any, 'ensureDeviceFresh').returns(Promise.resolve(true) as any);
 
             manager['discoveredDevices'].push({ ip: '192.168.1.55', serialNumber: 'single-1' });
             manager['setDeviceState']({ ip: '192.168.1.55', serialNumber: 'single-1' }, 'unknown');
@@ -1977,7 +1965,7 @@ describe('DeviceManager', () => {
             await manager.getDeviceInfo('192.168.1.100', 8060);
             await manager.getDeviceInfo('192.168.1.100', 8060);
 
-            // fetchDeviceInfo always makes network calls (caching is in resolveDevice)
+            // fetchDeviceInfo always makes network calls (caching is in ensureDeviceFresh)
             expect(getDeviceInfoStub.callCount).to.equal(2);
         });
     });
@@ -2030,7 +2018,7 @@ describe('DeviceManager', () => {
         });
     });
 
-    describe('resolveDevice caching', () => {
+    describe('ensureDeviceFresh caching', () => {
         it('only makes one network call for rapid successive requests', async () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
@@ -2046,9 +2034,9 @@ describe('DeviceManager', () => {
             // Stub random delay to be instant
             sinon.stub(manager as any, 'randomDelay').resolves();
 
-            // Call twice in rapid succession via resolveDevice
-            await manager['resolveDevice'](device, { syntheticDelay: false });
-            await manager['resolveDevice'](device, { syntheticDelay: false });
+            // Call twice in rapid succession via ensureDeviceFresh
+            await manager['ensureDeviceFresh'](device, { syntheticDelay: false });
+            await manager['ensureDeviceFresh'](device, { syntheticDelay: false });
 
             // Should only have made one actual network call (second uses cache)
             expect(getDeviceInfoStub.callCount).to.equal(1);
@@ -2072,14 +2060,14 @@ describe('DeviceManager', () => {
                 sinon.stub(manager as any, 'randomDelay').resolves();
 
                 // First call - should hit network
-                await manager['resolveDevice'](device, { syntheticDelay: false });
+                await manager['ensureDeviceFresh'](device, { syntheticDelay: false });
                 expect(getDeviceInfoStub.callCount).to.equal(1);
 
                 // Advance past TTL (5 minutes)
                 clock.tick((5 * 60 * 1_000) + 1);
 
                 // Second call - cache expired, should hit network again
-                await manager['resolveDevice'](device, { syntheticDelay: false });
+                await manager['ensureDeviceFresh'](device, { syntheticDelay: false });
                 expect(getDeviceInfoStub.callCount).to.equal(2);
             } finally {
                 clock.restore();
@@ -2117,15 +2105,15 @@ describe('DeviceManager', () => {
             sinon.stub(manager as any, 'randomDelay').resolves();
 
             // Call for two different devices
-            await manager['resolveDevice'](device1, { syntheticDelay: false });
-            await manager['resolveDevice'](device2, { syntheticDelay: false });
+            await manager['ensureDeviceFresh'](device1, { syntheticDelay: false });
+            await manager['ensureDeviceFresh'](device2, { syntheticDelay: false });
 
             // Should make two network calls (different serials)
             expect(getDeviceInfoStub.callCount).to.equal(2);
 
             // Calling same devices again should use cache (keyed by serial)
-            await manager['resolveDevice'](device1, { syntheticDelay: false });
-            await manager['resolveDevice'](device2, { syntheticDelay: false });
+            await manager['ensureDeviceFresh'](device1, { syntheticDelay: false });
+            await manager['ensureDeviceFresh'](device2, { syntheticDelay: false });
 
             // Still only two calls (cache hit)
             expect(getDeviceInfoStub.callCount).to.equal(2);
@@ -2136,6 +2124,7 @@ describe('DeviceManager', () => {
 
             // Device with unknown serial (only IP known) - like a newly discovered device
             const deviceIpOnly = { ip: '192.168.1.100' };
+            manager['discoveredDevices'].push({ ip: '192.168.1.100' });
 
             const getDeviceInfoStub = sinon.stub(rokuDeploy, 'getDeviceInfo').resolves({
                 'device-id': 'device-123',
@@ -2147,11 +2136,11 @@ describe('DeviceManager', () => {
             sinon.stub(manager as any, 'randomDelay').resolves();
 
             // First call - fetches from network (no cache, no IP→serial mapping)
-            await manager['resolveDevice'](deviceIpOnly, { syntheticDelay: false });
+            await manager['ensureDeviceFresh'](deviceIpOnly, { syntheticDelay: false });
             expect(getDeviceInfoStub.callCount).to.equal(1);
 
             // Now we have IP→serial mapping. Second call should use cache.
-            await manager['resolveDevice'](deviceIpOnly, { syntheticDelay: false });
+            await manager['ensureDeviceFresh'](deviceIpOnly, { syntheticDelay: false });
             expect(getDeviceInfoStub.callCount).to.equal(1);
 
             // Simulate network change
@@ -2161,7 +2150,7 @@ describe('DeviceManager', () => {
 
             // On new network, IP→serial mapping is cleared.
             // Resolving by IP alone should refetch since we can't look up the serial.
-            await manager['resolveDevice'](deviceIpOnly, { syntheticDelay: false });
+            await manager['ensureDeviceFresh'](deviceIpOnly, { syntheticDelay: false });
             expect(getDeviceInfoStub.callCount).to.equal(2);
         });
 
@@ -2182,11 +2171,11 @@ describe('DeviceManager', () => {
             sinon.stub(manager as any, 'randomDelay').resolves();
 
             // First call - fetches from network
-            await manager['resolveDevice'](device, { syntheticDelay: false });
+            await manager['ensureDeviceFresh'](device, { syntheticDelay: false });
             expect(getDeviceInfoStub.callCount).to.equal(1);
 
             // Verify cache is working
-            await manager['resolveDevice'](device, { syntheticDelay: false });
+            await manager['ensureDeviceFresh'](device, { syntheticDelay: false });
             expect(getDeviceInfoStub.callCount).to.equal(1);
 
             // Simulate network change
@@ -2201,7 +2190,7 @@ describe('DeviceManager', () => {
             // Even though device info cache is keyed by serial, we validate that the
             // cached IP matches the device's current IP. After network change, this
             // validation fails so we must refetch to confirm the device is still at this IP.
-            await manager['resolveDevice'](device, { syntheticDelay: false });
+            await manager['ensureDeviceFresh'](device, { syntheticDelay: false });
             expect(getDeviceInfoStub.callCount).to.equal(2); // Refetches after network change
         });
     });
@@ -2604,7 +2593,7 @@ describe('DeviceManager', () => {
                 // Stub to simulate network failure
                 sinon.stub(rokuDeploy, 'getDeviceInfo').rejects(new Error('Device not responding'));
 
-                const result = await manager['resolveDevice'](device, { bypassCache: true, syntheticDelay: false });
+                const result = await manager['ensureDeviceFresh'](device, { maxAgeMs: 0, syntheticDelay: false });
 
                 expect(result).to.be.false;
                 expect(manager.getAllDevices().length).to.equal(1);
@@ -2628,7 +2617,7 @@ describe('DeviceManager', () => {
                 // Stub to simulate network failure
                 sinon.stub(rokuDeploy, 'getDeviceInfo').rejects(new Error('Device not responding'));
 
-                const result = await manager['resolveDevice'](device, { bypassCache: true, syntheticDelay: false });
+                const result = await manager['ensureDeviceFresh'](device, { maxAgeMs: 0, syntheticDelay: false });
 
                 expect(result).to.be.false;
                 expect(manager.getAllDevices().length).to.equal(1);
@@ -2652,7 +2641,7 @@ describe('DeviceManager', () => {
                 // Stub to simulate network failure
                 sinon.stub(rokuDeploy, 'getDeviceInfo').rejects(new Error('Device not responding'));
 
-                const result = await manager['resolveDevice'](device, { bypassCache: true, syntheticDelay: false });
+                const result = await manager['ensureDeviceFresh'](device, { maxAgeMs: 0, syntheticDelay: false });
 
                 expect(result).to.be.false;
                 expect(manager.getAllDevices().length).to.equal(0);
@@ -2685,7 +2674,7 @@ describe('DeviceManager', () => {
 
                 sinon.stub(rokuDeploy, 'getDeviceInfo').rejects(new Error('Offline'));
 
-                await manager['resolveDevice'](device, { bypassCache: true, syntheticDelay: false });
+                await manager['ensureDeviceFresh'](device, { maxAgeMs: 0, syntheticDelay: false });
 
                 // Device kept (configured) but not discovered
                 expect(manager.getAllDevices().length).to.equal(1);
@@ -2708,7 +2697,7 @@ describe('DeviceManager', () => {
 
                 sinon.stub(rokuDeploy, 'getDeviceInfo').rejects(new Error('Offline'));
 
-                await manager['resolveDevice'](device, { bypassCache: true, syntheticDelay: false });
+                await manager['ensureDeviceFresh'](device, { maxAgeMs: 0, syntheticDelay: false });
 
                 // Device removed (not configured, not discovered)
                 expect(manager.getAllDevices().length).to.equal(0);
@@ -2888,7 +2877,7 @@ describe('DeviceManager', () => {
                     'default-device-name': 'Roku Express'
                 } as any);
 
-                await manager['resolveDevice']({ ip: '192.168.1.100' });
+                await manager['ensureDeviceFresh']({ ip: '192.168.1.100' });
 
                 const devices = manager.getAllDevices();
                 expect(devices.length).to.equal(2);
@@ -2965,6 +2954,9 @@ describe('DeviceManager', () => {
 
                 manager['loadLastSeenDevices']();
 
+                //record fresh knowledge so the read below doesn't queue a hydration for the fixture
+                manager['lastCheckedByIp'].set('192.168.1.101', Date.now());
+
                 // Only configured device should remain (state unchanged - reset happens in network change handler)
                 expect(manager.getAllDevices().length).to.equal(1);
                 const serial = manager.getAllDevices()[0].serialNumber;
@@ -2973,7 +2965,7 @@ describe('DeviceManager', () => {
             });
         });
 
-        describe('resolveDevice', () => {
+        describe('ensureDeviceFresh', () => {
             it('preserves isConfigured after successful resolution', async () => {
                 manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
@@ -2991,7 +2983,7 @@ describe('DeviceManager', () => {
                     'default-device-name': 'Roku Express'
                 } as any);
 
-                await manager['resolveDevice'](device);
+                await manager['ensureDeviceFresh'](device);
 
                 expect(manager.getAllDevices()[0].deviceState).to.equal('online');
                 expect(manager.getAllDevices()[0].isConfigured).to.equal(true);
@@ -3056,11 +3048,11 @@ describe('DeviceManager', () => {
                     sinon.stub(manager as any, 'randomDelay').resolves();
 
                     // Perform health check to populate cache
-                    await manager['resolveDevice'](device);
+                    await manager['ensureDeviceFresh'](device);
                     expect(getDeviceInfoStub.calledOnce).to.be.true;
 
                     // Second call should use cache (no new network call)
-                    await manager['resolveDevice'](device);
+                    await manager['ensureDeviceFresh'](device);
                     expect(getDeviceInfoStub.calledOnce).to.be.true; // Still just one call
 
                     // Clear cache (clears globalStateManager.deviceCache and IP→serial mappings)
@@ -3070,22 +3062,22 @@ describe('DeviceManager', () => {
                     addDevice(device);
 
                     // Now health check should hit network again (cache was cleared)
-                    await manager['resolveDevice'](device);
+                    await manager['ensureDeviceFresh'](device);
                     expect(getDeviceInfoStub.calledTwice).to.be.true;
                 });
 
-                it('clears resolveDeviceSequence map', () => {
+                it('clears deviceCheckSequence map', () => {
                     manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
                     const device = createMockDevice();
 
                     // Populate sequence map
-                    manager['resolveDeviceSequence'].set(device.ip, 5);
-                    expect(manager['resolveDeviceSequence'].get(device.ip)).to.equal(5);
+                    manager['deviceCheckSequence'].set(device.ip, 5);
+                    expect(manager['deviceCheckSequence'].get(device.ip)).to.equal(5);
 
                     manager.clearAllCache();
 
-                    expect(manager['resolveDeviceSequence'].has(device.ip)).to.be.false;
+                    expect(manager['deviceCheckSequence'].has(device.ip)).to.be.false;
                 });
             });
 
@@ -3131,17 +3123,17 @@ describe('DeviceManager', () => {
                     manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
                     const device = createMockDevice();
-                    const resolveDeviceSpy = sinon.stub(manager as any, 'resolveDevice').returns(Promise.resolve(true));
+                    const resolveDeviceSpy = sinon.stub(manager as any, 'ensureDeviceFresh').returns(Promise.resolve(true));
 
                     // First health check
-                    await manager['resolveDevice'](device);
+                    await manager['ensureDeviceFresh'](device);
                     expect(resolveDeviceSpy.calledOnce).to.be.true;
 
                     // Clear cache (should clear cooldown)
                     manager.clearAllCache();
 
                     // Health check should run immediately (no cooldown)
-                    await manager['resolveDevice'](device);
+                    await manager['ensureDeviceFresh'](device);
                     expect(resolveDeviceSpy.calledTwice).to.be.true;
                 });
 
@@ -3155,15 +3147,15 @@ describe('DeviceManager', () => {
                     const healthCheckPromise = new Promise<boolean>((resolve) => {
                         resolvePromise = resolve;
                     });
-                    sinon.stub(manager as any, 'resolveDevice').returns(healthCheckPromise);
+                    sinon.stub(manager as any, 'ensureDeviceFresh').returns(healthCheckPromise);
 
-                    const healthCheckCall = manager['resolveDevice'](device);
+                    const healthCheckCall = manager['ensureDeviceFresh'](device);
 
                     // Clear cache while health check is in flight
                     manager.clearAllCache();
 
                     // Sequence should be cleared
-                    expect(manager['resolveDeviceSequence'].has(device.ip)).to.be.false;
+                    expect(manager['deviceCheckSequence'].has(device.ip)).to.be.false;
 
                     // Complete the health check
                     if (resolvePromise) {
@@ -3401,7 +3393,7 @@ describe('DeviceManager', () => {
                 expect(result?.key).to.equal('i:192.168.1.100');
 
                 // Simulate device resolution - update discovered entry with serial
-                // (this is what resolveDevice does when it successfully fetches deviceInfo)
+                // (this is what ensureDeviceFresh does when it successfully fetches deviceInfo)
                 manager['setDiscoveredDevice']('192.168.1.100', 'NEWSERIAL');
 
                 // Device now has serial-based key
@@ -3482,7 +3474,7 @@ describe('DeviceManager', () => {
             });
         });
 
-        describe('resolveDevice', () => {
+        describe('ensureDeviceFresh', () => {
             it('removes old entry when same serial resolved at new IP', async () => {
                 manager = new DeviceManager(vscode.context, mockGlobalStateManager);
                 sinon.stub(manager as any, 'randomDelay').resolves();
@@ -3514,7 +3506,7 @@ describe('DeviceManager', () => {
                     'developer-enabled': 'true'
                 } as any);
 
-                await manager['resolveDevice'](newDevice);
+                await manager['ensureDeviceFresh'](newDevice);
 
                 // Should have exactly one device at new IP
                 expect(manager.getAllDevices().length).to.equal(1);
@@ -3555,7 +3547,7 @@ describe('DeviceManager', () => {
                     'developer-enabled': 'true'
                 } as any);
 
-                await manager['resolveDevice'](newDevice);
+                await manager['ensureDeviceFresh'](newDevice);
 
                 // Should preserve configured properties
                 expect(manager.getAllDevices().length).to.equal(1);
@@ -3598,7 +3590,7 @@ describe('DeviceManager', () => {
                     'developer-enabled': 'true'
                 } as any);
 
-                await manager['resolveDevice'](device2);
+                await manager['ensureDeviceFresh'](device2);
 
                 // Should have exactly one device - the one that was just resolved
                 expect(manager.getAllDevices().length).to.equal(1);
@@ -3699,8 +3691,8 @@ describe('DeviceManager', () => {
 
                 // Resolve both concurrently (simulating race condition)
                 await Promise.all([
-                    manager['resolveDevice']({ ip: '192.168.1.100', serialNumber: 'XYZ', isDiscovered: false } as any),
-                    manager['resolveDevice']({ ip: '192.168.1.50', serialNumber: 'XYZ', isDiscovered: true } as any)
+                    manager['ensureDeviceFresh']({ ip: '192.168.1.100', serialNumber: 'XYZ', isDiscovered: false } as any),
+                    manager['ensureDeviceFresh']({ ip: '192.168.1.50', serialNumber: 'XYZ', isDiscovered: true } as any)
                 ]);
 
                 // Should have ONE merged device showing ONLINE (discovered state wins)
@@ -3740,8 +3732,8 @@ describe('DeviceManager', () => {
                 } as any);
 
                 // Resolve in OPPOSITE order: wrong IP first, then correct IP
-                await manager['resolveDevice']({ ip: '192.168.1.100', serialNumber: 'XYZ', isDiscovered: false } as any);
-                await manager['resolveDevice']({ ip: '192.168.1.50', serialNumber: 'XYZ', isDiscovered: true } as any);
+                await manager['ensureDeviceFresh']({ ip: '192.168.1.100', serialNumber: 'XYZ', isDiscovered: false } as any);
+                await manager['ensureDeviceFresh']({ ip: '192.168.1.50', serialNumber: 'XYZ', isDiscovered: true } as any);
 
                 // Should still show online
                 expect(manager.getAllDevices().length).to.equal(1);
@@ -3756,8 +3748,8 @@ describe('DeviceManager', () => {
                     'default-device-name': 'Roku Express'
                 } as any);
 
-                await manager['resolveDevice']({ ip: '192.168.1.50', serialNumber: 'XYZ', isDiscovered: true } as any);
-                await manager['resolveDevice']({ ip: '192.168.1.100', serialNumber: 'XYZ', isDiscovered: false } as any);
+                await manager['ensureDeviceFresh']({ ip: '192.168.1.50', serialNumber: 'XYZ', isDiscovered: true } as any);
+                await manager['ensureDeviceFresh']({ ip: '192.168.1.100', serialNumber: 'XYZ', isDiscovered: false } as any);
 
                 // Should still show online (discovered state wins, not affected by configured failure)
                 expect(manager.getAllDevices().length).to.equal(1);
@@ -3876,7 +3868,7 @@ describe('DeviceManager', () => {
         });
 
         describe('config reload on mismatch', () => {
-            it('reloads configured devices when resolveDevice detects serial mismatch', async () => {
+            it('reloads configured devices when ensureDeviceFresh detects serial mismatch', async () => {
                 manager = new DeviceManager(vscode.context, mockGlobalStateManager);
                 sinon.stub(manager as any, 'randomDelay').resolves();
 
@@ -3902,7 +3894,7 @@ describe('DeviceManager', () => {
                 addDiscoveredDevice(device);
 
                 // Resolve device
-                await manager['resolveDevice'](device);
+                await manager['ensureDeviceFresh'](device);
 
                 // Should have called loadConfiguredDevices
                 expect(loadConfigSpy.calledOnce).to.be.true;
@@ -3942,7 +3934,7 @@ describe('DeviceManager', () => {
                 } as any);
 
                 // Resolve device
-                await manager['resolveDevice']({ ip: '192.168.1.100' });
+                await manager['ensureDeviceFresh']({ ip: '192.168.1.100' });
 
                 // Should NOT have called loadConfiguredDevices
                 expect(loadConfigSpy.called).to.be.false;
@@ -3995,7 +3987,7 @@ describe('DeviceManager', () => {
                 addDiscoveredDevice(device);
 
                 // Resolve the discovered device - this will find XYZ serial
-                await manager['resolveDevice'](device);
+                await manager['ensureDeviceFresh'](device);
 
                 // Get the devices
                 const devices = manager.getAllDevices();

--- a/src/deviceDiscovery/DeviceManager.spec.ts
+++ b/src/deviceDiscovery/DeviceManager.spec.ts
@@ -393,6 +393,28 @@ describe('DeviceManager', () => {
             expect(isHealthy).to.be.true;
             expect(healthCheckStub.calledOnceWith(device, true, false)).to.be.true;
         });
+
+        it('resolves an encoded tree key itself', async () => {
+            manager = new DeviceManager(vscode.context, mockGlobalStateManager);
+            manager['discoveredDevices'].push({ ip: '192.168.1.60', serialNumber: 'KEY60', state: 'online' } as any);
+            const resolveStub = sinon.stub(manager as any, 'resolveDevice').returns(Promise.resolve(true) as any);
+
+            const isHealthy = await manager.deviceEngaged('s:KEY60');
+
+            expect(isHealthy).to.be.true;
+            expect(resolveStub.calledOnce).to.be.true;
+            expect(resolveStub.firstCall.args[0]).to.include({ serialNumber: 'KEY60' });
+        });
+
+        it('reports an unknown key as unhealthy without hitting the network', async () => {
+            manager = new DeviceManager(vscode.context, mockGlobalStateManager);
+            const resolveStub = sinon.stub(manager as any, 'resolveDevice');
+
+            const isHealthy = await manager.deviceEngaged('s:GONE');
+
+            expect(isHealthy).to.be.false;
+            expect(resolveStub.called).to.be.false;
+        });
     });
 
     describe('stale timers', () => {

--- a/src/deviceDiscovery/DeviceManager.spec.ts
+++ b/src/deviceDiscovery/DeviceManager.spec.ts
@@ -273,16 +273,18 @@ describe('DeviceManager', () => {
             expect(manager.getPendingBroadcastReasons()).to.include('stale');
         });
 
-        it('takes the real reasons and leaves the except-listed ones queued', () => {
+        it('when a real reason triggers execution, the whole set is cleared — excepted reasons included', () => {
             const broadcastStub = sinon.stub(manager as any, 'broadcast').returns(true);
             manager.submitBroadcast('stale');
             manager.submitBroadcast('network');
 
             const result = manager.fulfillPendingBroadcast({ except: ['stale'] });
 
+            //the scan satisfies the stale want too, so it rides along instead of staying queued
             expect(result).to.be.true;
-            expect(broadcastStub.calledOnceWith(['network'])).to.be.true;
-            expect(manager.getPendingBroadcastReasons()).to.eql(['stale']);
+            expect(broadcastStub.calledOnce).to.be.true;
+            expect(broadcastStub.firstCall.args[0]).to.have.members(['stale', 'network']);
+            expect(manager.getPendingBroadcastReasons()).to.be.empty;
         });
 
         it('returns false and does nothing when no order is pending', () => {

--- a/src/deviceDiscovery/DeviceManager.spec.ts
+++ b/src/deviceDiscovery/DeviceManager.spec.ts
@@ -1790,6 +1790,21 @@ describe('DeviceManager', () => {
         });
     });
 
+    describe('peekDevice (internal read)', () => {
+        it('reads a device without scheduling any background work', async () => {
+            manager = new DeviceManager(vscode.context, mockGlobalStateManager);
+            const ensureStub = sinon.stub(manager as any, 'ensureDeviceFresh');
+            manager['discoveredDevices'].push({ ip: '192.168.1.90', serialNumber: 'PEEK90' });
+            manager['setDeviceState']({ ip: '192.168.1.90', serialNumber: 'PEEK90' }, 'unknown');
+
+            const device = manager['peekDevice']({ ip: '192.168.1.90' });
+
+            //an unknown device read through getDevice would schedule a refresh; peek must not
+            expect(device.serialNumber).to.equal('PEEK90');
+            expect(ensureStub.called).to.be.false;
+        });
+    });
+
     describe('background refresh on read', () => {
         function flush(): Promise<void> {
             return new Promise(resolve => {

--- a/src/deviceDiscovery/DeviceManager.spec.ts
+++ b/src/deviceDiscovery/DeviceManager.spec.ts
@@ -166,30 +166,167 @@ describe('DeviceManager', () => {
         sinon.restore();
     });
 
-    describe('setScanNeeded', () => {
-        it('emits event when scanNeeded is false', () => {
+    describe('orders (submit + pending slots)', () => {
+        it('submitBroadcast fills the pending slot and emits broadcast-ordered with the reason', () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
             const eventSpy = sinon.spy();
-            manager.on('scanNeeded-changed', eventSpy);
+            manager.on('broadcast-ordered', eventSpy);
 
-            manager['setScanNeeded']();
+            manager.submitBroadcast('network');
 
             expect(eventSpy.calledOnce).to.be.true;
+            expect(eventSpy.firstCall.args[0].reason).to.equal('network');
+            expect(manager.getPendingBroadcast()).to.include({ reason: 'network' });
         });
 
-        it('does not emit event when scanNeeded is already true', () => {
+        it('submitReconcile fills the pending slot and emits reconcile-ordered with the reason', () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
-            manager['setScanNeeded'](); // Set to true first
 
             const eventSpy = sinon.spy();
-            manager.on('scanNeeded-changed', eventSpy);
+            manager.on('reconcile-ordered', eventSpy);
 
-            manager['setScanNeeded'](); // Set to true again
+            manager.submitReconcile('config-changed');
 
-            expect(eventSpy.called).to.be.false;
+            expect(eventSpy.calledOnce).to.be.true;
+            expect(eventSpy.firstCall.args[0].reason).to.equal('config-changed');
+            expect(manager.getPendingReconcile()).to.include({ reason: 'config-changed' });
         });
 
+        it('a newer order replaces the pending slot', () => {
+            manager = new DeviceManager(vscode.context, mockGlobalStateManager);
+
+            manager.submitBroadcast('sleep');
+            manager.submitBroadcast('network');
+
+            expect(manager.getPendingBroadcast()).to.include({ reason: 'network' });
+        });
+
+        it('a stale order never downgrades a pending real trigger', () => {
+            manager = new DeviceManager(vscode.context, mockGlobalStateManager);
+
+            manager.submitBroadcast('network');
+            manager.submitBroadcast('stale');
+
+            //the real trigger keeps the slot (but the stale event still fired for live views)
+            expect(manager.getPendingBroadcast()).to.include({ reason: 'network' });
+        });
+
+        it('broadcast and reconcile pending slots are independent', () => {
+            manager = new DeviceManager(vscode.context, mockGlobalStateManager);
+
+            manager.submitBroadcast('network');
+            manager.submitReconcile('config-changed');
+
+            expect(manager.getPendingBroadcast()).to.include({ reason: 'network' });
+            expect(manager.getPendingReconcile()).to.include({ reason: 'config-changed' });
+        });
+    });
+
+    describe('fulfillPendingBroadcast / fulfillPendingReconcile', () => {
+        beforeEach(() => {
+            manager = new DeviceManager(vscode.context, mockGlobalStateManager);
+        });
+
+        it('consumes and executes a pending broadcast, forced for non-stale reasons', () => {
+            const broadcastStub = sinon.stub(manager, 'broadcast').returns(true);
+            manager.submitBroadcast('network');
+
+            const result = manager.fulfillPendingBroadcast();
+
+            expect(result).to.be.true;
+            expect(broadcastStub.calledOnceWith(true)).to.be.true;
+            expect(manager.getPendingBroadcast()).to.be.null;
+        });
+
+        it('executes a stale broadcast without forcing (staleness-gated)', () => {
+            const broadcastStub = sinon.stub(manager, 'broadcast').returns(false);
+            manager.submitBroadcast('stale');
+
+            manager.fulfillPendingBroadcast();
+
+            expect(broadcastStub.calledOnceWith(false)).to.be.true;
+        });
+
+        it('leaves except-listed reasons QUEUED instead of consuming them', () => {
+            const broadcastStub = sinon.stub(manager, 'broadcast').returns(true);
+            manager.submitBroadcast('stale');
+
+            const result = manager.fulfillPendingBroadcast({ except: ['stale'] });
+
+            expect(result).to.be.false;
+            expect(broadcastStub.called).to.be.false;
+            expect(manager.getPendingBroadcast()).to.include({ reason: 'stale' });
+        });
+
+        it('returns false and does nothing when no order is pending', () => {
+            const broadcastStub = sinon.stub(manager, 'broadcast').returns(true);
+
+            expect(manager.fulfillPendingBroadcast()).to.be.false;
+            expect(broadcastStub.called).to.be.false;
+        });
+
+        it('is atomic: a second fulfillment finds the slot empty', () => {
+            const broadcastStub = sinon.stub(manager, 'broadcast').returns(true);
+            manager.submitBroadcast('network');
+
+            expect(manager.fulfillPendingBroadcast()).to.be.true;
+            expect(manager.fulfillPendingBroadcast()).to.be.false;
+            expect(broadcastStub.calledOnce).to.be.true;
+        });
+
+        it('forces a reconcile only for refresh-clicked', () => {
+            const reconcileStub = sinon.stub(manager, 'reconcile');
+
+            manager.submitReconcile('config-changed');
+            expect(manager.fulfillPendingReconcile()).to.be.true;
+            expect(reconcileStub.calledOnceWith(false)).to.be.true;
+
+            reconcileStub.resetHistory();
+            manager.submitReconcile('refresh-clicked');
+            expect(manager.fulfillPendingReconcile()).to.be.true;
+            expect(reconcileStub.calledOnceWith(true)).to.be.true;
+        });
+
+        it('leaves an except-listed reconcile queued', () => {
+            const reconcileStub = sinon.stub(manager, 'reconcile');
+            manager.submitReconcile('stale');
+
+            expect(manager.fulfillPendingReconcile({ except: ['stale'] })).to.be.false;
+            expect(reconcileStub.called).to.be.false;
+            expect(manager.getPendingReconcile()).to.include({ reason: 'stale' });
+        });
+    });
+
+    describe('stale timers', () => {
+        it('activateMonitoring starts the stale order timers, deactivateMonitoring stops them', async () => {
+            const clock = sinon.useFakeTimers();
+            try {
+                manager = new DeviceManager(vscode.context, mockGlobalStateManager);
+                sinon.stub(manager['finder'], 'start').resolves();
+                sinon.stub(manager['networkChangeMonitor'], 'start');
+                sinon.stub(manager['networkChangeMonitor'], 'stop');
+
+                await manager['activateMonitoring']();
+
+                clock.tick(manager['STALE_RECONCILE_INTERVAL_MS']);
+                expect(manager.getPendingReconcile()).to.include({ reason: 'stale' });
+
+                clock.tick(manager['STALE_SCAN_THRESHOLD_MS']);
+                expect(manager.getPendingBroadcast()).to.include({ reason: 'stale' });
+
+                //consume the pending orders, stop monitoring, and verify no new stale orders arrive
+                manager['pendingBroadcast'] = null;
+                manager['pendingReconcile'] = null;
+                manager['deactivateMonitoring']();
+
+                clock.tick(manager['STALE_SCAN_THRESHOLD_MS'] * 2);
+                expect(manager.getPendingBroadcast()).to.be.null;
+                expect(manager.getPendingReconcile()).to.be.null;
+            } finally {
+                clock.restore();
+            }
+        });
     });
 
     describe('timeSinceLastScan', () => {
@@ -198,12 +335,12 @@ describe('DeviceManager', () => {
             expect(manager['timeSinceLastScan']).to.equal(Infinity);
         });
 
-        it('returns elapsed time after refresh', () => {
+        it('returns elapsed time after a broadcast', () => {
             const clock = sinon.useFakeTimers();
             try {
                 manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
-                manager.refresh(true);
+                manager.broadcast(true);
 
                 clock.tick(5_000);
 
@@ -399,16 +536,14 @@ describe('DeviceManager', () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
             const handler = sinon.spy();
-            const unsubscribe = manager.on('scanNeeded-changed', handler);
+            const unsubscribe = manager.on('broadcast-ordered', handler);
 
-            manager['setScanNeeded']();
+            manager.submitBroadcast('network');
             expect(handler.calledOnce).to.be.true;
 
             unsubscribe();
 
-            // Reset via refresh and try again
-            manager.refresh(true);
-            manager['setScanNeeded']();
+            manager.submitBroadcast('network');
             expect(handler.calledOnce).to.be.true; // Still just one call (unsubscribed)
         });
 
@@ -416,7 +551,7 @@ describe('DeviceManager', () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
             const disposables: any[] = [];
-            manager.on('scanNeeded-changed', () => { }, disposables);
+            manager.on('broadcast-ordered', () => { }, disposables);
 
             expect(disposables.length).to.equal(1);
             expect(disposables[0]).to.have.property('dispose');
@@ -491,34 +626,15 @@ describe('DeviceManager', () => {
         });
     });
 
-    describe('refresh', () => {
-        it('resets scanNeeded flag (allows event to fire again)', () => {
-            manager = new DeviceManager(vscode.context, mockGlobalStateManager);
-
-            const eventSpy = sinon.spy();
-            manager.on('scanNeeded-changed', eventSpy);
-
-            manager['setScanNeeded']();
-            expect(eventSpy.calledOnce).to.be.true;
-
-            // Before refresh, calling setScanNeeded again should not emit
-            manager['setScanNeeded']();
-            expect(eventSpy.calledOnce).to.be.true;
-
-            // After refresh, the flag is reset so event should fire again
-            manager.refresh(true);
-            manager['setScanNeeded']();
-            expect(eventSpy.calledTwice).to.be.true;
-        });
-
-        it('sets lastScanDate', () => {
+    describe('reconcile', () => {
+        it('sets lastScanDate via broadcast', () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
             expect(manager['timeSinceLastScan']).to.equal(Infinity);
 
-            manager.refresh(true);
+            manager.broadcast(true);
 
-            // After refresh, timeSinceLastScan should be very small (just happened)
+            // After a broadcast, timeSinceLastScan should be very small (just happened)
             expect(manager['timeSinceLastScan']).to.be.lessThan(100);
         });
 
@@ -527,25 +643,25 @@ describe('DeviceManager', () => {
 
             const healthCheckAllDevicesSpy = sinon.stub(manager as any, 'healthCheckAllDevices').resolves();
 
-            manager.refresh(true);
+            manager.reconcile(true);
             expect(healthCheckAllDevicesSpy.calledWith(true)).to.be.true;
 
-            manager.refresh(false);
+            manager.reconcile(false);
             expect(healthCheckAllDevicesSpy.calledWith(false)).to.be.true;
 
-            manager.refresh(); // defaults to false
+            manager.reconcile(); // defaults to false
             expect(healthCheckAllDevicesSpy.calledWith(false)).to.be.true;
         });
     });
 
-    describe('scan', () => {
+    describe('broadcast', () => {
         it('triggers discovery without health checking', () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
             const discoverAllSpy = sinon.spy(manager as any, 'discoverAll');
             const healthCheckAllDevicesSpy = sinon.spy(manager as any, 'healthCheckAllDevices');
 
-            manager.scan(true);
+            manager.broadcast(true);
 
             expect(discoverAllSpy.calledOnce).to.be.true;
             expect(healthCheckAllDevicesSpy.called).to.be.false;
@@ -557,7 +673,7 @@ describe('DeviceManager', () => {
 
             const discoverAllSpy = sinon.spy(manager as any, 'discoverAll');
 
-            const result = manager.scan(false);
+            const result = manager.broadcast(false);
 
             expect(result).to.be.false;
             expect(discoverAllSpy.called).to.be.false;
@@ -569,10 +685,18 @@ describe('DeviceManager', () => {
 
             const discoverAllSpy = sinon.spy(manager as any, 'discoverAll');
 
-            const result = manager.scan(true);
+            const result = manager.broadcast(true);
 
             expect(result).to.be.true;
             expect(discoverAllSpy.calledOnce).to.be.true;
+        });
+
+        it('is staleness-gated when not forced: no scan when the last scan is recent', () => {
+            manager = new DeviceManager(vscode.context, mockGlobalStateManager);
+            sinon.stub(manager['finder'], 'scan');
+
+            expect(manager.broadcast(true)).to.be.true; //sets lastScanDate
+            expect(manager.broadcast(false)).to.be.false; //fresh — gate closed
         });
 
         it('emits scan-started event', () => {
@@ -583,7 +707,7 @@ describe('DeviceManager', () => {
                 const scanStartedSpy = sinon.spy();
                 manager.on('scan-started', scanStartedSpy);
 
-                manager.scan(true);
+                manager.broadcast(true);
 
                 expect(scanStartedSpy.calledOnce).to.be.true;
             } finally {
@@ -760,7 +884,7 @@ describe('DeviceManager', () => {
                 const scanStartedSpy = sinon.spy();
                 manager.on('scan-started', scanStartedSpy);
 
-                manager.refresh(true);
+                manager.broadcast(true);
 
                 expect(scanStartedSpy.calledOnce).to.be.true;
             } finally {
@@ -776,7 +900,7 @@ describe('DeviceManager', () => {
                 const scanEndedSpy = sinon.spy();
                 manager.on('scan-ended', scanEndedSpy);
 
-                manager.refresh(true);
+                manager.broadcast(true);
 
                 // Not ended yet - neither timer has fired
                 expect(scanEndedSpy.called).to.be.false;
@@ -801,11 +925,11 @@ describe('DeviceManager', () => {
                 const scanStartedSpy = sinon.spy();
                 manager.on('scan-started', scanStartedSpy);
 
-                manager.refresh(true);
+                manager.broadcast(true);
                 expect(scanStartedSpy.calledOnce).to.be.true;
 
                 // Try to start another scan while one is in progress
-                manager.refresh(true);
+                manager.broadcast(true);
                 expect(scanStartedSpy.calledOnce).to.be.true; // Still just one call
             } finally {
                 clock.restore();
@@ -822,7 +946,7 @@ describe('DeviceManager', () => {
                 manager.on('scan-started', scanStartedSpy);
                 manager.on('scan-ended', scanEndedSpy);
 
-                manager.refresh(true);
+                manager.broadcast(true);
                 expect(scanStartedSpy.calledOnce).to.be.true;
 
                 // Complete the scan
@@ -830,7 +954,7 @@ describe('DeviceManager', () => {
                 expect(scanEndedSpy.calledOnce).to.be.true;
 
                 // Now can start a new scan
-                manager.refresh(true);
+                manager.broadcast(true);
                 expect(scanStartedSpy.calledTwice).to.be.true;
             } finally {
                 clock.restore();
@@ -1077,8 +1201,8 @@ describe('DeviceManager', () => {
             const device = createMockDevice({ serialNumber: 'device-123' });
             addDevice(device);
 
-            // Stub refresh to prevent cascade of health checks
-            sinon.stub(manager, 'refresh');
+            // Suppress the unhealthy-device order noise from failed checks
+            sinon.stub(manager as any, 'submitUnhealthyDeviceBroadcast');
 
             let resolveFetch: (value: any) => void;
             const getDeviceInfoStub = sinon.stub(rokuDeploy, 'getDeviceInfo').returns(new Promise<any>(resolve => {
@@ -1111,8 +1235,8 @@ describe('DeviceManager', () => {
             addDevice(device1);
             addDevice(device2);
 
-            // Stub refresh to prevent cascade of health checks
-            sinon.stub(manager, 'refresh');
+            // Suppress the unhealthy-device order noise from failed checks
+            sinon.stub(manager as any, 'submitUnhealthyDeviceBroadcast');
 
             let resolveDevice1: (value: any) => void;
             let resolveDevice2: (value: any) => void;
@@ -2050,10 +2174,8 @@ describe('DeviceManager', () => {
             expect(manager['discoveredDevices'].length).to.equal(0);
         });
 
-        it('calls setScanNeeded when network changes', () => {
+        it('submits broadcast + reconcile orders when the network changes', () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
-
-            const setScanNeededSpy = sinon.spy(manager as any, 'setScanNeeded');
 
             // Change the network hash
             (NetworkChangeMonitorModule.getNetworkHash as sinon.SinonStub).returns('new-network-hash');
@@ -2061,7 +2183,8 @@ describe('DeviceManager', () => {
             // Trigger the network change callback directly
             manager['networkChangeMonitor']['onNetworkChanged']();
 
-            expect(setScanNeededSpy.calledOnce).to.be.true;
+            expect(manager.getPendingBroadcast()).to.include({ reason: 'network' });
+            expect(manager.getPendingReconcile()).to.include({ reason: 'network' });
         });
 
         it('clears discovered devices when network changes', () => {
@@ -2396,7 +2519,7 @@ describe('DeviceManager', () => {
             it('marks configured device as offline when health check fails and cache exists', async () => {
                 manager = new DeviceManager(vscode.context, mockGlobalStateManager);
                 sinon.stub(manager as any, 'randomDelay').resolves();
-                sinon.stub(manager as any, 'refresh').resolves();
+                sinon.stub(manager as any, 'submitUnhealthyDeviceBroadcast');
 
                 const device = createMockDevice({
                     serialNumber: 'device-123',
@@ -2424,7 +2547,7 @@ describe('DeviceManager', () => {
             it('marks configured device as offline when health check fails and no cache exists', async () => {
                 manager = new DeviceManager(vscode.context, mockGlobalStateManager);
                 sinon.stub(manager as any, 'randomDelay').resolves();
-                sinon.stub(manager as any, 'refresh').resolves();
+                sinon.stub(manager as any, 'submitUnhealthyDeviceBroadcast');
 
                 const device = createMockDevice({
                     serialNumber: 'device-123',
@@ -2451,7 +2574,7 @@ describe('DeviceManager', () => {
             it('removes discovered-only device when health check fails', async () => {
                 manager = new DeviceManager(vscode.context, mockGlobalStateManager);
                 sinon.stub(manager as any, 'randomDelay').resolves();
-                sinon.stub(manager as any, 'refresh').resolves();
+                sinon.stub(manager as any, 'submitUnhealthyDeviceBroadcast');
 
                 const device = createMockDevice({
                     serialNumber: 'device-123',
@@ -2483,7 +2606,7 @@ describe('DeviceManager', () => {
             it('sets isDiscovered false when health check fails on configured device', async () => {
                 manager = new DeviceManager(vscode.context, mockGlobalStateManager);
                 sinon.stub(manager as any, 'randomDelay').resolves();
-                sinon.stub(manager as any, 'refresh').resolves();
+                sinon.stub(manager as any, 'submitUnhealthyDeviceBroadcast');
 
                 const device = createMockDevice({
                     ip: '192.168.1.100',
@@ -2506,7 +2629,7 @@ describe('DeviceManager', () => {
             it('removes discovered-only device when health check fails', async () => {
                 manager = new DeviceManager(vscode.context, mockGlobalStateManager);
                 sinon.stub(manager as any, 'randomDelay').resolves();
-                sinon.stub(manager as any, 'refresh').resolves();
+                sinon.stub(manager as any, 'submitUnhealthyDeviceBroadcast');
 
                 const device = createMockDevice({
                     ip: '192.168.1.100',
@@ -3476,7 +3599,7 @@ describe('DeviceManager', () => {
             it('shows online when configured at wrong IP and discovered at correct IP resolve concurrently', async () => {
                 manager = new DeviceManager(vscode.context, mockGlobalStateManager);
                 sinon.stub(manager as any, 'randomDelay').resolves();
-                sinon.stub(manager as any, 'refresh').resolves();
+                sinon.stub(manager as any, 'submitUnhealthyDeviceBroadcast');
 
                 // Configured device XYZ at wrong IP (192.168.1.100)
                 const configuredDevice = createMockDevice({
@@ -3524,7 +3647,7 @@ describe('DeviceManager', () => {
             it('shows online regardless of which concurrent health check completes first', async () => {
                 manager = new DeviceManager(vscode.context, mockGlobalStateManager);
                 sinon.stub(manager as any, 'randomDelay').resolves();
-                sinon.stub(manager as any, 'refresh').resolves();
+                sinon.stub(manager as any, 'submitUnhealthyDeviceBroadcast');
 
                 // Same setup: configured at wrong IP, discovered at correct IP
                 addDevice(createMockDevice({

--- a/src/deviceDiscovery/DeviceManager.spec.ts
+++ b/src/deviceDiscovery/DeviceManager.spec.ts
@@ -382,13 +382,13 @@ describe('DeviceManager', () => {
         });
     });
 
-    describe('deviceEngaged', () => {
+    describe('healthCheckDevice / getDeviceInfo', () => {
         it('freshens the device with the cache trust window bypassed and reports health', async () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
             manager['discoveredDevices'].push({ ip: '192.168.1.50', serialNumber: 'ENG50', state: 'online' } as any);
             const resolveStub = sinon.stub(manager as any, 'resolveDevice').returns(Promise.resolve(true) as any);
 
-            const isHealthy = await manager.deviceEngaged({ ip: '192.168.1.50' });
+            const isHealthy = await manager.healthCheckDevice({ ip: '192.168.1.50' });
 
             expect(isHealthy).to.be.true;
             //engagement policy: no synthetic delay, cache trust window bypassed
@@ -401,7 +401,7 @@ describe('DeviceManager', () => {
             manager['discoveredDevices'].push({ ip: '192.168.1.60', serialNumber: 'KEY60', state: 'online' } as any);
             const resolveStub = sinon.stub(manager as any, 'resolveDevice').returns(Promise.resolve(true) as any);
 
-            const isHealthy = await manager.deviceEngaged('s:KEY60');
+            const isHealthy = await manager.healthCheckDevice('s:KEY60');
 
             expect(isHealthy).to.be.true;
             expect(resolveStub.calledOnce).to.be.true;
@@ -412,10 +412,38 @@ describe('DeviceManager', () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
             const resolveStub = sinon.stub(manager as any, 'resolveDevice');
 
-            const isHealthy = await manager.deviceEngaged('s:GONE');
+            const isHealthy = await manager.healthCheckDevice('s:GONE');
 
             expect(isHealthy).to.be.false;
             expect(resolveStub.called).to.be.false;
+        });
+
+        it('getDeviceInfo does the same fetch but returns the freshly-cached device info', async () => {
+            manager = new DeviceManager(vscode.context, mockGlobalStateManager);
+            manager['discoveredDevices'].push({ ip: '192.168.1.50', serialNumber: 'ENG50', state: 'online' } as any);
+            mockGlobalStateManager.setCachedDevice('ENG50', {
+                serialNumber: 'ENG50',
+                deviceInfo: { 'serial-number': 'ENG50', 'user-device-name': 'living room' },
+                createdAt: Date.now()
+            });
+            const resolveStub = sinon.stub(manager as any, 'resolveDevice').returns(Promise.resolve(true) as any);
+
+            const deviceInfo = await manager.getDeviceInfo({ ip: '192.168.1.50' });
+
+            expect(resolveStub.calledOnce).to.be.true;
+            expect(resolveStub.firstCall.args[1]).to.eql({ bypassCache: true, syntheticDelay: false });
+            expect(deviceInfo).to.include({ 'user-device-name': 'living room' });
+        });
+
+        it('getDeviceInfo returns undefined for an unreachable device', async () => {
+            manager = new DeviceManager(vscode.context, mockGlobalStateManager);
+            manager['discoveredDevices'].push({ ip: '192.168.1.50', serialNumber: 'ENG50', state: 'online' } as any);
+            sinon.stub(manager as any, 'resolveDevice').returns(Promise.resolve(false) as any);
+            sinon.stub(manager as any, 'submitUnhealthyDeviceBroadcast');
+
+            const deviceInfo = await manager.getDeviceInfo({ ip: '192.168.1.50' });
+
+            expect(deviceInfo).to.be.undefined;
         });
     });
 
@@ -991,7 +1019,7 @@ describe('DeviceManager', () => {
             }
         });
 
-        it('deviceEngaged always fetches regardless of cooldown (engagement bypasses the cache)', async () => {
+        it('healthCheckDevice always fetches regardless of cooldown (single-device checks bypass the cache)', async () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
             const device = createMockDevice();
@@ -1007,11 +1035,11 @@ describe('DeviceManager', () => {
             sinon.stub(manager as any, 'randomDelay').resolves();
 
             // First engagement
-            await manager.deviceEngaged(device);
+            await manager.healthCheckDevice(device);
             expect(getDeviceInfoStub.calledOnce).to.be.true;
 
             // Second engagement immediately - should still fetch
-            await manager.deviceEngaged(device);
+            await manager.healthCheckDevice(device);
             expect(getDeviceInfoStub.calledTwice).to.be.true;
         });
     });
@@ -1187,7 +1215,7 @@ describe('DeviceManager', () => {
         });
     });
 
-    describe('deviceEngaged (single-device check)', () => {
+    describe('healthCheckDevice (single-device check)', () => {
         it('sets device to pending during health check', async () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
             (vscode.window as any).state = { focused: true };
@@ -1202,7 +1230,7 @@ describe('DeviceManager', () => {
             });
             sinon.stub(rokuDeploy, 'getDeviceInfo').returns(healthPromise);
 
-            const checkPromise = manager.deviceEngaged(device);
+            const checkPromise = manager.healthCheckDevice(device);
 
             // Device should be pending during check
             expect(manager.getAllDevices()[0].deviceState).to.equal('pending');
@@ -1228,7 +1256,7 @@ describe('DeviceManager', () => {
 
             sinon.stub(rokuDeploy, 'getDeviceInfo').rejects(new Error('Device not responding'));
 
-            const result = await manager.deviceEngaged(device);
+            const result = await manager.healthCheckDevice(device);
 
             expect(result).to.be.false;
             expect(manager.getAllDevices().length).to.equal(0);
@@ -1303,7 +1331,7 @@ describe('DeviceManager', () => {
 
             // First health check fails (device offline)
             sinon.stub(rokuDeploy, 'getDeviceInfo').rejects(new Error('Device not responding'));
-            await manager.deviceEngaged(device);
+            await manager.healthCheckDevice(device);
 
             // Cache should still exist with device info preserved for offline display
             const cached = mockGlobalStateManager.getCachedDevice('device-123');
@@ -1326,7 +1354,7 @@ describe('DeviceManager', () => {
                 'default-device-name': 'Roku Express'
             });
 
-            const result = await manager.deviceEngaged(device);
+            const result = await manager.healthCheckDevice(device);
 
             expect(result).to.be.true;
         });
@@ -1350,8 +1378,8 @@ describe('DeviceManager', () => {
                 resolveFetch = resolve;
             }) as any);
 
-            const first = manager.deviceEngaged(device);
-            const second = manager.deviceEngaged(device);
+            const first = manager.healthCheckDevice(device);
+            const second = manager.healthCheckDevice(device);
 
             resolveFetch({
                 'device-id': 'device-123',
@@ -1393,8 +1421,8 @@ describe('DeviceManager', () => {
             getDeviceInfoStub.onSecondCall().returns(device2Promise);
 
             // Start health checks for both devices
-            const result1 = manager.deviceEngaged(device1);
-            const result2 = manager.deviceEngaged(device2);
+            const result1 = manager.healthCheckDevice(device1);
+            const result2 = manager.healthCheckDevice(device2);
 
             // Device 2 completes first (healthy)
             resolveDevice2({
@@ -2551,7 +2579,7 @@ describe('DeviceManager', () => {
             });
         });
 
-        describe('deviceEngaged with failed network calls', () => {
+        describe('healthCheckDevice with failed network calls', () => {
             it('marks configured device as offline when health check fails and cache exists', async () => {
                 manager = new DeviceManager(vscode.context, mockGlobalStateManager);
                 sinon.stub(manager as any, 'randomDelay').resolves();
@@ -2573,7 +2601,7 @@ describe('DeviceManager', () => {
                 // Stub to simulate network failure
                 sinon.stub(rokuDeploy, 'getDeviceInfo').rejects(new Error('Device not responding'));
 
-                const result = await manager.deviceEngaged(device);
+                const result = await manager.healthCheckDevice(device);
 
                 expect(result).to.be.false;
                 expect(manager.getAllDevices().length).to.equal(1);
@@ -2597,7 +2625,7 @@ describe('DeviceManager', () => {
                 // Stub to simulate network failure
                 sinon.stub(rokuDeploy, 'getDeviceInfo').rejects(new Error('Device not responding'));
 
-                const result = await manager.deviceEngaged(device);
+                const result = await manager.healthCheckDevice(device);
 
                 expect(result).to.be.false;
                 expect(manager.getAllDevices().length).to.equal(1);
@@ -2621,7 +2649,7 @@ describe('DeviceManager', () => {
                 // Stub to simulate network failure
                 sinon.stub(rokuDeploy, 'getDeviceInfo').rejects(new Error('Device not responding'));
 
-                const result = await manager.deviceEngaged(device);
+                const result = await manager.healthCheckDevice(device);
 
                 expect(result).to.be.false;
                 expect(manager.getAllDevices().length).to.equal(0);
@@ -2654,7 +2682,7 @@ describe('DeviceManager', () => {
 
                 sinon.stub(rokuDeploy, 'getDeviceInfo').rejects(new Error('Offline'));
 
-                await manager.deviceEngaged(device);
+                await manager.healthCheckDevice(device);
 
                 // Device kept (configured) but not discovered
                 expect(manager.getAllDevices().length).to.equal(1);
@@ -2677,7 +2705,7 @@ describe('DeviceManager', () => {
 
                 sinon.stub(rokuDeploy, 'getDeviceInfo').rejects(new Error('Offline'));
 
-                await manager.deviceEngaged(device);
+                await manager.healthCheckDevice(device);
 
                 // Device removed (not configured, not discovered)
                 expect(manager.getAllDevices().length).to.equal(0);

--- a/src/deviceDiscovery/DeviceManager.spec.ts
+++ b/src/deviceDiscovery/DeviceManager.spec.ts
@@ -386,65 +386,66 @@ describe('DeviceManager', () => {
     });
 
     describe('healthCheckDevice / getDeviceInfo', () => {
-        it('freshens the device with the cache trust window bypassed and reports health', async () => {
+        it('returns true when the device answers the direct info request', async () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
             manager['discoveredDevices'].push({ ip: '192.168.1.50', serialNumber: 'ENG50', state: 'online' } as any);
-            const resolveStub = sinon.stub(manager as any, 'resolveDevice').returns(Promise.resolve(true) as any);
+            const getDeviceInfoStub = sinon.stub(manager, 'getDeviceInfo').resolves({ 'serial-number': 'ENG50' } as any);
 
             const isHealthy = await manager.healthCheckDevice({ ip: '192.168.1.50' });
 
             expect(isHealthy).to.be.true;
-            //engagement policy: no synthetic delay, cache trust window bypassed
-            expect(resolveStub.calledOnce).to.be.true;
-            expect(resolveStub.firstCall.args[1]).to.eql({ bypassCache: true, syntheticDelay: false });
+            expect(getDeviceInfoStub.calledOnceWith({ ip: '192.168.1.50' })).to.be.true;
         });
 
-        it('resolves an encoded tree key itself', async () => {
+        it('returns false when the device does not answer', async () => {
+            manager = new DeviceManager(vscode.context, mockGlobalStateManager);
+            manager['discoveredDevices'].push({ ip: '192.168.1.50', serialNumber: 'ENG50', state: 'online' } as any);
+            sinon.stub(manager, 'getDeviceInfo').resolves(undefined);
+
+            expect(await manager.healthCheckDevice({ ip: '192.168.1.50' })).to.be.false;
+        });
+
+        it('getDeviceInfo resolves an encoded tree key down to the device ip', async () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
             manager['discoveredDevices'].push({ ip: '192.168.1.60', serialNumber: 'KEY60', state: 'online' } as any);
-            const resolveStub = sinon.stub(manager as any, 'resolveDevice').returns(Promise.resolve(true) as any);
+            const rokuDeployStub = sinon.stub(rokuDeploy, 'getDeviceInfo').resolves({ 'serial-number': 'KEY60' } as any);
 
-            const isHealthy = await manager.healthCheckDevice('s:KEY60');
+            const deviceInfo = await manager.getDeviceInfo('s:KEY60');
 
-            expect(isHealthy).to.be.true;
-            expect(resolveStub.calledOnce).to.be.true;
-            expect(resolveStub.firstCall.args[0]).to.include({ serialNumber: 'KEY60' });
+            expect(deviceInfo).to.include({ 'serial-number': 'KEY60' });
+            expect(rokuDeployStub.firstCall.args[0]).to.include({ host: '192.168.1.60' });
         });
 
         it('reports an unknown key as unhealthy without hitting the network', async () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
-            const resolveStub = sinon.stub(manager as any, 'resolveDevice');
+            const rokuDeployStub = sinon.stub(rokuDeploy, 'getDeviceInfo');
 
             const isHealthy = await manager.healthCheckDevice('s:GONE');
 
             expect(isHealthy).to.be.false;
-            expect(resolveStub.called).to.be.false;
+            expect(rokuDeployStub.called).to.be.false;
         });
 
-        it('getDeviceInfo does the same fetch but returns the freshly-cached device info', async () => {
+        it('getDeviceInfo always hits the device directly and returns its info', async () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
-            manager['discoveredDevices'].push({ ip: '192.168.1.50', serialNumber: 'ENG50', state: 'online' } as any);
-            mockGlobalStateManager.setCachedDevice('ENG50', {
-                serialNumber: 'ENG50',
-                deviceInfo: { 'serial-number': 'ENG50', 'user-device-name': 'living room' },
-                createdAt: Date.now()
-            });
-            const resolveStub = sinon.stub(manager as any, 'resolveDevice').returns(Promise.resolve(true) as any);
+            const getDeviceInfoStub = sinon.stub(rokuDeploy, 'getDeviceInfo').resolves({
+                'serial-number': 'RAW50',
+                'user-device-name': 'living room'
+            } as any);
 
-            const deviceInfo = await manager.getDeviceInfo({ ip: '192.168.1.50' });
+            const deviceInfo = await manager.getDeviceInfo('192.168.1.50');
 
-            expect(resolveStub.calledOnce).to.be.true;
-            expect(resolveStub.firstCall.args[1]).to.eql({ bypassCache: true, syntheticDelay: false });
+            expect(getDeviceInfoStub.calledOnce).to.be.true;
             expect(deviceInfo).to.include({ 'user-device-name': 'living room' });
+            //success caches the result for future getDevice reads
+            expect(mockGlobalStateManager.getCachedDevice('RAW50')).to.exist;
         });
 
         it('getDeviceInfo returns undefined for an unreachable device', async () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
-            manager['discoveredDevices'].push({ ip: '192.168.1.50', serialNumber: 'ENG50', state: 'online' } as any);
-            sinon.stub(manager as any, 'resolveDevice').returns(Promise.resolve(false) as any);
-            sinon.stub(manager as any, 'submitUnhealthyDeviceBroadcast');
+            sinon.stub(rokuDeploy, 'getDeviceInfo').rejects(new Error('Unreachable'));
 
-            const deviceInfo = await manager.getDeviceInfo({ ip: '192.168.1.50' });
+            const deviceInfo = await manager.getDeviceInfo('192.168.1.50');
 
             expect(deviceInfo).to.be.undefined;
         });
@@ -1232,7 +1233,7 @@ describe('DeviceManager', () => {
             });
             sinon.stub(rokuDeploy, 'getDeviceInfo').returns(healthPromise);
 
-            const checkPromise = manager.healthCheckDevice(device);
+            const checkPromise = manager['resolveDevice'](device, { bypassCache: true, syntheticDelay: false });
 
             // Device should be pending during check
             expect(manager.getAllDevices()[0].deviceState).to.equal('pending');
@@ -1258,7 +1259,7 @@ describe('DeviceManager', () => {
 
             sinon.stub(rokuDeploy, 'getDeviceInfo').rejects(new Error('Device not responding'));
 
-            const result = await manager.healthCheckDevice(device);
+            const result = await manager['resolveDevice'](device, { bypassCache: true, syntheticDelay: false });
 
             expect(result).to.be.false;
             expect(manager.getAllDevices().length).to.equal(0);
@@ -1333,7 +1334,7 @@ describe('DeviceManager', () => {
 
             // First health check fails (device offline)
             sinon.stub(rokuDeploy, 'getDeviceInfo').rejects(new Error('Device not responding'));
-            await manager.healthCheckDevice(device);
+            await manager['resolveDevice'](device, { bypassCache: true, syntheticDelay: false });
 
             // Cache should still exist with device info preserved for offline display
             const cached = mockGlobalStateManager.getCachedDevice('device-123');
@@ -1973,15 +1974,15 @@ describe('DeviceManager', () => {
 
             // Call twice SEQUENTIALLY - both should hit network (in-flight sharing only applies
             // to concurrent callers; a settled request is not reused)
-            await manager['fetchDeviceInfo']('192.168.1.100', 8060);
-            await manager['fetchDeviceInfo']('192.168.1.100', 8060);
+            await manager.getDeviceInfo('192.168.1.100', 8060);
+            await manager.getDeviceInfo('192.168.1.100', 8060);
 
             // fetchDeviceInfo always makes network calls (caching is in resolveDevice)
             expect(getDeviceInfoStub.callCount).to.equal(2);
         });
     });
 
-    describe('fetchDeviceInfo in-flight de-dupe (the design doc\'s "de-dupe rule")', () => {
+    describe('getDeviceInfo in-flight de-dupe (the design doc\'s "de-dupe rule")', () => {
         it('shares a single HTTP request between concurrent callers for the same ip:port', async () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
@@ -1991,8 +1992,8 @@ describe('DeviceManager', () => {
             }) as any);
 
             //e.g. the broadcast response and the reconcile racing on the same device
-            const first = manager['fetchDeviceInfo']('192.168.1.10', 8060);
-            const second = manager['fetchDeviceInfo']('192.168.1.10', 8060);
+            const first = manager.getDeviceInfo('192.168.1.10', 8060);
+            const second = manager.getDeviceInfo('192.168.1.10', 8060);
 
             resolveFetch({ 'serial-number': 'shared-1' });
             const [firstResult, secondResult] = await Promise.all([first, second]);
@@ -2007,8 +2008,8 @@ describe('DeviceManager', () => {
             const getDeviceInfoStub = sinon.stub(rokuDeploy, 'getDeviceInfo').resolves({ 'serial-number': 'x' } as any);
 
             await Promise.all([
-                manager['fetchDeviceInfo']('192.168.1.10', 8060),
-                manager['fetchDeviceInfo']('192.168.1.11', 8060)
+                manager.getDeviceInfo('192.168.1.10', 8060),
+                manager.getDeviceInfo('192.168.1.11', 8060)
             ]);
 
             expect(getDeviceInfoStub.calledTwice).to.be.true;
@@ -2019,8 +2020,8 @@ describe('DeviceManager', () => {
             const getDeviceInfoStub = sinon.stub(rokuDeploy, 'getDeviceInfo').rejects(new Error('Unreachable'));
 
             const [first, second] = await Promise.all([
-                manager['fetchDeviceInfo']('192.168.1.10', 8060),
-                manager['fetchDeviceInfo']('192.168.1.10', 8060)
+                manager.getDeviceInfo('192.168.1.10', 8060),
+                manager.getDeviceInfo('192.168.1.10', 8060)
             ]);
 
             expect(getDeviceInfoStub.calledOnce).to.be.true;
@@ -2603,7 +2604,7 @@ describe('DeviceManager', () => {
                 // Stub to simulate network failure
                 sinon.stub(rokuDeploy, 'getDeviceInfo').rejects(new Error('Device not responding'));
 
-                const result = await manager.healthCheckDevice(device);
+                const result = await manager['resolveDevice'](device, { bypassCache: true, syntheticDelay: false });
 
                 expect(result).to.be.false;
                 expect(manager.getAllDevices().length).to.equal(1);
@@ -2627,7 +2628,7 @@ describe('DeviceManager', () => {
                 // Stub to simulate network failure
                 sinon.stub(rokuDeploy, 'getDeviceInfo').rejects(new Error('Device not responding'));
 
-                const result = await manager.healthCheckDevice(device);
+                const result = await manager['resolveDevice'](device, { bypassCache: true, syntheticDelay: false });
 
                 expect(result).to.be.false;
                 expect(manager.getAllDevices().length).to.equal(1);
@@ -2651,7 +2652,7 @@ describe('DeviceManager', () => {
                 // Stub to simulate network failure
                 sinon.stub(rokuDeploy, 'getDeviceInfo').rejects(new Error('Device not responding'));
 
-                const result = await manager.healthCheckDevice(device);
+                const result = await manager['resolveDevice'](device, { bypassCache: true, syntheticDelay: false });
 
                 expect(result).to.be.false;
                 expect(manager.getAllDevices().length).to.equal(0);
@@ -2684,7 +2685,7 @@ describe('DeviceManager', () => {
 
                 sinon.stub(rokuDeploy, 'getDeviceInfo').rejects(new Error('Offline'));
 
-                await manager.healthCheckDevice(device);
+                await manager['resolveDevice'](device, { bypassCache: true, syntheticDelay: false });
 
                 // Device kept (configured) but not discovered
                 expect(manager.getAllDevices().length).to.equal(1);
@@ -2707,7 +2708,7 @@ describe('DeviceManager', () => {
 
                 sinon.stub(rokuDeploy, 'getDeviceInfo').rejects(new Error('Offline'));
 
-                await manager.healthCheckDevice(device);
+                await manager['resolveDevice'](device, { bypassCache: true, syntheticDelay: false });
 
                 // Device removed (not configured, not discovered)
                 expect(manager.getAllDevices().length).to.equal(0);

--- a/src/deviceDiscovery/DeviceManager.spec.ts
+++ b/src/deviceDiscovery/DeviceManager.spec.ts
@@ -173,7 +173,7 @@ describe('DeviceManager', () => {
             const eventSpy = sinon.spy();
             manager.on('broadcast-ordered', eventSpy);
 
-            manager.submitBroadcast('network');
+            manager['submitBroadcast']('network');
 
             expect(eventSpy.calledOnce).to.be.true;
             expect(eventSpy.firstCall.args[0].reason).to.equal('network');
@@ -186,7 +186,7 @@ describe('DeviceManager', () => {
             const eventSpy = sinon.spy();
             manager.on('reconcile-ordered', eventSpy);
 
-            manager.submitReconcile('config-changed');
+            manager['submitReconcile']('config-changed');
 
             expect(eventSpy.calledOnce).to.be.true;
             expect(eventSpy.firstCall.args[0].reason).to.equal('config-changed');
@@ -196,9 +196,9 @@ describe('DeviceManager', () => {
         it('different reasons accumulate instead of replacing each other', () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
-            manager.submitBroadcast('sleep');
-            manager.submitBroadcast('network');
-            manager.submitBroadcast('stale');
+            manager['submitBroadcast']('sleep');
+            manager['submitBroadcast']('network');
+            manager['submitBroadcast']('stale');
 
             expect(manager.getPendingBroadcastReasons()).to.have.members(['sleep', 'network', 'stale']);
         });
@@ -206,9 +206,9 @@ describe('DeviceManager', () => {
         it('the same reason never queues twice', () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
-            manager.submitBroadcast('stale');
-            manager.submitBroadcast('stale');
-            manager.submitBroadcast('stale');
+            manager['submitBroadcast']('stale');
+            manager['submitBroadcast']('stale');
+            manager['submitBroadcast']('stale');
 
             expect(manager.getPendingBroadcastReasons()).to.eql(['stale']);
         });
@@ -216,8 +216,8 @@ describe('DeviceManager', () => {
         it('broadcast and reconcile pending sets are independent', () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
-            manager.submitBroadcast('network');
-            manager.submitReconcile('config-changed');
+            manager['submitBroadcast']('network');
+            manager['submitReconcile']('config-changed');
 
             expect(manager.getPendingBroadcastReasons()).to.include('network');
             expect(manager.getPendingReconcileReasons()).to.include('config-changed');
@@ -240,7 +240,7 @@ describe('DeviceManager', () => {
 
         it('consumes and executes a pending broadcast, passing its reason through', () => {
             const broadcastStub = sinon.stub(manager as any, 'broadcast').returns(true);
-            manager.submitBroadcast('network');
+            manager['submitBroadcast']('network');
 
             const result = manager.fulfillPendingBroadcast();
 
@@ -251,8 +251,8 @@ describe('DeviceManager', () => {
 
         it('consumes all accumulated reasons in a single execution', () => {
             const broadcastStub = sinon.stub(manager as any, 'broadcast').returns(true);
-            manager.submitBroadcast('sleep');
-            manager.submitBroadcast('network');
+            manager['submitBroadcast']('sleep');
+            manager['submitBroadcast']('network');
 
             const result = manager.fulfillPendingBroadcast();
 
@@ -264,7 +264,7 @@ describe('DeviceManager', () => {
 
         it('passes a stale reason through (broadcast applies the staleness gate itself)', () => {
             const broadcastStub = sinon.stub(manager as any, 'broadcast').returns(false);
-            manager.submitBroadcast('stale');
+            manager['submitBroadcast']('stale');
 
             manager.fulfillPendingBroadcast();
 
@@ -273,7 +273,7 @@ describe('DeviceManager', () => {
 
         it('leaves except-listed reasons QUEUED instead of consuming them', () => {
             const broadcastStub = sinon.stub(manager as any, 'broadcast').returns(true);
-            manager.submitBroadcast('stale');
+            manager['submitBroadcast']('stale');
 
             const result = manager.fulfillPendingBroadcast({ except: ['stale'] });
 
@@ -284,8 +284,8 @@ describe('DeviceManager', () => {
 
         it('when a real reason triggers execution, the whole set is cleared — excepted reasons included', () => {
             const broadcastStub = sinon.stub(manager as any, 'broadcast').returns(true);
-            manager.submitBroadcast('stale');
-            manager.submitBroadcast('network');
+            manager['submitBroadcast']('stale');
+            manager['submitBroadcast']('network');
 
             const result = manager.fulfillPendingBroadcast({ except: ['stale'] });
 
@@ -305,7 +305,7 @@ describe('DeviceManager', () => {
 
         it('is atomic: a second fulfillment finds the set empty', () => {
             const broadcastStub = sinon.stub(manager as any, 'broadcast').returns(true);
-            manager.submitBroadcast('network');
+            manager['submitBroadcast']('network');
 
             expect(manager.fulfillPendingBroadcast()).to.be.true;
             expect(manager.fulfillPendingBroadcast()).to.be.false;
@@ -315,19 +315,19 @@ describe('DeviceManager', () => {
         it('passes the reconcile reason through (reconcile decides cache bypass itself)', () => {
             const reconcileStub = sinon.stub(manager as any, 'reconcile');
 
-            manager.submitReconcile('config-changed');
+            manager['submitReconcile']('config-changed');
             expect(manager.fulfillPendingReconcile()).to.be.true;
             expect(reconcileStub.calledOnceWith(['config-changed'])).to.be.true;
 
             reconcileStub.resetHistory();
-            manager.submitReconcile('refresh-clicked');
+            manager['submitReconcile']('refresh-clicked');
             expect(manager.fulfillPendingReconcile()).to.be.true;
             expect(reconcileStub.calledOnceWith(['refresh-clicked'])).to.be.true;
         });
 
         it('leaves an except-listed reconcile queued', () => {
             const reconcileStub = sinon.stub(manager as any, 'reconcile');
-            manager.submitReconcile('stale');
+            manager['submitReconcile']('stale');
 
             expect(manager.fulfillPendingReconcile({ except: ['stale'] })).to.be.false;
             expect(reconcileStub.called).to.be.false;
@@ -351,8 +351,8 @@ describe('DeviceManager', () => {
         it('fulfillPendingOrders passes the except list to both order types', () => {
             const broadcastStub = sinon.stub(manager as any, 'broadcast').returns(true);
             const reconcileStub = sinon.stub(manager as any, 'reconcile');
-            manager.submitBroadcast('stale');
-            manager.submitReconcile('stale');
+            manager['submitBroadcast']('stale');
+            manager['submitReconcile']('stale');
 
             const result = manager.fulfillPendingOrders({ except: ['stale'] });
 
@@ -617,12 +617,12 @@ describe('DeviceManager', () => {
             const handler = sinon.spy();
             const unsubscribe = manager.on('broadcast-ordered', handler);
 
-            manager.submitBroadcast('network');
+            manager['submitBroadcast']('network');
             expect(handler.calledOnce).to.be.true;
 
             unsubscribe();
 
-            manager.submitBroadcast('network');
+            manager['submitBroadcast']('network');
             expect(handler.calledOnce).to.be.true; // Still just one call (unsubscribed)
         });
 

--- a/src/deviceDiscovery/DeviceManager.spec.ts
+++ b/src/deviceDiscovery/DeviceManager.spec.ts
@@ -1791,7 +1791,7 @@ describe('DeviceManager', () => {
     });
 
     describe('peekDevice (internal read)', () => {
-        it('reads a device without scheduling any background work', async () => {
+        it('reads a device without scheduling any background work', () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
             const ensureStub = sinon.stub(manager as any, 'ensureDeviceFresh');
             manager['discoveredDevices'].push({ ip: '192.168.1.90', serialNumber: 'PEEK90' });

--- a/src/deviceDiscovery/DeviceManager.spec.ts
+++ b/src/deviceDiscovery/DeviceManager.spec.ts
@@ -393,7 +393,7 @@ describe('DeviceManager', () => {
             expect(isHealthy).to.be.true;
             //engagement policy: no synthetic delay, cache trust window bypassed
             expect(resolveStub.calledOnce).to.be.true;
-            expect(resolveStub.firstCall.args.slice(1)).to.eql([false, true]);
+            expect(resolveStub.firstCall.args[1]).to.eql({ bypassCache: true, syntheticDelay: false });
         });
 
         it('resolves an encoded tree key itself', async () => {
@@ -858,7 +858,7 @@ describe('DeviceManager', () => {
     });
 
     describe('healthCheckAllDevices', () => {
-        it('sets all devices to pending and checks all when force=true', async () => {
+        it('sets all devices to pending and checks all when bypassing the device cache', async () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
             const device1 = createMockDevice({ serialNumber: 'device-1', ip: '192.168.1.101' });
@@ -889,7 +889,7 @@ describe('DeviceManager', () => {
             expect(resolveDeviceSpy.calledTwice).to.be.true;
         });
 
-        it('sets devices to pending before checking when force=false', async () => {
+        it('sets devices to pending before checking when the cache is trusted', async () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
             const device = createMockDevice();
@@ -923,7 +923,7 @@ describe('DeviceManager', () => {
             sinon.stub(manager as any, 'randomDelay').resolves();
 
             // Pre-populate the cache by calling resolveDevice once
-            await manager['resolveDevice'](device, false);
+            await manager['resolveDevice'](device, { syntheticDelay: false });
             expect(getDeviceInfoStub.calledOnce).to.be.true;
 
             // Now call healthCheckAllDevices - should use cached data
@@ -934,7 +934,7 @@ describe('DeviceManager', () => {
         });
     });
 
-    describe('resolveDevice cooldown (force=false)', () => {
+    describe('resolveDevice cooldown (cache trusted)', () => {
         it('skips network fetch if within cooldown period (uses cached data)', async () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
@@ -991,7 +991,7 @@ describe('DeviceManager', () => {
             }
         });
 
-        it('deviceEngaged always fetches regardless of cooldown (engagement forces)', async () => {
+        it('deviceEngaged always fetches regardless of cooldown (engagement bypasses the cache)', async () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
             const device = createMockDevice();
@@ -1006,11 +1006,11 @@ describe('DeviceManager', () => {
             // Stub random delay to be instant
             sinon.stub(manager as any, 'randomDelay').resolves();
 
-            // First call with force
+            // First engagement
             await manager.deviceEngaged(device);
             expect(getDeviceInfoStub.calledOnce).to.be.true;
 
-            // Second call immediately with force - should still fetch
+            // Second engagement immediately - should still fetch
             await manager.deviceEngaged(device);
             expect(getDeviceInfoStub.calledTwice).to.be.true;
         });
@@ -1262,7 +1262,7 @@ describe('DeviceManager', () => {
             randomDelayStub.onCall(1).resolves();
 
             // Start the first (soon-to-be-stale) check.
-            const firstCheck = manager['resolveDevice'](device, true);
+            const firstCheck = manager['resolveDevice'](device);
 
             // Let it reach (and suspend on) its synthetic delay. By that point its own network
             // call has already failed and cleared out of the in-flight map, which is what lets
@@ -1273,7 +1273,7 @@ describe('DeviceManager', () => {
             expect(randomDelayStub.callCount).to.equal(1);
 
             // Start a second, newer check for the SAME device while the first is still suspended.
-            await manager['resolveDevice'](device, true);
+            await manager['resolveDevice'](device);
 
             // The newer check's result (online) is applied.
             expect(manager.getAllDevices()[0].deviceState).to.equal('online');
@@ -1806,9 +1806,8 @@ describe('DeviceManager', () => {
 
             expect(resolveStub.calledOnce).to.be.true;
             expect(resolveStub.firstCall.args[0]).to.deep.equal({ ip: '192.168.1.50', serialNumber: 'no-cache-1' });
-            //silent background refresh: no synthetic delay, not forced
-            expect(resolveStub.firstCall.args[1]).to.equal(false);
-            expect(resolveStub.firstCall.args[2]).to.equal(false);
+            //silent background refresh: no synthetic delay, cache trusted
+            expect(resolveStub.firstCall.args[1]).to.eql({ syntheticDelay: false });
         });
 
         it('does not hydrate a device whose cache is fresh', async () => {
@@ -1972,8 +1971,8 @@ describe('DeviceManager', () => {
             sinon.stub(manager as any, 'randomDelay').resolves();
 
             // Call twice in rapid succession via resolveDevice
-            await manager['resolveDevice'](device, false);
-            await manager['resolveDevice'](device, false);
+            await manager['resolveDevice'](device, { syntheticDelay: false });
+            await manager['resolveDevice'](device, { syntheticDelay: false });
 
             // Should only have made one actual network call (second uses cache)
             expect(getDeviceInfoStub.callCount).to.equal(1);
@@ -1997,14 +1996,14 @@ describe('DeviceManager', () => {
                 sinon.stub(manager as any, 'randomDelay').resolves();
 
                 // First call - should hit network
-                await manager['resolveDevice'](device, false);
+                await manager['resolveDevice'](device, { syntheticDelay: false });
                 expect(getDeviceInfoStub.callCount).to.equal(1);
 
                 // Advance past TTL (5 minutes)
                 clock.tick((5 * 60 * 1_000) + 1);
 
                 // Second call - cache expired, should hit network again
-                await manager['resolveDevice'](device, false);
+                await manager['resolveDevice'](device, { syntheticDelay: false });
                 expect(getDeviceInfoStub.callCount).to.equal(2);
             } finally {
                 clock.restore();
@@ -2042,15 +2041,15 @@ describe('DeviceManager', () => {
             sinon.stub(manager as any, 'randomDelay').resolves();
 
             // Call for two different devices
-            await manager['resolveDevice'](device1, false);
-            await manager['resolveDevice'](device2, false);
+            await manager['resolveDevice'](device1, { syntheticDelay: false });
+            await manager['resolveDevice'](device2, { syntheticDelay: false });
 
             // Should make two network calls (different serials)
             expect(getDeviceInfoStub.callCount).to.equal(2);
 
             // Calling same devices again should use cache (keyed by serial)
-            await manager['resolveDevice'](device1, false);
-            await manager['resolveDevice'](device2, false);
+            await manager['resolveDevice'](device1, { syntheticDelay: false });
+            await manager['resolveDevice'](device2, { syntheticDelay: false });
 
             // Still only two calls (cache hit)
             expect(getDeviceInfoStub.callCount).to.equal(2);
@@ -2072,11 +2071,11 @@ describe('DeviceManager', () => {
             sinon.stub(manager as any, 'randomDelay').resolves();
 
             // First call - fetches from network (no cache, no IP→serial mapping)
-            await manager['resolveDevice'](deviceIpOnly, false);
+            await manager['resolveDevice'](deviceIpOnly, { syntheticDelay: false });
             expect(getDeviceInfoStub.callCount).to.equal(1);
 
             // Now we have IP→serial mapping. Second call should use cache.
-            await manager['resolveDevice'](deviceIpOnly, false);
+            await manager['resolveDevice'](deviceIpOnly, { syntheticDelay: false });
             expect(getDeviceInfoStub.callCount).to.equal(1);
 
             // Simulate network change
@@ -2086,7 +2085,7 @@ describe('DeviceManager', () => {
 
             // On new network, IP→serial mapping is cleared.
             // Resolving by IP alone should refetch since we can't look up the serial.
-            await manager['resolveDevice'](deviceIpOnly, false);
+            await manager['resolveDevice'](deviceIpOnly, { syntheticDelay: false });
             expect(getDeviceInfoStub.callCount).to.equal(2);
         });
 
@@ -2107,11 +2106,11 @@ describe('DeviceManager', () => {
             sinon.stub(manager as any, 'randomDelay').resolves();
 
             // First call - fetches from network
-            await manager['resolveDevice'](device, false);
+            await manager['resolveDevice'](device, { syntheticDelay: false });
             expect(getDeviceInfoStub.callCount).to.equal(1);
 
             // Verify cache is working
-            await manager['resolveDevice'](device, false);
+            await manager['resolveDevice'](device, { syntheticDelay: false });
             expect(getDeviceInfoStub.callCount).to.equal(1);
 
             // Simulate network change
@@ -2126,7 +2125,7 @@ describe('DeviceManager', () => {
             // Even though device info cache is keyed by serial, we validate that the
             // cached IP matches the device's current IP. After network change, this
             // validation fails so we must refetch to confirm the device is still at this IP.
-            await manager['resolveDevice'](device, false);
+            await manager['resolveDevice'](device, { syntheticDelay: false });
             expect(getDeviceInfoStub.callCount).to.equal(2); // Refetches after network change
         });
     });

--- a/src/deviceDiscovery/DeviceManager.spec.ts
+++ b/src/deviceDiscovery/DeviceManager.spec.ts
@@ -222,6 +222,15 @@ describe('DeviceManager', () => {
             expect(manager.getPendingBroadcastReasons()).to.include('network');
             expect(manager.getPendingReconcileReasons()).to.include('config-changed');
         });
+
+        it('submitRefreshOrders submits a refresh-clicked broadcast AND reconcile', () => {
+            manager = new DeviceManager(vscode.context, mockGlobalStateManager);
+
+            manager.submitRefreshOrders();
+
+            expect(manager.getPendingBroadcastReasons()).to.eql(['refresh-clicked']);
+            expect(manager.getPendingReconcileReasons()).to.eql(['refresh-clicked']);
+        });
     });
 
     describe('fulfillPendingBroadcast / fulfillPendingReconcile', () => {
@@ -323,6 +332,48 @@ describe('DeviceManager', () => {
             expect(manager.fulfillPendingReconcile({ except: ['stale'] })).to.be.false;
             expect(reconcileStub.called).to.be.false;
             expect(manager.getPendingReconcileReasons()).to.include('stale');
+        });
+
+        it('fulfillPendingOrders fulfills both order types in one call', () => {
+            const broadcastStub = sinon.stub(manager as any, 'broadcast').returns(true);
+            const reconcileStub = sinon.stub(manager as any, 'reconcile');
+            manager.submitRefreshOrders();
+
+            const result = manager.fulfillPendingOrders();
+
+            expect(result).to.eql({ scanStarted: true, reconciled: true });
+            expect(broadcastStub.calledOnceWith(['refresh-clicked'])).to.be.true;
+            expect(reconcileStub.calledOnceWith(['refresh-clicked'])).to.be.true;
+            expect(manager.getPendingBroadcastReasons()).to.be.empty;
+            expect(manager.getPendingReconcileReasons()).to.be.empty;
+        });
+
+        it('fulfillPendingOrders passes the except list to both order types', () => {
+            const broadcastStub = sinon.stub(manager as any, 'broadcast').returns(true);
+            const reconcileStub = sinon.stub(manager as any, 'reconcile');
+            manager.submitBroadcast('stale');
+            manager.submitReconcile('stale');
+
+            const result = manager.fulfillPendingOrders({ except: ['stale'] });
+
+            expect(result).to.eql({ scanStarted: false, reconciled: false });
+            expect(broadcastStub.called).to.be.false;
+            expect(reconcileStub.called).to.be.false;
+            expect(manager.getPendingBroadcastReasons()).to.include('stale');
+            expect(manager.getPendingReconcileReasons()).to.include('stale');
+        });
+    });
+
+    describe('deviceEngaged', () => {
+        it('freshens the device with the cache trust window bypassed and reports health', async () => {
+            manager = new DeviceManager(vscode.context, mockGlobalStateManager);
+            const healthCheckStub = sinon.stub(manager as any, 'healthCheckDevice').returns(Promise.resolve(true) as any);
+
+            const device = { ip: '192.168.1.50' };
+            const isHealthy = await manager.deviceEngaged(device);
+
+            expect(isHealthy).to.be.true;
+            expect(healthCheckStub.calledOnceWith(device, true, false)).to.be.true;
         });
     });
 
@@ -858,11 +909,11 @@ describe('DeviceManager', () => {
             sinon.stub(manager as any, 'randomDelay').resolves();
 
             // First call - should fetch from network
-            await manager.healthCheckDevice(device);
+            await manager['healthCheckDevice'](device);
             expect(getDeviceInfoStub.calledOnce).to.be.true;
 
             // Second call immediately - should use cache, no new network call
-            await manager.healthCheckDevice(device);
+            await manager['healthCheckDevice'](device);
             expect(getDeviceInfoStub.calledOnce).to.be.true; // Still just one call
         });
 
@@ -884,14 +935,14 @@ describe('DeviceManager', () => {
                 sinon.stub(manager as any, 'randomDelay').resolves();
 
                 // First call
-                await manager.healthCheckDevice(device);
+                await manager['healthCheckDevice'](device);
                 expect(getDeviceInfoStub.calledOnce).to.be.true;
 
                 // Advance past cooldown (5 minutes)
                 clock.tick((5 * 60 * 1_000) + 1);
 
                 // Second call - cache expired, should fetch again
-                await manager.healthCheckDevice(device);
+                await manager['healthCheckDevice'](device);
                 expect(getDeviceInfoStub.calledTwice).to.be.true;
             } finally {
                 clock.restore();
@@ -914,11 +965,11 @@ describe('DeviceManager', () => {
             sinon.stub(manager as any, 'randomDelay').resolves();
 
             // First call with force
-            await manager.healthCheckDevice(device, true);
+            await manager['healthCheckDevice'](device, true);
             expect(getDeviceInfoStub.calledOnce).to.be.true;
 
             // Second call immediately with force - should still fetch
-            await manager.healthCheckDevice(device, true);
+            await manager['healthCheckDevice'](device, true);
             expect(getDeviceInfoStub.calledTwice).to.be.true;
         });
     });
@@ -1109,7 +1160,7 @@ describe('DeviceManager', () => {
             });
             sinon.stub(rokuDeploy, 'getDeviceInfo').returns(healthPromise);
 
-            const checkPromise = manager.healthCheckDevice(device, true);
+            const checkPromise = manager['healthCheckDevice'](device, true);
 
             // Device should be pending during check
             expect(manager.getAllDevices()[0].deviceState).to.equal('pending');
@@ -1135,7 +1186,7 @@ describe('DeviceManager', () => {
 
             sinon.stub(rokuDeploy, 'getDeviceInfo').rejects(new Error('Device not responding'));
 
-            const result = await manager.healthCheckDevice(device, true);
+            const result = await manager['healthCheckDevice'](device, true);
 
             expect(result).to.be.false;
             expect(manager.getAllDevices().length).to.equal(0);
@@ -1210,7 +1261,7 @@ describe('DeviceManager', () => {
 
             // First health check fails (device offline)
             sinon.stub(rokuDeploy, 'getDeviceInfo').rejects(new Error('Device not responding'));
-            await manager.healthCheckDevice(device, true);
+            await manager['healthCheckDevice'](device, true);
 
             // Cache should still exist with device info preserved for offline display
             const cached = mockGlobalStateManager.getCachedDevice('device-123');
@@ -1233,7 +1284,7 @@ describe('DeviceManager', () => {
                 'default-device-name': 'Roku Express'
             });
 
-            const result = await manager.healthCheckDevice(device, true);
+            const result = await manager['healthCheckDevice'](device, true);
 
             expect(result).to.be.true;
         });
@@ -1257,8 +1308,8 @@ describe('DeviceManager', () => {
                 resolveFetch = resolve;
             }) as any);
 
-            const first = manager.healthCheckDevice(device, true, false);
-            const second = manager.healthCheckDevice(device, true, false);
+            const first = manager['healthCheckDevice'](device, true, false);
+            const second = manager['healthCheckDevice'](device, true, false);
 
             resolveFetch({
                 'device-id': 'device-123',
@@ -1300,8 +1351,8 @@ describe('DeviceManager', () => {
             getDeviceInfoStub.onSecondCall().returns(device2Promise);
 
             // Start health checks for both devices
-            const result1 = manager.healthCheckDevice(device1, true);
-            const result2 = manager.healthCheckDevice(device2, true);
+            const result1 = manager['healthCheckDevice'](device1, true);
+            const result2 = manager['healthCheckDevice'](device2, true);
 
             // Device 2 completes first (healthy)
             resolveDevice2({
@@ -1684,7 +1735,7 @@ describe('DeviceManager', () => {
 
             manager['discoveredDevices'].push({ ip: '192.168.1.100' });
             const startStub = sinon.stub(manager['networkChangeMonitor'], 'start');
-            const healthCheckStub = sinon.stub(manager, 'healthCheckDevice').resolves(true);
+            const healthCheckStub = sinon.stub(manager as any, 'healthCheckDevice').returns(Promise.resolve(true) as any);
 
             manager['notifyFocusGained']();
 
@@ -2436,7 +2487,7 @@ describe('DeviceManager', () => {
                 // Stub to simulate network failure
                 sinon.stub(rokuDeploy, 'getDeviceInfo').rejects(new Error('Device not responding'));
 
-                const result = await manager.healthCheckDevice(device, true);
+                const result = await manager['healthCheckDevice'](device, true);
 
                 expect(result).to.be.false;
                 expect(manager.getAllDevices().length).to.equal(1);
@@ -2460,7 +2511,7 @@ describe('DeviceManager', () => {
                 // Stub to simulate network failure
                 sinon.stub(rokuDeploy, 'getDeviceInfo').rejects(new Error('Device not responding'));
 
-                const result = await manager.healthCheckDevice(device, true);
+                const result = await manager['healthCheckDevice'](device, true);
 
                 expect(result).to.be.false;
                 expect(manager.getAllDevices().length).to.equal(1);
@@ -2484,7 +2535,7 @@ describe('DeviceManager', () => {
                 // Stub to simulate network failure
                 sinon.stub(rokuDeploy, 'getDeviceInfo').rejects(new Error('Device not responding'));
 
-                const result = await manager.healthCheckDevice(device, true);
+                const result = await manager['healthCheckDevice'](device, true);
 
                 expect(result).to.be.false;
                 expect(manager.getAllDevices().length).to.equal(0);
@@ -2517,7 +2568,7 @@ describe('DeviceManager', () => {
 
                 sinon.stub(rokuDeploy, 'getDeviceInfo').rejects(new Error('Offline'));
 
-                await manager.healthCheckDevice(device, true);
+                await manager['healthCheckDevice'](device, true);
 
                 // Device kept (configured) but not discovered
                 expect(manager.getAllDevices().length).to.equal(1);
@@ -2540,7 +2591,7 @@ describe('DeviceManager', () => {
 
                 sinon.stub(rokuDeploy, 'getDeviceInfo').rejects(new Error('Offline'));
 
-                await manager.healthCheckDevice(device, true);
+                await manager['healthCheckDevice'](device, true);
 
                 // Device removed (not configured, not discovered)
                 expect(manager.getAllDevices().length).to.equal(0);
@@ -2888,11 +2939,11 @@ describe('DeviceManager', () => {
                     sinon.stub(manager as any, 'randomDelay').resolves();
 
                     // Perform health check to populate cache
-                    await manager.healthCheckDevice(device);
+                    await manager['healthCheckDevice'](device);
                     expect(getDeviceInfoStub.calledOnce).to.be.true;
 
                     // Second call should use cache (no new network call)
-                    await manager.healthCheckDevice(device);
+                    await manager['healthCheckDevice'](device);
                     expect(getDeviceInfoStub.calledOnce).to.be.true; // Still just one call
 
                     // Clear cache (clears globalStateManager.deviceCache and IP→serial mappings)
@@ -2902,7 +2953,7 @@ describe('DeviceManager', () => {
                     addDevice(device);
 
                     // Now health check should hit network again (cache was cleared)
-                    await manager.healthCheckDevice(device);
+                    await manager['healthCheckDevice'](device);
                     expect(getDeviceInfoStub.calledTwice).to.be.true;
                 });
 
@@ -2962,14 +3013,14 @@ describe('DeviceManager', () => {
                     const resolveDeviceSpy = sinon.stub(manager as any, 'resolveDevice').returns(Promise.resolve(true));
 
                     // First health check
-                    await manager.healthCheckDevice(device);
+                    await manager['healthCheckDevice'](device);
                     expect(resolveDeviceSpy.calledOnce).to.be.true;
 
                     // Clear cache (should clear cooldown)
                     manager.clearAllCache();
 
                     // Health check should run immediately (no cooldown)
-                    await manager.healthCheckDevice(device);
+                    await manager['healthCheckDevice'](device);
                     expect(resolveDeviceSpy.calledTwice).to.be.true;
                 });
 
@@ -2985,7 +3036,7 @@ describe('DeviceManager', () => {
                     });
                     sinon.stub(manager as any, 'resolveDevice').returns(healthCheckPromise);
 
-                    const healthCheckCall = manager.healthCheckDevice(device);
+                    const healthCheckCall = manager['healthCheckDevice'](device);
 
                     // Clear cache while health check is in flight
                     manager.clearAllCache();

--- a/src/deviceDiscovery/DeviceManager.spec.ts
+++ b/src/deviceDiscovery/DeviceManager.spec.ts
@@ -228,28 +228,28 @@ describe('DeviceManager', () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
         });
 
-        it('consumes and executes a pending broadcast, forced for non-stale reasons', () => {
-            const broadcastStub = sinon.stub(manager, 'broadcast').returns(true);
+        it('consumes and executes a pending broadcast, passing its reason through', () => {
+            const broadcastStub = sinon.stub(manager as any, 'broadcast').returns(true);
             manager.submitBroadcast('network');
 
             const result = manager.fulfillPendingBroadcast();
 
             expect(result).to.be.true;
-            expect(broadcastStub.calledOnceWith(true)).to.be.true;
+            expect(broadcastStub.calledOnceWith('network')).to.be.true;
             expect(manager.getPendingBroadcast()).to.be.null;
         });
 
-        it('executes a stale broadcast without forcing (staleness-gated)', () => {
-            const broadcastStub = sinon.stub(manager, 'broadcast').returns(false);
+        it('passes a stale reason through (broadcast applies the staleness gate itself)', () => {
+            const broadcastStub = sinon.stub(manager as any, 'broadcast').returns(false);
             manager.submitBroadcast('stale');
 
             manager.fulfillPendingBroadcast();
 
-            expect(broadcastStub.calledOnceWith(false)).to.be.true;
+            expect(broadcastStub.calledOnceWith('stale')).to.be.true;
         });
 
         it('leaves except-listed reasons QUEUED instead of consuming them', () => {
-            const broadcastStub = sinon.stub(manager, 'broadcast').returns(true);
+            const broadcastStub = sinon.stub(manager as any, 'broadcast').returns(true);
             manager.submitBroadcast('stale');
 
             const result = manager.fulfillPendingBroadcast({ except: ['stale'] });
@@ -260,14 +260,14 @@ describe('DeviceManager', () => {
         });
 
         it('returns false and does nothing when no order is pending', () => {
-            const broadcastStub = sinon.stub(manager, 'broadcast').returns(true);
+            const broadcastStub = sinon.stub(manager as any, 'broadcast').returns(true);
 
             expect(manager.fulfillPendingBroadcast()).to.be.false;
             expect(broadcastStub.called).to.be.false;
         });
 
         it('is atomic: a second fulfillment finds the slot empty', () => {
-            const broadcastStub = sinon.stub(manager, 'broadcast').returns(true);
+            const broadcastStub = sinon.stub(manager as any, 'broadcast').returns(true);
             manager.submitBroadcast('network');
 
             expect(manager.fulfillPendingBroadcast()).to.be.true;
@@ -275,21 +275,21 @@ describe('DeviceManager', () => {
             expect(broadcastStub.calledOnce).to.be.true;
         });
 
-        it('forces a reconcile only for refresh-clicked', () => {
-            const reconcileStub = sinon.stub(manager, 'reconcile');
+        it('passes the reconcile reason through (reconcile decides cache bypass itself)', () => {
+            const reconcileStub = sinon.stub(manager as any, 'reconcile');
 
             manager.submitReconcile('config-changed');
             expect(manager.fulfillPendingReconcile()).to.be.true;
-            expect(reconcileStub.calledOnceWith(false)).to.be.true;
+            expect(reconcileStub.calledOnceWith('config-changed')).to.be.true;
 
             reconcileStub.resetHistory();
             manager.submitReconcile('refresh-clicked');
             expect(manager.fulfillPendingReconcile()).to.be.true;
-            expect(reconcileStub.calledOnceWith(true)).to.be.true;
+            expect(reconcileStub.calledOnceWith('refresh-clicked')).to.be.true;
         });
 
         it('leaves an except-listed reconcile queued', () => {
-            const reconcileStub = sinon.stub(manager, 'reconcile');
+            const reconcileStub = sinon.stub(manager as any, 'reconcile');
             manager.submitReconcile('stale');
 
             expect(manager.fulfillPendingReconcile({ except: ['stale'] })).to.be.false;
@@ -340,7 +340,7 @@ describe('DeviceManager', () => {
             try {
                 manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
-                manager.broadcast(true);
+                manager['broadcast']('refresh-clicked');
 
                 clock.tick(5_000);
 
@@ -632,25 +632,25 @@ describe('DeviceManager', () => {
 
             expect(manager['timeSinceLastScan']).to.equal(Infinity);
 
-            manager.broadcast(true);
+            manager['broadcast']('refresh-clicked');
 
             // After a broadcast, timeSinceLastScan should be very small (just happened)
             expect(manager['timeSinceLastScan']).to.be.lessThan(100);
         });
 
-        it('calls healthCheckAllDevices with force flag', () => {
+        it('bypasses the per-device cache only for refresh-clicked', () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
             const healthCheckAllDevicesSpy = sinon.stub(manager as any, 'healthCheckAllDevices').resolves();
 
-            manager.reconcile(true);
+            manager['reconcile']('refresh-clicked');
             expect(healthCheckAllDevicesSpy.calledWith(true)).to.be.true;
 
-            manager.reconcile(false);
+            manager['reconcile']('config-changed');
             expect(healthCheckAllDevicesSpy.calledWith(false)).to.be.true;
 
-            manager.reconcile(); // defaults to false
-            expect(healthCheckAllDevicesSpy.calledWith(false)).to.be.true;
+            manager['reconcile']('network');
+            expect(healthCheckAllDevicesSpy.lastCall.args[0]).to.equal(false);
         });
     });
 
@@ -658,45 +658,57 @@ describe('DeviceManager', () => {
         it('triggers discovery without health checking', () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
-            const discoverAllSpy = sinon.spy(manager as any, 'discoverAll');
+            const finderScanSpy = sinon.stub(manager['finder'], 'scan');
             const healthCheckAllDevicesSpy = sinon.spy(manager as any, 'healthCheckAllDevices');
 
-            manager.broadcast(true);
+            manager['broadcast']('refresh-clicked');
 
-            expect(discoverAllSpy.calledOnce).to.be.true;
+            expect(finderScanSpy.calledOnce).to.be.true;
             expect(healthCheckAllDevicesSpy.called).to.be.false;
         });
 
-        it('respects deviceDiscoveryEnabled when force=false', () => {
+        it('a stale reason does not scan while device discovery is disabled', () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
             sinon.stub(manager as any, 'deviceDiscoveryEnabled').get(() => false);
 
-            const discoverAllSpy = sinon.spy(manager as any, 'discoverAll');
+            const finderScanSpy = sinon.stub(manager['finder'], 'scan');
 
-            const result = manager.broadcast(false);
+            const result = manager['broadcast']('stale');
 
             expect(result).to.be.false;
-            expect(discoverAllSpy.called).to.be.false;
+            expect(finderScanSpy.called).to.be.false;
         });
 
-        it('ignores deviceDiscoveryEnabled when force=true', () => {
+        it('a real reason scans even while device discovery is disabled (explicit user intent)', () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
             sinon.stub(manager as any, 'deviceDiscoveryEnabled').get(() => false);
 
-            const discoverAllSpy = sinon.spy(manager as any, 'discoverAll');
+            const finderScanSpy = sinon.stub(manager['finder'], 'scan');
 
-            const result = manager.broadcast(true);
+            const result = manager['broadcast']('refresh-clicked');
 
             expect(result).to.be.true;
-            expect(discoverAllSpy.calledOnce).to.be.true;
+            expect(finderScanSpy.calledOnce).to.be.true;
         });
 
-        it('is staleness-gated when not forced: no scan when the last scan is recent', () => {
+        it('a stale reason is staleness-gated: no scan when the last scan is recent', () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
             sinon.stub(manager['finder'], 'scan');
 
-            expect(manager.broadcast(true)).to.be.true; //sets lastScanDate
-            expect(manager.broadcast(false)).to.be.false; //fresh — gate closed
+            expect(manager['broadcast']('refresh-clicked')).to.be.true; //sets lastScanDate
+            expect(manager['broadcast']('stale')).to.be.false; //fresh — gate closed
+        });
+
+        it('a stale reason scans when the last scan is older than the threshold', () => {
+            manager = new DeviceManager(vscode.context, mockGlobalStateManager);
+            //the suite-wide config stub disables discovery; this test is about the staleness half of the gate
+            sinon.stub(manager as any, 'deviceDiscoveryEnabled').get(() => true);
+            sinon.stub(manager['finder'], 'scan');
+
+            //backdate the last scan past the staleness threshold
+            manager['lastScanDate'] = new Date(Date.now() - manager['STALE_SCAN_THRESHOLD_MS'] - 1);
+
+            expect(manager['broadcast']('stale')).to.be.true;
         });
 
         it('emits scan-started event', () => {
@@ -707,7 +719,7 @@ describe('DeviceManager', () => {
                 const scanStartedSpy = sinon.spy();
                 manager.on('scan-started', scanStartedSpy);
 
-                manager.broadcast(true);
+                manager['broadcast']('refresh-clicked');
 
                 expect(scanStartedSpy.calledOnce).to.be.true;
             } finally {
@@ -884,7 +896,7 @@ describe('DeviceManager', () => {
                 const scanStartedSpy = sinon.spy();
                 manager.on('scan-started', scanStartedSpy);
 
-                manager.broadcast(true);
+                manager['broadcast']('refresh-clicked');
 
                 expect(scanStartedSpy.calledOnce).to.be.true;
             } finally {
@@ -900,7 +912,7 @@ describe('DeviceManager', () => {
                 const scanEndedSpy = sinon.spy();
                 manager.on('scan-ended', scanEndedSpy);
 
-                manager.broadcast(true);
+                manager['broadcast']('refresh-clicked');
 
                 // Not ended yet - neither timer has fired
                 expect(scanEndedSpy.called).to.be.false;
@@ -925,11 +937,11 @@ describe('DeviceManager', () => {
                 const scanStartedSpy = sinon.spy();
                 manager.on('scan-started', scanStartedSpy);
 
-                manager.broadcast(true);
+                manager['broadcast']('refresh-clicked');
                 expect(scanStartedSpy.calledOnce).to.be.true;
 
                 // Try to start another scan while one is in progress
-                manager.broadcast(true);
+                manager['broadcast']('refresh-clicked');
                 expect(scanStartedSpy.calledOnce).to.be.true; // Still just one call
             } finally {
                 clock.restore();
@@ -946,7 +958,7 @@ describe('DeviceManager', () => {
                 manager.on('scan-started', scanStartedSpy);
                 manager.on('scan-ended', scanEndedSpy);
 
-                manager.broadcast(true);
+                manager['broadcast']('refresh-clicked');
                 expect(scanStartedSpy.calledOnce).to.be.true;
 
                 // Complete the scan
@@ -954,7 +966,7 @@ describe('DeviceManager', () => {
                 expect(scanEndedSpy.calledOnce).to.be.true;
 
                 // Now can start a new scan
-                manager.broadcast(true);
+                manager['broadcast']('refresh-clicked');
                 expect(scanStartedSpy.calledTwice).to.be.true;
             } finally {
                 clock.restore();
@@ -2887,27 +2899,24 @@ describe('DeviceManager', () => {
 
             describe('functionality verification', () => {
                 it('allows immediate rescan after clear', () => {
-                    const clock = sinon.useFakeTimers();
-                    try {
-                        manager = new DeviceManager(vscode.context, mockGlobalStateManager);
+                    manager = new DeviceManager(vscode.context, mockGlobalStateManager);
+                    //the suite-wide config stub disables discovery; this test is about the staleness half of the gate
+                    sinon.stub(manager as any, 'deviceDiscoveryEnabled').get(() => true);
 
-                        // Simulate recent scan
-                        manager['lastScanDate'] = new Date();
-                        sinon.stub(manager['finder'], 'scan');
+                    // Simulate recent scan
+                    manager['lastScanDate'] = new Date();
+                    sinon.stub(manager['finder'], 'scan');
 
-                        // discoverAll should return false (scan not needed)
-                        let scanStarted = manager['discoverAll'](false);
-                        expect(scanStarted).to.be.false;
+                    // a stale broadcast is gated: the last scan is too recent
+                    let scanStarted = manager['broadcast']('stale');
+                    expect(scanStarted).to.be.false;
 
-                        // Clear cache
-                        manager.clearAllCache();
+                    // Clear cache
+                    manager.clearAllCache();
 
-                        // Now scan should be allowed (lastScanDate is null, timeSinceLastScan is Infinity)
-                        scanStarted = manager['discoverAll'](false);
-                        expect(scanStarted).to.be.true;
-                    } finally {
-                        clock.restore();
-                    }
+                    // Now scan should be allowed (lastScanDate is null, timeSinceLastScan is Infinity)
+                    scanStarted = manager['broadcast']('stale');
+                    expect(scanStarted).to.be.true;
                 });
 
                 it('health check runs immediately after clear', async () => {

--- a/src/deviceDiscovery/DeviceManager.spec.ts
+++ b/src/deviceDiscovery/DeviceManager.spec.ts
@@ -357,7 +357,7 @@ describe('DeviceManager', () => {
             const reconcileStub = sinon.stub(manager as any, 'reconcile');
             manager.submitOrders([{ type: 'broadcast', reason: 'refresh-clicked' }, { type: 'reconcile', reason: 'refresh-clicked' }]);
 
-            const result = manager.fulfillOrders();
+            const result = manager.fulfillOrders({ types: ['broadcast', 'reconcile'] });
 
             expect(result).to.eql({ scanStarted: true, reconciled: true });
             expect(broadcastStub.calledOnceWith(['refresh-clicked'])).to.be.true;
@@ -372,7 +372,7 @@ describe('DeviceManager', () => {
             manager.submitOrders([{ type: 'broadcast', reason: 'stale' }]);
             manager.submitOrders([{ type: 'reconcile', reason: 'stale' }]);
 
-            const result = manager.fulfillOrders({ except: ['stale'] });
+            const result = manager.fulfillOrders({ types: ['broadcast', 'reconcile'], except: ['stale'] });
 
             expect(result).to.eql({ scanStarted: false, reconciled: false });
             expect(broadcastStub.called).to.be.false;

--- a/src/deviceDiscovery/DeviceManager.spec.ts
+++ b/src/deviceDiscovery/DeviceManager.spec.ts
@@ -1625,273 +1625,124 @@ describe('DeviceManager', () => {
             expect(showTimedStub.calledTwice).to.be.true;
         });
 
-        describe('uncached device resolution on focus', () => {
-            it('triggers resolveUncachedDiscoveredDevices when focused and no cache exists', () => {
-                (vscode.window as any).state = { focused: true };
-                manager = new DeviceManager(vscode.context, mockGlobalStateManager);
-
-                const resolveStub = sinon.stub(manager as any, 'resolveUncachedDiscoveredDevices').resolves();
-
-                manager['handleDeviceOnline']('192.168.1.100', 'YN00AB123456');
-
-                expect(resolveStub.calledOnce).to.be.true;
-            });
-
-            it('does not trigger resolveUncachedDiscoveredDevices when focused but device already has cache', () => {
-                (vscode.window as any).state = { focused: true };
-                manager = new DeviceManager(vscode.context, mockGlobalStateManager);
-
-                // Cache the device so hasDeviceCache returns true
-                const device = createMockDevice({
-                    serialNumber: 'YN00AB123456',
-                    ip: '192.168.1.100',
-                    deviceInfo: mockDeviceInfo
-                });
-                addDevice(device);
-
-                const resolveStub = sinon.stub(manager as any, 'resolveUncachedDiscoveredDevices').resolves();
-
-                manager['handleDeviceOnline']('192.168.1.100', 'YN00AB123456');
-
-                expect(resolveStub.called).to.be.false;
-            });
-
-            it('does not trigger resolveUncachedDiscoveredDevices when not focused, even if no cache', () => {
-                (vscode.window as any).state = { focused: false };
-                manager = new DeviceManager(vscode.context, mockGlobalStateManager);
-
-                const resolveStub = sinon.stub(manager as any, 'resolveUncachedDiscoveredDevices').resolves();
-
-                manager['handleDeviceOnline']('192.168.1.100', 'YN00AB123456');
-
-                expect(resolveStub.called).to.be.false;
-            });
-
-            it('uses IP→serial mapping to detect cache when no serial is provided', () => {
-                (vscode.window as any).state = { focused: true };
-                manager = new DeviceManager(vscode.context, mockGlobalStateManager);
-
-                // Seed mapping AND cache so hasDeviceCache returns true via the mapped serial
-                mockGlobalStateManager.setSerialNumberForIp('test-network-hash', '192.168.1.100', 'MAPPED-SERIAL');
-                mockGlobalStateManager.setCachedDevice('MAPPED-SERIAL', {
-                    serialNumber: 'MAPPED-SERIAL',
-                    deviceInfo: { 'default-device-name': 'Mapped Roku' },
-                    createdAt: Date.now()
-                });
-
-                const resolveStub = sinon.stub(manager as any, 'resolveUncachedDiscoveredDevices').resolves();
-
-                manager['handleDeviceOnline']('192.168.1.100');
-
-                // The mapped serial has cache, so resolution should NOT trigger
-                expect(resolveStub.called).to.be.false;
-            });
-
-            it('prefers the provided serial over the IP→serial mapping when checking cache', () => {
-                (vscode.window as any).state = { focused: true };
-                manager = new DeviceManager(vscode.context, mockGlobalStateManager);
-
-                // Cache the MAPPED serial. The provided serial is different & uncached.
-                mockGlobalStateManager.setSerialNumberForIp('test-network-hash', '192.168.1.100', 'MAPPED-SERIAL');
-                mockGlobalStateManager.setCachedDevice('MAPPED-SERIAL', {
-                    serialNumber: 'MAPPED-SERIAL',
-                    deviceInfo: {},
-                    createdAt: Date.now()
-                });
-
-                const resolveStub = sinon.stub(manager as any, 'resolveUncachedDiscoveredDevices').resolves();
-
-                manager['handleDeviceOnline']('192.168.1.100', 'PROVIDED-SERIAL');
-
-                // Provided serial wins → no cache for it → should trigger resolution
-                expect(resolveStub.calledOnce).to.be.true;
-            });
-
-            it('triggers resolveUncachedDiscoveredDevices when neither serial provided nor mapped', () => {
-                (vscode.window as any).state = { focused: true };
-                manager = new DeviceManager(vscode.context, mockGlobalStateManager);
-
-                const resolveStub = sinon.stub(manager as any, 'resolveUncachedDiscoveredDevices').resolves();
-
-                manager['handleDeviceOnline']('192.168.1.100');
-
-                // No serial → hasCache=false → focused → triggers resolution
-                expect(resolveStub.calledOnce).to.be.true;
-            });
-
-            it('swallows errors from resolveUncachedDiscoveredDevices so the caller is not affected', () => {
-                (vscode.window as any).state = { focused: true };
-                manager = new DeviceManager(vscode.context, mockGlobalStateManager);
-
-                sinon.stub(manager as any, 'resolveUncachedDiscoveredDevices').rejects(new Error('network down'));
-
-                // Should not throw
-                expect(() => manager['handleDeviceOnline']('192.168.1.100', 'YN00AB123456')).to.not.throw();
-            });
-        });
+        //NOTE: ssdp:alive deliberately does NOT trigger eager health checks — lazy hydration
+        //on read covers uncached devices when a view actually asks for the list (spec:
+        //"Passive SSDP announcements" / "Lazy hydration on read")
     });
 
-    describe('notifyFocusGained / resolveUncachedDiscoveredDevices', () => {
-        it('health-checks discovered devices that have no serial number', async () => {
+    describe('notifyFocusGained', () => {
+        it('starts the network change monitor and does NOT health-check devices', () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
             manager['discoveredDevices'].push({ ip: '192.168.1.100' });
-
-            const healthCheckStub = sinon.stub(manager, 'healthCheckDevice').resolves(true);
-
-            await manager['resolveUncachedDiscoveredDevices']();
-
-            expect(healthCheckStub.calledOnce).to.be.true;
-            expect(healthCheckStub.firstCall.args[0]).to.deep.equal({ ip: '192.168.1.100', serialNumber: undefined });
-            expect(healthCheckStub.firstCall.args[1]).to.equal(false);
-            expect(healthCheckStub.firstCall.args[2]).to.equal(false);
-        });
-
-        it('health-checks discovered devices that have a serial but no cache entry', async () => {
-            manager = new DeviceManager(vscode.context, mockGlobalStateManager);
-
-            manager['discoveredDevices'].push({ ip: '192.168.1.101', serialNumber: 'no-cache-serial' });
-
-            const healthCheckStub = sinon.stub(manager, 'healthCheckDevice').resolves(true);
-
-            await manager['resolveUncachedDiscoveredDevices']();
-
-            expect(healthCheckStub.calledOnce).to.be.true;
-            expect(healthCheckStub.firstCall.args[0]).to.deep.equal({ ip: '192.168.1.101', serialNumber: 'no-cache-serial' });
-        });
-
-        it('skips discovered devices that already have a cache entry', async () => {
-            manager = new DeviceManager(vscode.context, mockGlobalStateManager);
-
-            // Cache a device, then add it to discoveredDevices
-            mockGlobalStateManager.setCachedDevice('cached-serial', {
-                serialNumber: 'cached-serial',
-                deviceInfo: { 'default-device-name': 'Cached Roku' },
-                createdAt: Date.now()
-            });
-            manager['discoveredDevices'].push({ ip: '192.168.1.102', serialNumber: 'cached-serial' });
-
-            const healthCheckStub = sinon.stub(manager, 'healthCheckDevice').resolves(true);
-
-            await manager['resolveUncachedDiscoveredDevices']();
-
-            expect(healthCheckStub.called).to.be.false;
-        });
-
-        it('health-checks only the uncached entries when both cached and uncached exist', async () => {
-            manager = new DeviceManager(vscode.context, mockGlobalStateManager);
-
-            // One cached, one uncached, one without serial
-            mockGlobalStateManager.setCachedDevice('cached-serial', {
-                serialNumber: 'cached-serial',
-                deviceInfo: { 'default-device-name': 'Cached Roku' },
-                createdAt: Date.now()
-            });
-            manager['discoveredDevices'].push(
-                { ip: '192.168.1.100', serialNumber: 'cached-serial' },
-                { ip: '192.168.1.101', serialNumber: 'uncached-serial' },
-                { ip: '192.168.1.102' }
-            );
-
-            const healthCheckStub = sinon.stub(manager, 'healthCheckDevice').resolves(true);
-
-            await manager['resolveUncachedDiscoveredDevices']();
-
-            expect(healthCheckStub.calledTwice).to.be.true;
-            const ips = healthCheckStub.getCalls().map(c => (c.args[0] as any).ip).sort();
-            expect(ips).to.deep.equal(['192.168.1.101', '192.168.1.102']);
-        });
-
-        it('does nothing when there are no discovered devices', async () => {
-            manager = new DeviceManager(vscode.context, mockGlobalStateManager);
-
-            const healthCheckStub = sinon.stub(manager, 'healthCheckDevice').resolves(true);
-
-            await manager['resolveUncachedDiscoveredDevices']();
-
-            expect(healthCheckStub.called).to.be.false;
-        });
-
-        it('does nothing when all discovered devices are cached', async () => {
-            manager = new DeviceManager(vscode.context, mockGlobalStateManager);
-
-            mockGlobalStateManager.setCachedDevice('serial-a', {
-                serialNumber: 'serial-a', deviceInfo: {}, createdAt: Date.now()
-            });
-            mockGlobalStateManager.setCachedDevice('serial-b', {
-                serialNumber: 'serial-b', deviceInfo: {}, createdAt: Date.now()
-            });
-            manager['discoveredDevices'].push(
-                { ip: '192.168.1.100', serialNumber: 'serial-a' },
-                { ip: '192.168.1.101', serialNumber: 'serial-b' }
-            );
-
-            const healthCheckStub = sinon.stub(manager, 'healthCheckDevice').resolves(true);
-
-            await manager['resolveUncachedDiscoveredDevices']();
-
-            expect(healthCheckStub.called).to.be.false;
-        });
-
-        it('runs health checks in parallel (does not await one before starting the next)', async () => {
-            manager = new DeviceManager(vscode.context, mockGlobalStateManager);
-
-            manager['discoveredDevices'].push(
-                { ip: '192.168.1.100' },
-                { ip: '192.168.1.101' },
-                { ip: '192.168.1.102' }
-            );
-
-            // Resolve health checks only after all three have been kicked off
-            let resolveAll: () => void;
-            const allKickedOff = new Promise<void>(resolve => {
-                resolveAll = resolve;
-            });
-
-            let inFlight = 0;
-            const healthCheckStub = sinon.stub(manager, 'healthCheckDevice').callsFake(async () => {
-                inFlight++;
-                if (inFlight === 3) {
-                    resolveAll();
-                }
-                await allKickedOff;
-                return true;
-            });
-
-            await manager['resolveUncachedDiscoveredDevices']();
-
-            expect(healthCheckStub.callCount).to.equal(3);
-        });
-
-        it('continues resolving other devices even if one healthCheck rejects', async () => {
-            manager = new DeviceManager(vscode.context, mockGlobalStateManager);
-
-            manager['discoveredDevices'].push(
-                { ip: '192.168.1.100' },
-                { ip: '192.168.1.101' }
-            );
-
-            const healthCheckStub = sinon.stub(manager, 'healthCheckDevice');
-            healthCheckStub.onFirstCall().rejects(new Error('boom'));
-            healthCheckStub.onSecondCall().resolves(true);
-
-            // Should not reject
-            await manager['resolveUncachedDiscoveredDevices']();
-
-            expect(healthCheckStub.calledTwice).to.be.true;
-        });
-
-        it('is triggered by notifyFocusGained', () => {
-            manager = new DeviceManager(vscode.context, mockGlobalStateManager);
-
-            manager['discoveredDevices'].push({ ip: '192.168.1.100' });
-
+            const startStub = sinon.stub(manager['networkChangeMonitor'], 'start');
             const healthCheckStub = sinon.stub(manager, 'healthCheckDevice').resolves(true);
 
             manager['notifyFocusGained']();
 
-            expect(healthCheckStub.calledOnce).to.be.true;
-            expect(healthCheckStub.firstCall.args[0]).to.deep.equal({ ip: '192.168.1.100', serialNumber: undefined });
+            expect(startStub.calledOnce).to.be.true;
+            expect(healthCheckStub.called).to.be.false;
+        });
+    });
+
+    describe('lazy hydration on read', () => {
+        function flush(): Promise<void> {
+            return new Promise(resolve => {
+                setTimeout(resolve, 5);
+            });
+        }
+
+        it('queues a background resolve for an unknown device with no cached deviceInfo', async () => {
+            manager = new DeviceManager(vscode.context, mockGlobalStateManager);
+            const resolveStub = sinon.stub(manager as any, 'resolveDevice').returns(Promise.resolve(true) as any);
+
+            //a bare {ip, serial} entry, e.g. from ssdp:alive — no cache seeded
+            manager['discoveredDevices'].push({ ip: '192.168.1.50', serialNumber: 'no-cache-1' });
+            manager['setDeviceState']({ ip: '192.168.1.50', serialNumber: 'no-cache-1' }, 'unknown');
+
+            manager.getAllDevices();
+            await flush();
+
+            expect(resolveStub.calledOnce).to.be.true;
+            expect(resolveStub.firstCall.args[0]).to.deep.equal({ ip: '192.168.1.50', serialNumber: 'no-cache-1' });
+            //silent background refresh: no synthetic delay, not forced
+            expect(resolveStub.firstCall.args[1]).to.equal(false);
+            expect(resolveStub.firstCall.args[2]).to.equal(false);
+        });
+
+        it('does not hydrate a device whose cache is fresh', async () => {
+            manager = new DeviceManager(vscode.context, mockGlobalStateManager);
+            const resolveStub = sinon.stub(manager as any, 'resolveDevice').returns(Promise.resolve(true) as any);
+
+            const device = createMockDevice({ serialNumber: 'fresh-1', ip: '192.168.1.51', deviceInfo: { 'default-device-name': 'Roku Express' } });
+            addDevice(device);
+
+            manager.getAllDevices();
+            await flush();
+
+            expect(resolveStub.called).to.be.false;
+        });
+
+        it('hydrates a device whose cache is older than 8 hours, regardless of state', async () => {
+            manager = new DeviceManager(vscode.context, mockGlobalStateManager);
+            const resolveStub = sinon.stub(manager as any, 'resolveDevice').returns(Promise.resolve(true) as any);
+
+            const device = createMockDevice({ serialNumber: 'old-1', ip: '192.168.1.52', deviceInfo: { 'default-device-name': 'Roku Express' } });
+            addDevice(device);
+            //age the cache past the 8h hydration threshold
+            mockGlobalStateManager.setCachedDevice('old-1', {
+                serialNumber: 'old-1',
+                deviceInfo: { 'serial-number': 'old-1' },
+                createdAt: Date.now() - (8 * 60 * 60 * 1_000) - 1
+            });
+
+            manager.getAllDevices();
+            await flush();
+
+            expect(resolveStub.calledOnce).to.be.true;
+        });
+
+        it('does not re-queue a pending device (converges instead of looping)', async () => {
+            manager = new DeviceManager(vscode.context, mockGlobalStateManager);
+            const resolveStub = sinon.stub(manager as any, 'resolveDevice').returns(Promise.resolve(true) as any);
+
+            manager['discoveredDevices'].push({ ip: '192.168.1.53', serialNumber: 'pending-1' });
+            manager['setDeviceState']({ ip: '192.168.1.53', serialNumber: 'pending-1' }, 'pending');
+
+            manager.getAllDevices();
+            await flush();
+
+            expect(resolveStub.called).to.be.false;
+        });
+
+        it('rate-limits repeated attempts per IP (a failing device is not hammered on every read)', async () => {
+            manager = new DeviceManager(vscode.context, mockGlobalStateManager);
+            const resolveStub = sinon.stub(manager as any, 'resolveDevice').returns(Promise.resolve(false) as any);
+
+            manager['discoveredDevices'].push({ ip: '192.168.1.54', serialNumber: 'flaky-1' });
+            manager['setDeviceState']({ ip: '192.168.1.54', serialNumber: 'flaky-1' }, 'unknown');
+
+            //views re-read on every devices-changed — simulate several rapid reads
+            manager.getAllDevices();
+            await flush();
+            manager.getAllDevices();
+            manager.getAllDevices();
+            await flush();
+
+            expect(resolveStub.calledOnce).to.be.true;
+        });
+
+        it('getDevice (single lookup) also triggers hydration', async () => {
+            manager = new DeviceManager(vscode.context, mockGlobalStateManager);
+            const resolveStub = sinon.stub(manager as any, 'resolveDevice').returns(Promise.resolve(true) as any);
+
+            manager['discoveredDevices'].push({ ip: '192.168.1.55', serialNumber: 'single-1' });
+            manager['setDeviceState']({ ip: '192.168.1.55', serialNumber: 'single-1' }, 'unknown');
+
+            manager.getDevice({ ip: '192.168.1.55' });
+            await flush();
+
+            expect(resolveStub.calledOnce).to.be.true;
         });
     });
 

--- a/src/deviceDiscovery/DeviceManager.spec.ts
+++ b/src/deviceDiscovery/DeviceManager.spec.ts
@@ -969,6 +969,60 @@ describe('DeviceManager', () => {
             expect(manager.getAllDevices().length).to.equal(0);
         });
 
+        it('discards an earlier check\'s result when a newer check for the same IP already applied its own', async () => {
+            manager = new DeviceManager(vscode.context, mockGlobalStateManager);
+            (vscode.window as any).state = { focused: true };
+
+            const device = createMockDevice({ serialNumber: 'device-1', ip: '192.168.1.101' });
+            addDevice(device);
+
+            // First check's network call fails fast (device unreachable) - this is NOT the race
+            // window. The race window is the synthetic delay that runs *after* the fetch settles.
+            const getDeviceInfoStub = sinon.stub(rokuDeploy, 'getDeviceInfo');
+            getDeviceInfoStub.onCall(0).rejects(new Error('Unreachable'));
+            getDeviceInfoStub.onCall(1).resolves({
+                'device-id': 'device-1',
+                'serial-number': 'device-1',
+                'default-device-name': 'Roku Express'
+            } as any);
+
+            // Hold the first check's synthetic delay open so a second, independent check can
+            // start, finish, and apply its result before the first one resumes.
+            let releaseFirstDelay: () => void;
+            const firstDelay = new Promise<void>(resolve => {
+                releaseFirstDelay = resolve;
+            });
+            const randomDelayStub = sinon.stub(manager as any, 'randomDelay');
+            randomDelayStub.onCall(0).returns(firstDelay);
+            randomDelayStub.onCall(1).resolves();
+
+            // Start the first (soon-to-be-stale) check.
+            const firstCheck = manager['resolveDevice'](device, true);
+
+            // Let it reach (and suspend on) its synthetic delay. By that point its own network
+            // call has already failed and cleared out of the in-flight map, which is what lets
+            // the second check below issue its own independent request instead of joining it.
+            for (let i = 0; i < 20 && randomDelayStub.callCount < 1; i++) {
+                await Promise.resolve();
+            }
+            expect(randomDelayStub.callCount).to.equal(1);
+
+            // Start a second, newer check for the SAME device while the first is still suspended.
+            await manager['resolveDevice'](device, true);
+
+            // The newer check's result (online) is applied.
+            expect(manager.getAllDevices()[0].deviceState).to.equal('online');
+
+            // Now let the first (stale) check's failure resolve. Its result must be discarded -
+            // it must NOT flip the device back to offline or remove it.
+            releaseFirstDelay();
+            await firstCheck;
+
+            expect(getDeviceInfoStub.callCount).to.equal(2);
+            expect(manager.getAllDevices().length).to.equal(1);
+            expect(manager.getAllDevices()[0].deviceState).to.equal('online');
+        });
+
         it('preserves cache data when device goes offline (for offline display)', async () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
             (vscode.window as any).state = { focused: true };
@@ -1012,7 +1066,11 @@ describe('DeviceManager', () => {
             expect(result).to.be.true;
         });
 
-        it('ignores stale health check response when newer check completes first', async () => {
+        it('concurrent health checks of the same device share one request (the de-dupe rule)', async () => {
+            // Under the de-dupe rule, two truly-concurrent checks can no longer race two
+            // different responses — the second joins the first's in-flight request. The
+            // still-possible ordering hazard (first check settles, second starts and applies,
+            // first applies late) is covered by the "discards an earlier check's result" test.
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
             (vscode.window as any).state = { focused: true };
 
@@ -1022,43 +1080,24 @@ describe('DeviceManager', () => {
             // Stub refresh to prevent cascade of health checks
             sinon.stub(manager, 'refresh');
 
-            // Create two controllable promises for the health checks
-            let rejectSlowCheck: (err: Error) => void;
-            let resolveFastCheck: (value: any) => void;
-            const slowCheckPromise = new Promise<any>((_resolve, reject) => {
-                rejectSlowCheck = reject;
-            });
-            const fastCheckPromise = new Promise<any>(resolve => {
-                resolveFastCheck = resolve;
-            });
+            let resolveFetch: (value: any) => void;
+            const getDeviceInfoStub = sinon.stub(rokuDeploy, 'getDeviceInfo').returns(new Promise<any>(resolve => {
+                resolveFetch = resolve;
+            }) as any);
 
-            const getDeviceInfoStub = sinon.stub(rokuDeploy, 'getDeviceInfo');
-            getDeviceInfoStub.onFirstCall().returns(slowCheckPromise);
-            getDeviceInfoStub.onSecondCall().returns(fastCheckPromise);
+            const first = manager.healthCheckDevice(device, true, false);
+            const second = manager.healthCheckDevice(device, true, false);
 
-            // Start first (slow) health check - will return unhealthy
-            const slowResult = manager.healthCheckDevice(device, true);
-
-            // Start second (fast) health check - will return healthy
-            const fastResult = manager.healthCheckDevice(device, true);
-
-            // Fast check completes first with healthy result
-            resolveFastCheck({
+            resolveFetch({
                 'device-id': 'device-123',
                 'serial-number': 'device-123',
                 'default-device-name': 'Roku Express'
             });
-            await fastResult;
+            const [firstResult, secondResult] = await Promise.all([first, second]);
 
-            // Device should be online (fast check succeeded)
-            expect(manager.getAllDevices().length).to.equal(1);
-            expect(manager.getAllDevices()[0].deviceState).to.equal('online');
-
-            // Slow check completes later with unhealthy result
-            rejectSlowCheck(new Error('Device not responding'));
-            await slowResult;
-
-            // Device should STILL be online - slow check result was ignored (stale)
+            expect(getDeviceInfoStub.calledOnce).to.be.true;
+            expect(firstResult).to.be.true;
+            expect(secondResult).to.be.true;
             expect(manager.getAllDevices().length).to.equal(1);
             expect(manager.getAllDevices()[0].deviceState).to.equal('online');
         });
@@ -1742,12 +1781,61 @@ describe('DeviceManager', () => {
                 'default-device-name': 'Roku Express'
             } as any);
 
-            // Call twice in rapid succession - both should hit network
+            // Call twice SEQUENTIALLY - both should hit network (in-flight sharing only applies
+            // to concurrent callers; a settled request is not reused)
             await manager['fetchDeviceInfo']('192.168.1.100', 8060);
             await manager['fetchDeviceInfo']('192.168.1.100', 8060);
 
             // fetchDeviceInfo always makes network calls (caching is in resolveDevice)
             expect(getDeviceInfoStub.callCount).to.equal(2);
+        });
+    });
+
+    describe('fetchDeviceInfo in-flight de-dupe (the design doc\'s "de-dupe rule")', () => {
+        it('shares a single HTTP request between concurrent callers for the same ip:port', async () => {
+            manager = new DeviceManager(vscode.context, mockGlobalStateManager);
+
+            let resolveFetch: (value: any) => void;
+            const getDeviceInfoStub = sinon.stub(rokuDeploy, 'getDeviceInfo').returns(new Promise((resolve) => {
+                resolveFetch = resolve;
+            }) as any);
+
+            //e.g. the broadcast response and the reconcile racing on the same device
+            const first = manager['fetchDeviceInfo']('192.168.1.10', 8060);
+            const second = manager['fetchDeviceInfo']('192.168.1.10', 8060);
+
+            resolveFetch({ 'serial-number': 'shared-1' });
+            const [firstResult, secondResult] = await Promise.all([first, second]);
+
+            expect(getDeviceInfoStub.calledOnce).to.be.true;
+            expect(firstResult['serial-number']).to.equal('shared-1');
+            expect(secondResult['serial-number']).to.equal('shared-1');
+        });
+
+        it('does not share requests across different IPs', async () => {
+            manager = new DeviceManager(vscode.context, mockGlobalStateManager);
+            const getDeviceInfoStub = sinon.stub(rokuDeploy, 'getDeviceInfo').resolves({ 'serial-number': 'x' } as any);
+
+            await Promise.all([
+                manager['fetchDeviceInfo']('192.168.1.10', 8060),
+                manager['fetchDeviceInfo']('192.168.1.11', 8060)
+            ]);
+
+            expect(getDeviceInfoStub.calledTwice).to.be.true;
+        });
+
+        it('shares failures too (joiners get undefined, no unhandled rejection)', async () => {
+            manager = new DeviceManager(vscode.context, mockGlobalStateManager);
+            const getDeviceInfoStub = sinon.stub(rokuDeploy, 'getDeviceInfo').rejects(new Error('Unreachable'));
+
+            const [first, second] = await Promise.all([
+                manager['fetchDeviceInfo']('192.168.1.10', 8060),
+                manager['fetchDeviceInfo']('192.168.1.10', 8060)
+            ]);
+
+            expect(getDeviceInfoStub.calledOnce).to.be.true;
+            expect(first).to.be.undefined;
+            expect(second).to.be.undefined;
         });
     });
 

--- a/src/deviceDiscovery/DeviceManager.spec.ts
+++ b/src/deviceDiscovery/DeviceManager.spec.ts
@@ -1243,7 +1243,7 @@ describe('DeviceManager', () => {
 
             const result = await manager['ensureDeviceFresh'](device, { maxAgeMs: 0, syntheticDelay: false });
 
-            expect(result).to.be.false;
+            expect(result).to.be.undefined;
             expect(manager.getAllDevices().length).to.equal(0);
         });
 
@@ -2539,7 +2539,7 @@ describe('DeviceManager', () => {
 
                 const result = await manager['ensureDeviceFresh'](device, { maxAgeMs: 0, syntheticDelay: false });
 
-                expect(result).to.be.false;
+                expect(result).to.be.undefined;
                 expect(manager.getAllDevices().length).to.equal(1);
                 expect(manager.getAllDevices()[0].deviceState).to.equal('offline');
             });
@@ -2563,7 +2563,7 @@ describe('DeviceManager', () => {
 
                 const result = await manager['ensureDeviceFresh'](device, { maxAgeMs: 0, syntheticDelay: false });
 
-                expect(result).to.be.false;
+                expect(result).to.be.undefined;
                 expect(manager.getAllDevices().length).to.equal(1);
                 // State is always 'offline' - icon logic uses cache check to distinguish
                 expect(manager.getAllDevices()[0].deviceState).to.equal('offline');
@@ -2587,7 +2587,7 @@ describe('DeviceManager', () => {
 
                 const result = await manager['ensureDeviceFresh'](device, { maxAgeMs: 0, syntheticDelay: false });
 
-                expect(result).to.be.false;
+                expect(result).to.be.undefined;
                 expect(manager.getAllDevices().length).to.equal(0);
             });
         });

--- a/src/deviceDiscovery/DeviceManager.spec.ts
+++ b/src/deviceDiscovery/DeviceManager.spec.ts
@@ -1247,61 +1247,6 @@ describe('DeviceManager', () => {
             expect(manager.getAllDevices().length).to.equal(0);
         });
 
-        it('discards an earlier check\'s result when a newer check for the same IP already applied its own', async () => {
-            manager = new DeviceManager(vscode.context, mockGlobalStateManager);
-            (vscode.window as any).state = { focused: true };
-
-            const device = createMockDevice({ serialNumber: 'device-1', ip: '192.168.1.101' });
-            addDevice(device);
-
-            // First check's network call fails fast (device unreachable) - this is NOT the race
-            // window. The race window is the synthetic delay that runs *after* the fetch settles.
-            const getDeviceInfoStub = sinon.stub(rokuDeploy, 'getDeviceInfo');
-            getDeviceInfoStub.onCall(0).rejects(new Error('Unreachable'));
-            getDeviceInfoStub.onCall(1).resolves({
-                'device-id': 'device-1',
-                'serial-number': 'device-1',
-                'default-device-name': 'Roku Express'
-            } as any);
-
-            // Hold the first check's synthetic delay open so a second, independent check can
-            // start, finish, and apply its result before the first one resumes.
-            let releaseFirstDelay: () => void;
-            const firstDelay = new Promise<void>(resolve => {
-                releaseFirstDelay = resolve;
-            });
-            const randomDelayStub = sinon.stub(manager as any, 'randomDelay');
-            randomDelayStub.onCall(0).returns(firstDelay);
-            randomDelayStub.onCall(1).resolves();
-
-            // Start the first (soon-to-be-stale) check.
-            const firstCheck = manager['ensureDeviceFresh'](device);
-
-            // Let it reach (and suspend on) its synthetic delay. By that point its own network
-            // call has already failed and cleared out of the in-flight map, which is what lets
-            // the second check below issue its own independent request instead of joining it.
-            for (let i = 0; i < 20 && randomDelayStub.callCount < 1; i++) {
-                await Promise.resolve();
-            }
-            expect(randomDelayStub.callCount).to.equal(1);
-
-            // Start a second, newer check for the SAME device while the first is still
-            // suspended (maxAgeMs 0 so the freshness guard doesn't answer from pending state)
-            await manager['ensureDeviceFresh'](device, { maxAgeMs: 0 });
-
-            // The newer check's result (online) is applied.
-            expect(manager.getAllDevices()[0].deviceState).to.equal('online');
-
-            // Now let the first (stale) check's failure resolve. Its result must be discarded -
-            // it must NOT flip the device back to offline or remove it.
-            releaseFirstDelay();
-            await firstCheck;
-
-            expect(getDeviceInfoStub.callCount).to.equal(2);
-            expect(manager.getAllDevices().length).to.equal(1);
-            expect(manager.getAllDevices()[0].deviceState).to.equal('online');
-        });
-
         it('preserves cache data when device goes offline (for offline display)', async () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
             (vscode.window as any).state = { focused: true };
@@ -1346,10 +1291,9 @@ describe('DeviceManager', () => {
         });
 
         it('concurrent health checks of the same device share one request (the de-dupe rule)', async () => {
-            // Under the de-dupe rule, two truly-concurrent checks can no longer race two
-            // different responses — the second joins the first's in-flight request. The
-            // still-possible ordering hazard (first check settles, second starts and applies,
-            // first applies late) is covered by the "discards an earlier check's result" test.
+            // Under the de-dupe rule, concurrent checks share one in-flight request, and the
+            // result is applied exactly once when that shared request settles — out-of-order
+            // application is structurally impossible.
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
             (vscode.window as any).state = { focused: true };
 
@@ -3066,18 +3010,15 @@ describe('DeviceManager', () => {
                     expect(getDeviceInfoStub.calledTwice).to.be.true;
                 });
 
-                it('clears deviceCheckSequence map', () => {
+                it('clears the lastCheckedByIp knowledge map', () => {
                     manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
                     const device = createMockDevice();
-
-                    // Populate sequence map
-                    manager['deviceCheckSequence'].set(device.ip, 5);
-                    expect(manager['deviceCheckSequence'].get(device.ip)).to.equal(5);
+                    manager['lastCheckedByIp'].set(device.ip, Date.now());
 
                     manager.clearAllCache();
 
-                    expect(manager['deviceCheckSequence'].has(device.ip)).to.be.false;
+                    expect(manager['lastCheckedByIp'].has(device.ip)).to.be.false;
                 });
             });
 
@@ -3135,36 +3076,6 @@ describe('DeviceManager', () => {
                     // Health check should run immediately (no cooldown)
                     await manager['ensureDeviceFresh'](device);
                     expect(resolveDeviceSpy.calledTwice).to.be.true;
-                });
-
-                it('ignores concurrent health check results after clear', async () => {
-                    manager = new DeviceManager(vscode.context, mockGlobalStateManager);
-
-                    const device = createMockDevice();
-
-                    // Start a health check but don't let it complete
-                    let resolvePromise: ((value: boolean) => void) | undefined;
-                    const healthCheckPromise = new Promise<boolean>((resolve) => {
-                        resolvePromise = resolve;
-                    });
-                    sinon.stub(manager as any, 'ensureDeviceFresh').returns(healthCheckPromise);
-
-                    const healthCheckCall = manager['ensureDeviceFresh'](device);
-
-                    // Clear cache while health check is in flight
-                    manager.clearAllCache();
-
-                    // Sequence should be cleared
-                    expect(manager['deviceCheckSequence'].has(device.ip)).to.be.false;
-
-                    // Complete the health check
-                    if (resolvePromise) {
-                        resolvePromise(true);
-                    }
-                    await healthCheckCall;
-
-                    // Result should be ignored (sequence mismatch)
-                    // The device state should not be updated by the stale health check
                 });
 
                 it('handles multiple rapid clears safely', () => {

--- a/src/deviceDiscovery/DeviceManager.ts
+++ b/src/deviceDiscovery/DeviceManager.ts
@@ -666,7 +666,40 @@ export class DeviceManager {
         this.reconcile(reasons);
         return true;
     }
+
+    /**
+     * Fulfill both pending order types in one call — the common case for views (on open, on
+     * becoming visible). Views that need per-order-type policy (e.g. the quick pick's 7s
+     * fallback only wants broadcasts) can still call the specific fulfillments directly.
+     */
+    public fulfillPendingOrders(options?: { except?: Array<BroadcastReason | ReconcileReason> }): { scanStarted: boolean; reconciled: boolean } {
+        return {
+            scanStarted: this.fulfillPendingBroadcast({ except: options?.except as BroadcastReason[] }),
+            reconciled: this.fulfillPendingReconcile({ except: options?.except as ReconcileReason[] })
+        };
+    }
+
+    /**
+     * The "user clicked refresh / scan" interaction (spec: Clicking refresh): always submits a
+     * broadcast order AND a reconcile order, regardless of how recently either ran. Views report
+     * the interaction; which order types it implies is the manager's business.
+     */
+    public submitRefreshOrders(): void {
+        this.submitBroadcast('refresh-clicked');
+        this.submitReconcile('refresh-clicked');
+    }
     // #endregion
+
+    /**
+     * The user engaged with a specific device — clicked it, expanded it, selected it in the
+     * picker, or is about to launch to it (spec: "explicit engagement with that specific
+     * device"). Freshens the device now (bypassing its cache trust window) and reports whether
+     * it responded. Fire-and-forget callers can ignore the result; callers that need to know
+     * (picker validation, pre-launch checks) await it.
+     */
+    public async deviceEngaged(deviceOrLookup: RokuDevice | { ip?: string; serialNumber?: string }): Promise<boolean> {
+        return this.healthCheckDevice(deviceOrLookup, true, false);
+    }
 
     /**
      * Broadcast an SSDP M-SEARCH to discover devices on the network. Does NOT health-check
@@ -752,7 +785,7 @@ export class DeviceManager {
         this.clearCurrentDeviceList();
     }
 
-    public async healthCheckDevice(deviceOrLookup: RokuDevice | { ip?: string; serialNumber?: string }, force = false, doSyntheticDelay = true): Promise<boolean> {
+    private async healthCheckDevice(deviceOrLookup: RokuDevice | { ip?: string; serialNumber?: string }, force = false, doSyntheticDelay = true): Promise<boolean> {
         // If already a device object with deviceState, use it directly; otherwise look it up
         const device = 'deviceState' in deviceOrLookup
             ? deviceOrLookup

--- a/src/deviceDiscovery/DeviceManager.ts
+++ b/src/deviceDiscovery/DeviceManager.ts
@@ -39,8 +39,9 @@ export class DeviceManager {
             //if the `deviceDiscovery.enabled` setting was changed, start or stop monitoring
             if (event?.affectsConfiguration('brightscript.deviceDiscovery.enabled')) {
                 if (this.deviceDiscoveryEnabled) {
-                    //emit that we need a scan (will trigger UI to refresh and show devices as needed when enabled)
-                    this.setScanNeeded(true);
+                    //order a broadcast + reconcile so the views discover/health-check once enabled
+                    this.submitBroadcast('startup');
+                    this.submitReconcile('startup');
                     this.systemSleepMonitor.start();
                     void this.activateMonitoring();
                 } else {
@@ -54,11 +55,11 @@ export class DeviceManager {
                 this.emitDevicesChanged();
             }
 
-            //if the `devices` setting was changed, re-apply configured devices and health check them
+            //if the `devices` setting was changed, re-apply configured devices immediately (cheap,
+            //local) and order a health check for the views to fulfill when one is visible
             if (event?.affectsConfiguration('brightscript.devices')) {
-                this.loadConfiguredDevices().then(() => {
-                    return this.healthCheckAllDevices(false, true);
-                }).catch(() => { });
+                this.loadConfiguredDevices().catch(() => { });
+                this.submitReconcile('config-changed');
             }
 
             //if the `defaultDevicePassword` setting was changed, refresh any device views that rely on it
@@ -86,7 +87,9 @@ export class DeviceManager {
 
     private setupMonitors() {
         this.systemSleepMonitor = new SystemSleepMonitor(() => {
-            this.setScanNeeded();
+            //order a broadcast + reconcile so the views rescan/health-check on wake
+            this.submitBroadcast('sleep');
+            this.submitReconcile('sleep');
         });
         this.networkChangeMonitor = new NetworkChangeMonitor(() => {
             this.networkId = getNetworkHash();
@@ -107,8 +110,9 @@ export class DeviceManager {
 
             this.restartRokuFinder();
 
-            //this is important for telling the devices view to refresh and health check its devices
-            this.setScanNeeded();
+            //order a broadcast + reconcile so the views rescan/health-check on the new network
+            this.submitBroadcast('network');
+            this.submitReconcile('network');
         });
     }
 
@@ -130,14 +134,13 @@ export class DeviceManager {
             // Sleep monitor runs all the time when enabled (ignores focus state)
             this.systemSleepMonitor.start();
 
-            this.activateMonitoring().then(() => {
-                const lastSeenDeviceIds = this.globalStateManager.getLastSeenDevices(this.networkId);
-                if (lastSeenDeviceIds.length === 0) {
-                    this.refresh();
-                } else {
-                    this.setScanNeeded();
-                }
-            }).catch((e) => {
+            //order a broadcast + reconcile for the views to fulfill when they open.
+            //No proactive scan here even on a cold cache — per the design doc, no network
+            //traffic happens until a view is actually visible to consume these orders.
+            this.submitBroadcast('startup');
+            this.submitReconcile('startup');
+
+            this.activateMonitoring().catch((e) => {
                 console.error(e);
             });
         }
@@ -147,9 +150,16 @@ export class DeviceManager {
     // Core state and dependencies
     private configuredDevices: ConfiguredDeviceEntry[] = [];
     private discoveredDevices: DiscoveredDeviceEntry[] = [];
-    private scanNeeded = false;
     private lastUsedDeviceIp: string | undefined = undefined;
     private networkId: string;
+
+    // Orders (see docs/device-discovery.md "Orders"): deferred work submitted by triggers and
+    // fulfilled by visible views. One pending slot per order type — a newer order replaces the
+    // slot, except a `stale` order never downgrades a pending real trigger.
+    private pendingBroadcast: BroadcastOrder | null = null;
+    private pendingReconcile: ReconcileOrder | null = null;
+    private broadcastStaleTimer: ReturnType<typeof setInterval> | undefined;
+    private reconcileStaleTimer: ReturnType<typeof setInterval> | undefined;
 
     private emitter = new EventEmitter();
     private systemSleepMonitor: SystemSleepMonitor;
@@ -168,14 +178,19 @@ export class DeviceManager {
     private readonly DEVICES_CHANGED_DEBOUNCE_MS = 50;
     private deviceOnlineNotifiers = new Map<string, ReturnType<typeof debounce>>();
 
-    // Scan state management
+    // Scan state management. STALE_SCAN_THRESHOLD_MS is both the non-forced broadcast gate
+    // ("don't scan if the last scan is younger than this") and the `stale` broadcast timer
+    // interval — one definition of "it's been a while".
     private readonly STALE_SCAN_THRESHOLD_MS = 30 * 60 * 1_000; // 30 minutes
+    private readonly STALE_RECONCILE_INTERVAL_MS = 5 * 60 * 1_000; // 5 minutes - the spec's stale reconcile timer
+    private readonly UNHEALTHY_BROADCAST_MIN_INTERVAL_MS = 60_000; // 1 minute - suppress unhealthy-device orders this soon after a scan
     private lastScanDate: Date | null = null;
 
     public on(eventName: 'devices-changed', handler: () => void, disposables?: Disposable[]): () => void;
     public on(eventName: 'scan-started', handler: () => void, disposables?: Disposable[]): () => void;
     public on(eventName: 'scan-ended', handler: () => void, disposables?: Disposable[]): () => void;
-    public on(eventName: 'scanNeeded-changed', handler: () => void, disposables?: Disposable[]): () => void;
+    public on(eventName: 'broadcast-ordered', handler: (order: BroadcastOrder) => void, disposables?: Disposable[]): () => void;
+    public on(eventName: 'reconcile-ordered', handler: (order: ReconcileOrder) => void, disposables?: Disposable[]): () => void;
     public on(eventName: string, handler: (payload: any) => void, disposables?: Disposable[]): () => void {
         this.emitter.on(eventName, handler);
         const unsubscribe = () => {
@@ -504,12 +519,88 @@ export class DeviceManager {
         return !!this.globalStateManager.getCachedDevice(serialNumber);
     }
 
+    // #region Orders (docs/device-discovery.md "Orders" / "When are orders submitted?")
     /**
-     * Re-scan the network for devices and health-check existing ones
+     * Submit a broadcast (SSDP scan) order. Fills the pending slot AND emits `broadcast-ordered`
+     * so a visible view can fulfill it live; a hidden view consumes the slot when it opens.
+     * A `stale` submission never overwrites a pending real trigger.
      */
-    public refresh(force = false, doSyntheticDelay = true): boolean {
-        this.healthCheckAllDevices(force, doSyntheticDelay).catch(() => { });
-        // Block automatic scans when device discovery is disabled
+    public submitBroadcast(reason: BroadcastReason): void {
+        const order: BroadcastOrder = { reason: reason, timestamp: Date.now() };
+        if (!(this.pendingBroadcast && this.pendingBroadcast.reason !== 'stale' && reason === 'stale')) {
+            this.pendingBroadcast = order;
+        }
+        this.emitter.emit('broadcast-ordered', order);
+    }
+
+    /**
+     * Submit a reconcile (health-check-all) order. Same slot + event semantics as
+     * {@link submitBroadcast}.
+     */
+    public submitReconcile(reason: ReconcileReason): void {
+        const order: ReconcileOrder = { reason: reason, timestamp: Date.now() };
+        if (!(this.pendingReconcile && this.pendingReconcile.reason !== 'stale' && reason === 'stale')) {
+            this.pendingReconcile = order;
+        }
+        this.emitter.emit('reconcile-ordered', order);
+    }
+
+    /**
+     * The pending broadcast order, if a trigger queued one that no view has fulfilled yet.
+     */
+    public getPendingBroadcast(): BroadcastOrder | null {
+        return this.pendingBroadcast;
+    }
+
+    public getPendingReconcile(): ReconcileOrder | null {
+        return this.pendingReconcile;
+    }
+
+    /**
+     * Atomically consume AND execute the pending broadcast order, if any. The one-call
+     * fulfillment API for views: take + broadcast in a single step, with the force policy owned
+     * here — forced for every reason except `stale`, which stays staleness-gated.
+     *
+     * Consumption is atomic: when two visible views react to the same order event, the first
+     * caller fulfills it and later callers find the slot empty and do nothing.
+     *
+     * @param options.except - reasons to leave QUEUED (not consumed) for another view, e.g.
+     *   `{ except: ['stale'] }`. A blacklist on purpose: new reasons are acted on by default.
+     * @returns true if an order was consumed and a scan actually started
+     */
+    public fulfillPendingBroadcast(options?: { except?: BroadcastReason[] }): boolean {
+        const pending = this.pendingBroadcast;
+        if (!pending || options?.except?.includes(pending.reason)) {
+            return false;
+        }
+        this.pendingBroadcast = null;
+        return this.broadcast(pending.reason !== 'stale');
+    }
+
+    /**
+     * Atomically consume AND execute the pending reconcile order, if any. One-call twin of
+     * {@link fulfillPendingBroadcast}; the force policy here is: forced only for
+     * `refresh-clicked` (an explicit "I want fresh data now" from the user).
+     */
+    public fulfillPendingReconcile(options?: { except?: ReconcileReason[] }): boolean {
+        const pending = this.pendingReconcile;
+        if (!pending || options?.except?.includes(pending.reason)) {
+            return false;
+        }
+        this.pendingReconcile = null;
+        this.reconcile(pending.reason === 'refresh-clicked');
+        return true;
+    }
+    // #endregion
+
+    /**
+     * Broadcast an SSDP M-SEARCH to discover devices on the network. Does NOT health-check
+     * existing devices — that's {@link reconcile}. Non-forced calls are staleness-gated (no
+     * scan when the last scan is younger than STALE_SCAN_THRESHOLD_MS) and blocked while
+     * device discovery is disabled.
+     * @returns true if a scan was started
+     */
+    public broadcast(force = false): boolean {
         if (!force && !this.deviceDiscoveryEnabled) {
             return false;
         }
@@ -517,23 +608,18 @@ export class DeviceManager {
     }
 
     /**
-     * Trigger a network scan for devices without health checking existing devices.
-     * Use this when you just want to discover new devices without verifying existing ones.
-     * @param force - If true, scan even if deviceDiscovery is disabled
-     * @returns true if a scan was started, false otherwise
+     * Health-check every known device (configured + discovered), marking them online/offline.
+     * Does NOT scan for new devices — that's {@link broadcast}.
      */
-    public scan(force = false): boolean {
-        if (!force && !this.deviceDiscoveryEnabled) {
-            return false;
-        }
-        return this.discoverAll(force);
+    public reconcile(force = false, doSyntheticDelay = true): void {
+        this.healthCheckAllDevices(force, doSyntheticDelay).catch(() => { });
     }
 
     /**
      * Clear discovered devices from the device list, keeping configured devices.
      * Useful for refreshing the network scan without losing user-configured devices.
      */
-    public async clearCurrentDeviceList() {
+    public clearCurrentDeviceList(): void {
         // Clear discovered devices (ephemeral)
         this.discoveredDevices = [];
 
@@ -550,9 +636,10 @@ export class DeviceManager {
         //clear the cache for the current list of devices
         this.globalStateManager.setLastSeenDevices(this.networkId, []);
 
-        await this.healthCheckAllDevices(false, false).catch(() => { });
+        //this is a user-initiated action, so order a health check of the remaining (configured)
+        //devices rather than running one directly — a visible view fulfills it immediately
+        this.submitReconcile('refresh-clicked');
         this.emitDevicesChanged();
-
     }
 
     public clearAllCache() {
@@ -576,7 +663,7 @@ export class DeviceManager {
         }
 
         // Clear discovered devices (state goes with them)
-        this.clearCurrentDeviceList().catch(() => { });
+        this.clearCurrentDeviceList();
     }
 
     public async healthCheckDevice(deviceOrLookup: RokuDevice | { ip?: string; serialNumber?: string }, force = false, doSyntheticDelay = true): Promise<boolean> {
@@ -592,10 +679,26 @@ export class DeviceManager {
         // Cooldown is handled by fetchDeviceInfo cache; force bypasses it
         const isHealthy = await this.resolveDevice(device, doSyntheticDelay, force);
         if (!isHealthy && device.isDiscovered) {
-            // force a scan if passive scan is permitted
-            this.refresh(this.deviceDiscoveryEnabled);
+            // a discovered device went dark — order a rescan for the views to fulfill
+            this.submitUnhealthyDeviceBroadcast();
         }
         return isHealthy;
+    }
+
+    /**
+     * Submit an `unhealthy-device` broadcast order (a discovered device failed a health check,
+     * so the network picture may have changed). Rate-limited: suppressed when discovery is
+     * disabled or when a scan ran within the last minute — the terminating guard for the
+     * potential scan → health-check → fail → scan feedback loop.
+     */
+    private submitUnhealthyDeviceBroadcast(): void {
+        if (!this.deviceDiscoveryEnabled) {
+            return;
+        }
+        if (this.timeSinceLastScan < this.UNHEALTHY_BROADCAST_MIN_INTERVAL_MS) {
+            return;
+        }
+        this.submitBroadcast('unhealthy-device');
     }
 
     /**
@@ -1048,7 +1151,7 @@ export class DeviceManager {
         }
         this.emitDevicesChanged();
 
-        // Health check all devices - if any discovered device is unhealthy, trigger a scan
+        // Health check all devices - if any discovered device is unhealthy, order a scan
         let needsScan = false;
         await Promise.all([...allIps].map(async (ip) => {
             const isHealthy = await this.resolveDevice({ ip: ip }, doSyntheticDelay, force);
@@ -1058,7 +1161,7 @@ export class DeviceManager {
         }));
 
         if (needsScan) {
-            this.discoverAll(this.deviceDiscoveryEnabled);
+            this.submitUnhealthyDeviceBroadcast();
         }
     }
 
@@ -1158,8 +1261,7 @@ export class DeviceManager {
      * Discover all Roku devices on the network and watch for new ones that connect
      */
     private discoverAll(force: boolean): boolean {
-        if (force || this.scanNeeded || this.timeSinceLastScan > this.STALE_SCAN_THRESHOLD_MS) {
-            this.scanNeeded = false;
+        if (force || this.timeSinceLastScan > this.STALE_SCAN_THRESHOLD_MS) {
             this.lastScanDate = new Date();
             this.finder.scan();
             return true;
@@ -1393,12 +1495,39 @@ export class DeviceManager {
 
     private async activateMonitoring() {
         this.networkChangeMonitor.start();
+
+        //periodically submit `stale` broadcast/reconcile orders so long-lived sessions
+        //eventually refresh (the spec's "it's been a while" timers; views decide whether and
+        //how to fulfill them — visible views deliberately ignore live `stale` orders)
+        this.stopStaleTimers();
+        this.broadcastStaleTimer = setInterval(() => {
+            this.submitBroadcast('stale');
+        }, this.STALE_SCAN_THRESHOLD_MS);
+        this.reconcileStaleTimer = setInterval(() => {
+            this.submitReconcile('stale');
+        }, this.STALE_RECONCILE_INTERVAL_MS);
+        //don't keep the process alive just for these timers
+        this.broadcastStaleTimer?.unref?.();
+        this.reconcileStaleTimer?.unref?.();
+
         await this.startRokuFinder();
     }
 
     private deactivateMonitoring() {
         this.networkChangeMonitor.stop();
+        this.stopStaleTimers();
         this.stopRokuFinder();
+    }
+
+    private stopStaleTimers() {
+        if (this.broadcastStaleTimer) {
+            clearInterval(this.broadcastStaleTimer);
+            this.broadcastStaleTimer = undefined;
+        }
+        if (this.reconcileStaleTimer) {
+            clearInterval(this.reconcileStaleTimer);
+            this.reconcileStaleTimer = undefined;
+        }
     }
 
     /**
@@ -1501,17 +1630,6 @@ export class DeviceManager {
         this.networkChangeMonitor.stop();
     }
 
-    /**
-     * Set the flag indicating a scan is needed. Emits 'scanNeeded-changed' event
-     * when the flag flips from false to true.
-     */
-    private setScanNeeded(force = false): void {
-        if (!this.scanNeeded || force) {
-            this.scanNeeded = true;
-            this.emitter.emit('scanNeeded-changed');
-        }
-    }
-
     private emitDevicesChanged = throttleBounce(() => {
         this.emitter.emit('devices-changed');
     }, this.DEVICES_CHANGED_DEBOUNCE_MS);
@@ -1523,6 +1641,45 @@ export class DeviceManager {
 }
 
 export type DeviceState = 'offline' | 'unknown' | 'pending' | 'online';
+
+/**
+ * Why a broadcast (SSDP scan) was ordered. Views filter on this — e.g. a visible view ignores
+ * `stale` (timer-driven) orders to avoid surprise scans. (See docs/device-discovery.md "Orders")
+ */
+export type BroadcastReason =
+    | 'startup'
+    | 'network'
+    | 'sleep'
+    | 'refresh-clicked'
+    | 'unhealthy-device'
+    | 'stale';
+
+/**
+ * Why a reconcile (health-check-all) was ordered.
+ */
+export type ReconcileReason =
+    | 'startup'
+    | 'network'
+    | 'sleep'
+    | 'refresh-clicked'
+    | 'config-changed'
+    | 'stale';
+
+/**
+ * A unit of deferred work: queued by triggers, fulfilled by visible views.
+ */
+export interface BroadcastOrder {
+    reason: BroadcastReason;
+    /**
+     * When the order was submitted (ms epoch)
+     */
+    timestamp: number;
+}
+
+export interface ReconcileOrder {
+    reason: ReconcileReason;
+    timestamp: number;
+}
 
 export type PasswordValidationResult = 'ok' | 'bad-password' | 'unreachable';
 

--- a/src/deviceDiscovery/DeviceManager.ts
+++ b/src/deviceDiscovery/DeviceManager.ts
@@ -7,7 +7,7 @@ import { util as rokuDebugUtil } from 'roku-debug/dist/util';
 import type { GlobalStateManager } from '../GlobalStateManager';
 import { RokuFinder } from './RokuFinder';
 import { Orders } from './Orders';
-import type { Order, BroadcastReason, ReconcileReason } from './Orders';
+import type { Order, OrderType, SubmittedOrder, BroadcastReason, ReconcileReason } from './Orders';
 import { NetworkChangeMonitor, getNetworkHash } from './NetworkChangeMonitor';
 import { SystemSleepMonitor } from './SystemSleepMonitor';
 import { util } from '../util';
@@ -42,7 +42,10 @@ export class DeviceManager {
             if (event?.affectsConfiguration('brightscript.deviceDiscovery.enabled')) {
                 if (this.deviceDiscoveryEnabled) {
                     //order a broadcast + reconcile so the views discover/health-check once enabled
-                    this.submitOrders([{ type: 'broadcast', reason: 'startup' }, { type: 'reconcile', reason: 'startup' }]);
+                    this.submitOrders([
+                        { type: 'broadcast', reason: 'startup' },
+                        { type: 'reconcile', reason: 'startup' }
+                    ]);
                     this.systemSleepMonitor.start();
                     void this.activateMonitoring();
                 } else {
@@ -89,7 +92,10 @@ export class DeviceManager {
     private setupMonitors() {
         this.systemSleepMonitor = new SystemSleepMonitor(() => {
             //order a broadcast + reconcile so the views rescan/health-check on wake
-            this.submitOrders([{ type: 'broadcast', reason: 'sleep' }, { type: 'reconcile', reason: 'sleep' }]);
+            this.submitOrders([
+                { type: 'broadcast', reason: 'sleep' },
+                { type: 'reconcile', reason: 'sleep' }
+            ]);
         });
         this.networkChangeMonitor = new NetworkChangeMonitor(() => {
             this.networkId = getNetworkHash();
@@ -111,7 +117,10 @@ export class DeviceManager {
             this.restartRokuFinder();
 
             //order a broadcast + reconcile so the views rescan/health-check on the new network
-            this.submitOrders([{ type: 'broadcast', reason: 'network' }, { type: 'reconcile', reason: 'network' }]);
+            this.submitOrders([
+                { type: 'broadcast', reason: 'network' },
+                { type: 'reconcile', reason: 'network' }
+            ]);
         });
     }
 
@@ -136,7 +145,10 @@ export class DeviceManager {
             //order a broadcast + reconcile for the views to fulfill when they open.
             //No proactive scan here even on a cold cache — per the design doc, no network
             //traffic happens until a view is actually visible to consume these orders.
-            this.submitOrders([{ type: 'broadcast', reason: 'startup' }, { type: 'reconcile', reason: 'startup' }]);
+            this.submitOrders([
+                { type: 'broadcast', reason: 'startup' },
+                { type: 'reconcile', reason: 'startup' }
+            ]);
 
             this.activateMonitoring().catch((e) => {
                 console.error(e);
@@ -155,7 +167,7 @@ export class DeviceManager {
     // fulfilled by visible views. Each submitted order is announced on the emitter so live
     // views can fulfill immediately; hidden views drain the pending sets when they open.
     private orders = new Orders((order, timestamp) => {
-        this.emitter.emit(`${order.type}-ordered`, { reason: order.reason, timestamp: timestamp });
+        this.emitter.emit('order-submitted', { ...order, timestamp: timestamp });
     });
     private broadcastStaleTimer: ReturnType<typeof setInterval> | undefined;
     private reconcileStaleTimer: ReturnType<typeof setInterval> | undefined;
@@ -194,8 +206,7 @@ export class DeviceManager {
     public on(eventName: 'devices-changed', handler: () => void, disposables?: Disposable[]): () => void;
     public on(eventName: 'scan-started', handler: () => void, disposables?: Disposable[]): () => void;
     public on(eventName: 'scan-ended', handler: () => void, disposables?: Disposable[]): () => void;
-    public on(eventName: 'broadcast-ordered', handler: (order: BroadcastOrder) => void, disposables?: Disposable[]): () => void;
-    public on(eventName: 'reconcile-ordered', handler: (order: ReconcileOrder) => void, disposables?: Disposable[]): () => void;
+    public on(eventName: 'order-submitted', handler: (order: SubmittedOrder) => void, disposables?: Disposable[]): () => void;
     public on(eventName: string, handler: (payload: any) => void, disposables?: Disposable[]): () => void {
         this.emitter.on(eventName, handler);
         const unsubscribe = () => {
@@ -599,9 +610,8 @@ export class DeviceManager {
      * Submit orders. Each caller states exactly which order types its trigger implies — e.g.
      * a refresh click submits both types, a config change submits only a reconcile (an edit
      * can't add network devices), an unhealthy device submits only a broadcast (rescan, don't
-     * hammer every device). Every submitted order is announced
-     * (`broadcast-ordered`/`reconcile-ordered`) so a visible view fulfills it live; hidden
-     * views drain the pending sets when they open.
+     * hammer every device). Every submitted order is announced (`order-submitted`) so a
+     * visible view fulfills it live; hidden views drain the pending sets when they open.
      */
     public submitOrders(orders: Order[]): void {
         this.orders.submit(orders);
@@ -619,49 +629,34 @@ export class DeviceManager {
     }
 
     /**
-     * Atomically consume AND execute pending broadcast orders. The one-call fulfillment API
-     * for views: take + broadcast in a single step. The work is idempotent, so all taken
-     * reasons are satisfied by a single scan; the reasons travel into {@link broadcast}, which
-     * decides the urgency internally (only-`stale` stays staleness-gated; any real trigger
-     * scans now).
+     * Atomically consume AND execute pending orders — the one-call fulfillment API for views.
+     * The work is idempotent per order type, so all taken reasons are satisfied by a single
+     * execution: broadcast reasons by one scan (staleness-gated when stale-only), reconcile
+     * reasons by one health-check sweep (cache bypassed when `refresh-clicked` is among them).
      *
+     * @param options.types - which order types to fulfill; defaults to BOTH. Views with
+     *   per-type policy (e.g. the quick pick's 7s fallback only wants broadcasts) narrow it.
      * @param options.except - reasons that do not TRIGGER fulfillment on their own, e.g.
      *   `{ except: ['stale'] }` — see {@link Orders.take} for the full semantics.
-     * @returns true if orders were consumed and a scan actually started
      */
-    public fulfillPendingBroadcast(options?: { except?: BroadcastReason[] }): boolean {
-        const reasons = this.orders.take('broadcast', options?.except);
-        if (!reasons) {
-            return false;
-        }
-        return this.broadcast(reasons);
-    }
+    public fulfillOrders(options?: { types?: OrderType[]; except?: Array<BroadcastReason | ReconcileReason> }): { scanStarted: boolean; reconciled: boolean } {
+        const types = options?.types ?? ['broadcast', 'reconcile'];
+        const result = { scanStarted: false, reconciled: false };
 
-    /**
-     * Atomically consume AND execute pending reconcile orders. One-call twin of
-     * {@link fulfillPendingBroadcast}; the reasons travel into {@link reconcile}, which decides
-     * internally whether the per-device cache trust window is bypassed (only when
-     * `refresh-clicked` is among them — an explicit "I want fresh data now" from the user).
-     */
-    public fulfillPendingReconcile(options?: { except?: ReconcileReason[] }): boolean {
-        const reasons = this.orders.take('reconcile', options?.except);
-        if (!reasons) {
-            return false;
+        if (types.includes('broadcast')) {
+            const reasons = this.orders.take('broadcast', options?.except as BroadcastReason[]);
+            if (reasons) {
+                result.scanStarted = this.broadcast(reasons);
+            }
         }
-        this.reconcile(reasons);
-        return true;
-    }
-
-    /**
-     * Fulfill both pending order types in one call — the common case for views (on open, on
-     * becoming visible). Views that need per-order-type policy (e.g. the quick pick's 7s
-     * fallback only wants broadcasts) can still call the specific fulfillments directly.
-     */
-    public fulfillPendingOrders(options?: { except?: Array<BroadcastReason | ReconcileReason> }): { scanStarted: boolean; reconciled: boolean } {
-        return {
-            scanStarted: this.fulfillPendingBroadcast({ except: options?.except as BroadcastReason[] }),
-            reconciled: this.fulfillPendingReconcile({ except: options?.except as ReconcileReason[] })
-        };
+        if (types.includes('reconcile')) {
+            const reasons = this.orders.take('reconcile', options?.except as ReconcileReason[]);
+            if (reasons) {
+                this.reconcile(reasons);
+                result.reconciled = true;
+            }
+        }
+        return result;
     }
     // #endregion
 
@@ -1696,24 +1691,7 @@ export class DeviceManager {
 export type DeviceState = 'offline' | 'unknown' | 'pending' | 'online';
 
 //order types live with the Orders class; re-exported here so consumers keep one import site
-export type { Order, OrderType, BroadcastReason, ReconcileReason } from './Orders';
-
-/**
- * Payload of the `broadcast-ordered` event: the submitted order's reason plus when it was
- * submitted (ms epoch).
- */
-export interface BroadcastOrder {
-    reason: BroadcastReason;
-    timestamp: number;
-}
-
-/**
- * Payload of the `reconcile-ordered` event.
- */
-export interface ReconcileOrder {
-    reason: ReconcileReason;
-    timestamp: number;
-}
+export type { Order, OrderType, SubmittedOrder, BroadcastReason, ReconcileReason } from './Orders';
 
 export type PasswordValidationResult = 'ok' | 'bad-password' | 'unreachable';
 

--- a/src/deviceDiscovery/DeviceManager.ts
+++ b/src/deviceDiscovery/DeviceManager.ts
@@ -228,6 +228,21 @@ export class DeviceManager {
      */
     public getDevice(lookup: { ip?: string; serialNumber?: string }): RokuDevice | undefined;
     public getDevice(keyOrLookup: string | { ip?: string; serialNumber?: string }): RokuDevice | undefined {
+        const device = this.peekDevice(keyOrLookup);
+        if (device) {
+            //background freshness: return immediately, updates arrive via devices-changed
+            void this.ensureDeviceFresh(device, { maxAgeMs: this.ON_READ_TRUST_MS, syntheticDelay: false }).catch(() => { });
+        }
+        return device;
+    }
+
+    /**
+     * The internal read: same lookup semantics as getDevice, zero side effects. All
+     * DeviceManager-internal reads go through here - getDevice is the view-facing read
+     * and schedules background freshness work (calling it from inside the freshness
+     * machinery would make the machinery observe its own work).
+     */
+    private peekDevice(keyOrLookup: string | { ip?: string; serialNumber?: string }): RokuDevice | undefined {
         const { configured, discovered } = this.findDeviceEntries(keyOrLookup);
         const device = this.buildMergedDevice(configured, discovered);
 
@@ -236,11 +251,6 @@ export class DeviceManager {
             if (device.ip !== keyOrLookup.ip || device.serialNumber !== keyOrLookup.serialNumber) {
                 return undefined;
             }
-        }
-
-        if (device) {
-            //background freshness: return immediately, updates arrive via devices-changed
-            void this.ensureDeviceFresh(device, { maxAgeMs: this.ON_READ_TRUST_MS, syntheticDelay: false }).catch(() => { });
         }
         return device;
     }
@@ -691,7 +701,7 @@ export class DeviceManager {
      * workspace storage so the active device can be recovered in future sessions even if its IP changed.
      */
     public async setActiveDevice(ip: string): Promise<void> {
-        const serialNumber = this.getDevice({ ip: ip })?.serialNumber;
+        const serialNumber = this.peekDevice({ ip: ip })?.serialNumber;
         await this.context.workspaceState.update('remoteHost', ip);
         await this.context.workspaceState.update(DeviceManager.ACTIVE_DEVICE_STATE_KEY, { serialNumber: serialNumber, ip: ip } as ActiveDeviceEntry);
         await vscodeContextManager.set('activeHost', ip);
@@ -719,7 +729,7 @@ export class DeviceManager {
             return;
         }
 
-        const pickedSerialNumber = this.getDevice({ ip: pickedIp })?.serialNumber;
+        const pickedSerialNumber = this.peekDevice({ ip: pickedIp })?.serialNumber;
         const isSameDevice = pickedIp === activeDevice.ip ||
             (!!activeDevice.serialNumber && pickedSerialNumber === activeDevice.serialNumber);
         if (isSameDevice) {
@@ -746,7 +756,7 @@ export class DeviceManager {
         //falling back to the last IP we saw it at
         let currentIp = activeDevice.ip;
         if (activeDevice.serialNumber) {
-            currentIp = this.getDevice({ serialNumber: activeDevice.serialNumber })?.ip ??
+            currentIp = this.peekDevice({ serialNumber: activeDevice.serialNumber })?.ip ??
                 this.globalStateManager.getIpForSerial(activeDevice.serialNumber, this.networkId) ??
                 activeDevice.ip;
         }
@@ -966,7 +976,7 @@ export class DeviceManager {
         // Fresh enough for this caller (and not `unknown`): answer from what we already know
         if (currentStateObject.state !== 'unknown' && Date.now() - lastChecked < maxAgeMs) {
             const isHealthy = currentStateObject.state === 'online' || currentStateObject.state === 'pending';
-            return isHealthy ? this.getDeviceWithoutRefresh(device.ip) : undefined;
+            return isHealthy ? this.peekDevice({ ip: device.ip }) : undefined;
         }
 
         // Stagger the request (sweeps fire many of these at once)
@@ -976,16 +986,7 @@ export class DeviceManager {
 
         // getDeviceInfo applies everything we learn (states, cache, devices-changed)
         const info = await this.getDeviceInfo({ ip: device.ip, serialNumber: knownSerial });
-        return info ? this.getDeviceWithoutRefresh(device.ip) : undefined;
-    }
-
-    /**
-     * Read a device without kicking the background refresh (getDevice would re-enter
-     * ensureDeviceFresh, which calls this)
-     */
-    private getDeviceWithoutRefresh(ip: string): RokuDevice | undefined {
-        const { configured, discovered } = this.findDeviceEntries({ ip: ip });
-        return this.buildMergedDevice(configured, discovered);
+        return info ? this.peekDevice({ ip: device.ip }) : undefined;
     }
 
     /**
@@ -1077,10 +1078,10 @@ export class DeviceManager {
         if (typeof deviceKeyOrLookup === 'string') {
             //encoded tree keys resolve through the device list; any other string is already an ip
             ip = deviceKeyOrLookup.startsWith('s:') || deviceKeyOrLookup.startsWith('i:')
-                ? this.getDevice(deviceKeyOrLookup)?.ip
+                ? this.peekDevice(deviceKeyOrLookup)?.ip
                 : deviceKeyOrLookup;
         } else {
-            ip = deviceKeyOrLookup.ip ?? this.getDevice(deviceKeyOrLookup)?.ip;
+            ip = deviceKeyOrLookup.ip ?? this.peekDevice(deviceKeyOrLookup)?.ip;
         }
         if (!ip) {
             return Promise.resolve(undefined);
@@ -1088,7 +1089,7 @@ export class DeviceManager {
 
         //a serial hint for state keying when the fetch fails (the response carries its own on success)
         const serialHint = typeof deviceKeyOrLookup === 'string'
-            ? this.getDevice(deviceKeyOrLookup)?.serialNumber
+            ? this.peekDevice(deviceKeyOrLookup)?.serialNumber
             : deviceKeyOrLookup.serialNumber;
 
         const key = `${ip}:${port}`;

--- a/src/deviceDiscovery/DeviceManager.ts
+++ b/src/deviceDiscovery/DeviceManager.ts
@@ -41,7 +41,6 @@ export class DeviceManager {
             //if the `deviceDiscovery.enabled` setting was changed, start or stop monitoring
             if (event?.affectsConfiguration('brightscript.deviceDiscovery.enabled')) {
                 if (this.deviceDiscoveryEnabled) {
-                    //order a broadcast + reconcile so the views discover/health-check once enabled
                     this.submitOrders([
                         { type: 'broadcast', reason: 'startup' },
                         { type: 'reconcile', reason: 'startup' }
@@ -91,7 +90,6 @@ export class DeviceManager {
 
     private setupMonitors() {
         this.systemSleepMonitor = new SystemSleepMonitor(() => {
-            //order a broadcast + reconcile so the views rescan/health-check on wake
             this.submitOrders([
                 { type: 'broadcast', reason: 'sleep' },
                 { type: 'reconcile', reason: 'sleep' }
@@ -116,7 +114,6 @@ export class DeviceManager {
 
             this.restartRokuFinder();
 
-            //order a broadcast + reconcile so the views rescan/health-check on the new network
             this.submitOrders([
                 { type: 'broadcast', reason: 'network' },
                 { type: 'reconcile', reason: 'network' }
@@ -142,9 +139,7 @@ export class DeviceManager {
             // Sleep monitor runs all the time when enabled (ignores focus state)
             this.systemSleepMonitor.start();
 
-            //order a broadcast + reconcile for the views to fulfill when they open.
-            //No proactive scan here even on a cold cache - per the design doc, no network
-            //traffic happens until a view is actually visible to consume these orders.
+            //no proactive scan here, even on a cold cache - orders queue until a view is visible
             this.submitOrders([
                 { type: 'broadcast', reason: 'startup' },
                 { type: 'reconcile', reason: 'startup' }
@@ -163,9 +158,7 @@ export class DeviceManager {
     private lastUsedDeviceIp: string | undefined = undefined;
     private networkId: string;
 
-    // Orders (see docs/device-discovery.md "Orders"): deferred work submitted by triggers and
-    // fulfilled by visible views. Each submitted order is announced on the emitter so live
-    // views can fulfill immediately; hidden views drain the pending sets when they open.
+    // Orders (see docs/device-discovery.md "Orders")
     private orders = new Orders((order, timestamp) => {
         this.emitter.emit('order-submitted', { ...order, timestamp: timestamp });
     });
@@ -184,8 +177,7 @@ export class DeviceManager {
     private readonly OFFLINE_COOLDOWN_MS = 5_000; // 5 seconds - minimum time between resolve attempts for offline devices
     private static readonly HEALTH_CHECK_TIMEOUT_MS = 2_000; // 2 seconds
 
-    // Lazy hydration (background device-info refresh triggered by view reads - spec:
-    // "Lazy hydration on read")
+    // Lazy hydration (background device-info refresh triggered by view reads)
     private readonly HYDRATION_MAX_CACHE_AGE_MS = 8 * 60 * 60 * 1_000; // 8 hours - cache older than this re-hydrates on read
     private readonly HYDRATION_RETRY_COOLDOWN_MS = 5 * 60 * 1_000; // 5 minutes - minimum time between hydration attempts per IP
     private hydrationInFlight = new Set<string>();
@@ -196,10 +188,9 @@ export class DeviceManager {
     private deviceOnlineNotifiers = new Map<string, ReturnType<typeof debounce>>();
 
     // Scan state management. STALE_SCAN_THRESHOLD_MS is both the stale-only broadcast gate
-    // ("don't scan if the last scan is younger than this") and the `stale` broadcast timer
-    // interval - one definition of "it's been a while".
+    // and the stale broadcast timer interval
     private readonly STALE_SCAN_THRESHOLD_MS = 30 * 60 * 1_000; // 30 minutes
-    private readonly STALE_RECONCILE_INTERVAL_MS = 5 * 60 * 1_000; // 5 minutes - the spec's stale reconcile timer
+    private readonly STALE_RECONCILE_INTERVAL_MS = 5 * 60 * 1_000; // 5 minutes
     private readonly UNHEALTHY_BROADCAST_MIN_INTERVAL_MS = 60_000; // 1 minute - suppress unhealthy-device orders this soon after a scan
     private lastScanDate: Date | null = null;
 
@@ -269,10 +260,8 @@ export class DeviceManager {
     }
 
     /**
-     * Get a list of all roku devices.
-     * Returns all devices without filtering. Returns immediately from in-memory data; devices
-     * with missing or old cached info are hydrated in the background (see {@link queueHydration})
-     * and a `devices-changed` event fires when fresh data arrives.
+     * Get a list of all roku devices. Returns immediately from in-memory data; stale devices
+     * hydrate in the background and fire `devices-changed` when fresh data arrives.
      */
     public getAllDevices(): RokuDevice[] {
         const devices = this.buildAllDevices();
@@ -281,16 +270,13 @@ export class DeviceManager {
     }
 
     /**
-     * Does this device need a background device-info refresh? (spec: Lazy hydration on read)
-     * - state `unknown` - never confirmed this session (e.g. folded in from a scan response,
-     *   ssdp:alive, or the last-seen cache with info older than the 5-min freshness check).
-     *   Cache age doesn't matter here: cached info can render the row, but only a resolve can
-     *   confirm the device is actually there.
-     * - cached info older than {@link HYDRATION_MAX_CACHE_AGE_MS} (regardless of state)
+     * Does this device need a background device-info refresh? Yes when it has never been
+     * confirmed this session (`unknown`), or its cached info is older than
+     * HYDRATION_MAX_CACHE_AGE_MS.
      */
     private needsHydration(device: RokuDevice): boolean {
-        //a resolve is already in flight somewhere (required guard: the cache-age condition below
-        //is state-independent, so without this a pending device would re-queue on every read)
+        //pending means a resolve is already in flight - without this guard a pending device
+        //would re-queue on every read
         if (device.deviceState === 'pending') {
             return false;
         }
@@ -305,17 +291,9 @@ export class DeviceManager {
     }
 
     /**
-     * The "lazy hydration on read" mechanism from the design doc: queue background device-info
-     * fetches for devices that need one, then return immediately. As each resolve completes,
-     * `devices-changed` fires and views re-render with the fresh data.
-     *
-     * Re-entrancy protection (views call getAllDevices on every devices-changed, and resolves
-     * emit devices-changed, so this must converge):
-     * - while a fetch is in flight the device is `pending` and its IP is in `hydrationInFlight`
-     * - success renews the cache timestamp, so neither hydration condition holds anymore
-     * - failure removes discovered entries entirely; configured entries go `offline`
-     * - failure with a still-old cache would re-qualify - `hydrationLastAttempt` caps that at
-     *   one attempt per IP per {@link HYDRATION_RETRY_COOLDOWN_MS}
+     * Lazy hydration on read: queue background device-info fetches for devices that need one.
+     * Must converge even though resolves emit devices-changed (which triggers more reads) -
+     * the in-flight set and per-IP cooldown below are that guard.
      */
     private queueHydration(devices: RokuDevice[]): void {
         const now = Date.now();
@@ -334,7 +312,6 @@ export class DeviceManager {
             //timestamp at queue time so even instantly-failing attempts are rate-limited
             this.hydrationLastAttempt.set(device.ip, now);
             this.hydrationInFlight.add(device.ip);
-            //silent background refresh: no synthetic delay, cache trusted (offline cooldown applies)
             void this.resolveDevice({ ip: device.ip, serialNumber: device.serialNumber }, { syntheticDelay: false })
                 .catch(() => { })
                 .finally(() => {
@@ -607,17 +584,13 @@ export class DeviceManager {
 
     // #region Orders (docs/device-discovery.md "Orders" / "When are orders submitted?")
     /**
-     * Submit orders. Each caller states which order types its trigger implies. Every
-     * submitted order is announced (`order-submitted`) so a visible view fulfills it live;
+     * Submit orders. Emits `order-submitted` so a visible view can fulfill immediately;
      * hidden views drain the pending sets when they open.
      */
     public submitOrders(orders: Order[]): void {
         this.orders.submit(orders);
     }
 
-    /**
-     * The reasons of all pending broadcast orders that no view has fulfilled yet.
-     */
     public getPendingBroadcastReasons(): BroadcastReason[] {
         return this.orders.getPending('broadcast');
     }
@@ -627,13 +600,8 @@ export class DeviceManager {
     }
 
     /**
-     * Atomically consume AND execute pending orders. Each taken entry is executed once:
-     * broadcast by one scan, reconcile by one health-check sweep.
-     *
-     * @param options.types - which order types to fulfill
-     * @param options.except - reasons that do not trigger fulfillment on their own
-     *   (see {@link Orders.take})
-     * @returns what was taken and executed, one entry per order type that had work
+     * Atomically consume and execute pending orders (see {@link Orders.take} for the
+     * types/except semantics). Returns what was taken and executed.
      */
     public fulfillOrders(options: { types: OrderType[]; except?: Array<BroadcastReason | ReconcileReason> }): TakenOrders[] {
         const taken = this.orders.take(options);
@@ -649,23 +617,19 @@ export class DeviceManager {
     // #endregion
 
     /**
-     * Ensure the device still exists on the network. Accepts anything {@link getDevice} can
-     * look up (encoded tree key, ip/serial lookup) or a device object; an unknown device is
-     * reported unhealthy.
+     * Ensure the device still exists on the network
      */
     public async healthCheckDevice(deviceKeyOrLookup: RokuDevice | string | { ip?: string; serialNumber?: string }): Promise<boolean> {
         return (await this.getDeviceInfo(deviceKeyOrLookup)) !== undefined;
     }
 
     /**
-     * Broadcast an SSDP M-SEARCH to discover devices on the network. Does NOT health-check
-     * existing devices - that's {@link reconcile}. The reasons decide the urgency: any real
-     * trigger scans now, while a `stale` timer-tick is only a "things might be old" hint - a
-     * stale-only fulfillment scans only when discovery is enabled AND the last scan is older
-     * than STALE_SCAN_THRESHOLD_MS. Reachable only through order fulfillment.
+     * Broadcast an SSDP M-SEARCH to discover devices on the network.
      * @returns true if a scan was started
      */
     private broadcast(reasons: BroadcastReason[]): boolean {
+        //a stale-only fulfillment is just a freshness hint - skip unless discovery is enabled
+        //and the last scan is old
         const staleOnly = reasons.every(x => x === 'stale');
         if (staleOnly) {
             if (!this.deviceDiscoveryEnabled || this.timeSinceLastScan <= this.STALE_SCAN_THRESHOLD_MS) {
@@ -679,10 +643,7 @@ export class DeviceManager {
 
     /**
      * Health-check every known device (configured + discovered), marking them online/offline.
-     * Does NOT scan for new devices - that's {@link broadcast}. The reasons decide the urgency:
-     * only an explicit user click bypasses each device's cache trust window - a bypassing
-     * reconcile is one HTTP request per known device, so only "I want fresh data NOW" earns
-     * that. Reachable only through order fulfillment.
+     * Only an explicit user refresh bypasses each device's cache trust window.
      */
     private reconcile(reasons: ReconcileReason[]): void {
         const bypassDeviceCache = reasons.includes('refresh-clicked');
@@ -696,7 +657,6 @@ export class DeviceManager {
      * Useful for refreshing the network scan without losing user-configured devices.
      */
     public clearCurrentDeviceList(): void {
-        // Clear discovered devices (ephemeral)
         this.discoveredDevices = [];
 
         // Only clear lastUsedDeviceIp if it belonged to a discovered-only device
@@ -709,23 +669,17 @@ export class DeviceManager {
             }
         }
 
-        //clear the cache for the current list of devices
         this.globalStateManager.setLastSeenDevices(this.networkId, []);
 
-        //this is a user-initiated action, so order a health check of the remaining (configured)
-        //devices rather than running one directly - a visible view fulfills it immediately
         this.submitOrders([{ type: 'reconcile', reason: 'refresh-clicked' }]);
         this.emitDevicesChanged();
     }
 
     public clearAllCache() {
-
-        // End any in-progress scan (emits scan-ended) so late responses don't instantly
-        // repopulate the just-cleared state - but keep the passive SSDP listener running,
-        // otherwise the device list stays empty until the next explicit scan
+        //end any in-progress scan, but keep the passive SSDP listener running so alive
+        //announcements can repopulate the list
         this.finder.stopScan();
 
-        // Clear persisted global state
         this.globalStateManager.clearLastSeenDevices();
         this.globalStateManager.clearDeviceCache();
         this.globalStateManager.clearSerialNumberByIpForNetwork();
@@ -748,10 +702,8 @@ export class DeviceManager {
     }
 
     /**
-     * Submit an `unhealthy-device` broadcast order (a discovered device failed a health check,
-     * so the network picture may have changed). Rate-limited: suppressed when discovery is
-     * disabled or when a scan ran within the last minute - the terminating guard for the
-     * potential scan → health-check → fail → scan feedback loop.
+     * Submit an `unhealthy-device` broadcast order. Rate-limited - this is the terminating
+     * guard for the scan → health-check → fail → scan feedback loop.
      */
     private submitUnhealthyDeviceBroadcast(): void {
         if (!this.deviceDiscoveryEnabled) {
@@ -1041,8 +993,7 @@ export class DeviceManager {
     }
 
     private async resolveDevice(device: RokuDevice | { ip: string; serialNumber?: string }, options?: { bypassCache?: boolean; syntheticDelay?: boolean }): Promise<boolean> {
-        // bypassCache: skip the cache trust window AND the offline cooldown - "I want a real
-        // answer from the network NOW" (user engagement, refresh-clicked reconciles).
+        //bypassCache skips the cache trust window AND the offline cooldown
         const bypassCache = options?.bypassCache ?? false;
         const syntheticDelay = options?.syntheticDelay ?? true;
 
@@ -1232,25 +1183,11 @@ export class DeviceManager {
         }
     }
 
-    /**
-     * In-flight device-info requests by `ip:port`. This is the design doc's "de-dupe rule":
-     * within a single refresh flow a device only gets device-info'd once - concurrent callers
-     * (e.g. the broadcast response and the reconcile racing on the same device) share one HTTP
-     * request instead of each issuing their own. First one in wins; everyone else joins it.
-     */
     private inFlightDeviceInfo = new Map<string, Promise<DeviceInfoRaw | undefined>>();
 
     /**
-     * Get device info directly from the device. Never returns cached data - this always hits
-     * the network. Concurrent callers for the same ip:port piggyback on the in-flight request
-     * and get the same answer (the de-dupe rule in docs/device-discovery.md). Never rejects -
-     * failures return undefined.
-     *
-     * This does NOT update the device list or device states - those are maintained by the
-     * reconcile sweeps and lazy hydration. Use {@link getDevice} to read what's already known.
-     *
-     * Accepts an ip, an encoded tree key ("s:{serial}" / "i:{ip}"), an ip/serial lookup, or a
-     * device object. Returns undefined when the input can't be resolved to an ip.
+     * Get device info directly from the device (never from cache). Concurrent callers for the
+     * same ip:port share the in-flight request. Never rejects - failures return undefined.
      */
     public getDeviceInfo(deviceKeyOrLookup: RokuDevice | string | { ip?: string; serialNumber?: string }, port = 8060): Promise<DeviceInfoRaw | undefined> {
         //normalize the input down to an ip
@@ -1519,9 +1456,7 @@ export class DeviceManager {
     private async activateMonitoring() {
         this.networkChangeMonitor.start();
 
-        //periodically submit `stale` broadcast/reconcile orders so long-lived sessions
-        //eventually refresh (the spec's "it's been a while" timers; views decide whether and
-        //how to fulfill them - visible views deliberately ignore live `stale` orders)
+        //periodically submit `stale` orders so long-lived sessions eventually refresh
         this.stopStaleTimers();
         this.broadcastStaleTimer = setInterval(() => {
             this.submitOrders([{ type: 'broadcast', reason: 'stale' }]);
@@ -1529,7 +1464,6 @@ export class DeviceManager {
         this.reconcileStaleTimer = setInterval(() => {
             this.submitOrders([{ type: 'reconcile', reason: 'stale' }]);
         }, this.STALE_RECONCILE_INTERVAL_MS);
-        //don't keep the process alive just for these timers
         this.broadcastStaleTimer?.unref?.();
         this.reconcileStaleTimer?.unref?.();
 
@@ -1562,10 +1496,8 @@ export class DeviceManager {
         this.finder.removeAllListeners();
         this.finder.on('found', (ip: string, options?: { serialNumber?: string }) => {
             this.setDiscoveredDevice(ip, options?.serialNumber);
-            //no eager resolve here: this emit makes any visible view re-read the list, and a
-            //responder whose cache missed the 5-min freshness check lands in `unknown` - which
-            //lazy hydration on read always resolves (spec: "hydrate it immediately", routed
-            //through the views-as-the-gate read path)
+            //no eager resolve here - a responder that lands in `unknown` is picked up by lazy
+            //hydration on the next visible read
             this.emitDevicesChanged();
         });
 
@@ -1585,8 +1517,6 @@ export class DeviceManager {
 
         this.finder.on('scan-ended', () => {
             this.emitter.emit('scan-ended');
-            //devices that didn't respond to the scan are NOT eagerly health-checked here -
-            //lazy hydration on read covers them the next time a view asks for the list
         });
     }
 

--- a/src/deviceDiscovery/DeviceManager.ts
+++ b/src/deviceDiscovery/DeviceManager.ts
@@ -170,9 +170,15 @@ export class DeviceManager {
     private resolveDeviceSequence = new Map<string, number>();
     private readonly DEVICE_INFO_CACHE_MS = 5 * 60 * 1_000; // 5 minutes - cache duration for fetchDeviceInfo
     private readonly FRESH_CACHE_THRESHOLD_MS = 5 * 60 * 1_000; // 5 minutes - cache fresher than this = online on load
-    private readonly STALE_DEVICE_AFTER_SCAN_MS = 10_000; // 10 seconds - health check devices with cache older than this after scan
     private readonly OFFLINE_COOLDOWN_MS = 5_000; // 5 seconds - minimum time between resolve attempts for offline devices
     public static readonly HEALTH_CHECK_TIMEOUT_MS = 2_000; // 2 seconds
+
+    // Lazy hydration (background device-info refresh triggered by view reads — spec:
+    // "Lazy hydration on read")
+    private readonly HYDRATION_MAX_CACHE_AGE_MS = 8 * 60 * 60 * 1_000; // 8 hours - cache older than this re-hydrates on read
+    private readonly HYDRATION_RETRY_COOLDOWN_MS = 5 * 60 * 1_000; // 5 minutes - minimum time between hydration attempts per IP
+    private hydrationInFlight = new Set<string>();
+    private hydrationLastAttempt = new Map<string, number>();
 
     // Notifications and event debouncing
     private readonly DEVICES_CHANGED_DEBOUNCE_MS = 50;
@@ -233,6 +239,9 @@ export class DeviceManager {
             }
         }
 
+        if (device) {
+            this.queueHydration([device]);
+        }
         return device;
     }
 
@@ -251,10 +260,71 @@ export class DeviceManager {
 
     /**
      * Get a list of all roku devices.
-     * Returns all devices without filtering.
+     * Returns all devices without filtering. Returns immediately from in-memory data; devices
+     * with missing or old cached info are hydrated in the background (see {@link queueHydration})
+     * and a `devices-changed` event fires when fresh data arrives.
      */
     public getAllDevices(): RokuDevice[] {
-        return this.buildAllDevices();
+        const devices = this.buildAllDevices();
+        this.queueHydration(devices);
+        return devices;
+    }
+
+    /**
+     * Does this device need a background device-info refresh? (spec: Lazy hydration on read)
+     * - never resolved (`unknown` with no cached deviceInfo), or
+     * - cached info older than {@link HYDRATION_MAX_CACHE_AGE_MS} (regardless of state)
+     */
+    private needsHydration(device: RokuDevice): boolean {
+        //a resolve is already in flight somewhere (required guard: the cache-age condition below
+        //is state-independent, so without this a pending device would re-queue on every read)
+        if (device.deviceState === 'pending') {
+            return false;
+        }
+        const cached = device.serialNumber ? this.globalStateManager.getCachedDevice(device.serialNumber) : undefined;
+        if (!cached) {
+            return device.deviceState === 'unknown';
+        }
+        return Date.now() - cached.createdAt > this.HYDRATION_MAX_CACHE_AGE_MS;
+    }
+
+    /**
+     * The "lazy hydration on read" mechanism from the design doc: queue background device-info
+     * fetches for devices that need one, then return immediately. As each resolve completes,
+     * `devices-changed` fires and views re-render with the fresh data.
+     *
+     * Re-entrancy protection (views call getAllDevices on every devices-changed, and resolves
+     * emit devices-changed, so this must converge):
+     * - while a fetch is in flight the device is `pending` and its IP is in `hydrationInFlight`
+     * - success renews the cache timestamp, so neither hydration condition holds anymore
+     * - failure removes discovered entries entirely; configured entries go `offline`
+     * - failure with a still-old cache would re-qualify — `hydrationLastAttempt` caps that at
+     *   one attempt per IP per {@link HYDRATION_RETRY_COOLDOWN_MS}
+     */
+    private queueHydration(devices: RokuDevice[]): void {
+        const now = Date.now();
+        for (const device of devices) {
+            if (!this.needsHydration(device)) {
+                continue;
+            }
+            if (this.hydrationInFlight.has(device.ip)) {
+                continue;
+            }
+            const lastAttempt = this.hydrationLastAttempt.get(device.ip);
+            if (lastAttempt !== undefined && now - lastAttempt < this.HYDRATION_RETRY_COOLDOWN_MS) {
+                continue;
+            }
+
+            //timestamp at queue time so even instantly-failing attempts are rate-limited
+            this.hydrationLastAttempt.set(device.ip, now);
+            this.hydrationInFlight.add(device.ip);
+            //silent background refresh: no synthetic delay, not forced (offline cooldown applies)
+            void this.resolveDevice({ ip: device.ip, serialNumber: device.serialNumber }, false, false)
+                .catch(() => { })
+                .finally(() => {
+                    this.hydrationInFlight.delete(device.ip);
+                });
+        }
     }
 
     /**
@@ -654,6 +724,7 @@ export class DeviceManager {
         // Clear all timestamps and per-device state
         this.lastScanDate = null;
         this.resolveDeviceSequence.clear();
+        this.hydrationLastAttempt.clear();
 
         // Reset configured device states to unknown
         for (const entry of this.configuredDevices) {
@@ -978,7 +1049,7 @@ export class DeviceManager {
         this.emitDevicesChanged();
     }
 
-    private async resolveDevice(device: RokuDevice | { ip: string }, doSyntheticDelay = true, force = false): Promise<boolean> {
+    private async resolveDevice(device: RokuDevice | { ip: string; serialNumber?: string }, doSyntheticDelay = true, force = false): Promise<boolean> {
         // Extract serial from device if available (for proper state key management)
         const knownSerial = 'serialNumber' in device ? device.serialNumber : undefined;
 
@@ -1163,46 +1234,6 @@ export class DeviceManager {
         if (needsScan) {
             this.submitUnhealthyDeviceBroadcast();
         }
-    }
-
-    /**
-     * Health check devices that didn't respond to a scan.
-     * Called after scan-ended. Checks devices whose cache is older than STALE_DEVICE_AFTER_SCAN_MS.
-     * Iterates over both source arrays to ensure all devices are checked even when
-     * the same serial exists at multiple IPs.
-     */
-    private async healthCheckStaleDevices() {
-        const now = Date.now();
-
-        // Helper to check if a device with given serial is stale
-        const isStale = (serialNumber: string | undefined): boolean => {
-            if (!serialNumber) {
-                return true; // No serial = no cache, consider stale
-            }
-            const cached = this.globalStateManager.getCachedDevice(serialNumber);
-            if (!cached) {
-                return true;
-            }
-            const cacheAge = now - cached.createdAt;
-            return cacheAge > this.STALE_DEVICE_AFTER_SCAN_MS;
-        };
-
-        // Collect unique stale IPs from both source arrays
-        const staleIps = new Set([
-            ...this.configuredDevices
-                .filter(entry => entry.state !== 'offline' && isStale(entry.serialNumber))
-                .map(entry => entry.resolvedIp ?? entry.host),
-            ...this.discoveredDevices
-                .filter(entry => entry.state !== 'offline' && isStale(entry.serialNumber))
-                .map(entry => entry.ip)
-        ]);
-
-        if (staleIps.size === 0) {
-            return;
-        }
-
-        // Cooldown is handled by fetchDeviceInfo cache
-        await Promise.all([...staleIps].map(ip => this.resolveDevice({ ip: ip }, false)));
     }
 
     /**
@@ -1457,22 +1488,17 @@ export class DeviceManager {
     }
 
     /**
-     * Handle device-online event from RokuFinder.
-     * Health checks the device if focused and no cache, and shows notification if enabled.
+     * Handle device-online event from RokuFinder. Shows a notification if enabled.
+     * Does not eagerly device-info the device — lazy hydration on read handles that
+     * once a view actually asks for the device list (spec: Passive SSDP announcements).
      */
     private handleDeviceOnline(ip: string, serialNumber?: string): void {
-        // Use provided serial, fall back to IP→serial mapping if not provided
-        const actualSerial = serialNumber ?? this.globalStateManager.getSerialNumberForIp(ip, this.networkId);
-
-        // Health check if VS Code is focused and device has no cache
-        const hasCache = actualSerial ? this.hasDeviceCache(actualSerial) : false;
-        if (vscode.window.state.focused && !hasCache) {
-            this.resolveUncachedDiscoveredDevices().catch(() => { });
-        }
-
         if (!this.showInfoMessages) {
             return;
         }
+
+        // Use provided serial, fall back to IP→serial mapping if not provided
+        const actualSerial = serialNumber ?? this.globalStateManager.getSerialNumberForIp(ip, this.networkId);
 
         // Get cached device directly from globalStateManager
         const cachedDevice = actualSerial
@@ -1558,8 +1584,8 @@ export class DeviceManager {
 
         this.finder.on('scan-ended', () => {
             this.emitter.emit('scan-ended');
-            // Health check devices that didn't respond to the scan (stale cache)
-            this.healthCheckStaleDevices().catch(() => { });
+            //devices that didn't respond to the scan are NOT eagerly health-checked here —
+            //lazy hydration on read covers them the next time a view asks for the list
         });
     }
 
@@ -1603,27 +1629,6 @@ export class DeviceManager {
 
     private notifyFocusGained() {
         this.networkChangeMonitor.start();
-        // Resolve any discovered devices without cache that appeared while unfocused
-        this.resolveUncachedDiscoveredDevices().catch(() => { });
-    }
-
-    /**
-     * Health check discovered devices that don't have cached info.
-     * Called on focus gain to resolve devices that appeared while VS Code was unfocused.
-     */
-    private async resolveUncachedDiscoveredDevices(): Promise<void> {
-        const uncached = this.discoveredDevices.filter(entry => {
-            return !entry.serialNumber || !this.hasDeviceCache(entry.serialNumber);
-        });
-
-        if (uncached.length === 0) {
-            return;
-        }
-
-        // Health check each uncached device in parallel
-        await Promise.all(
-            uncached.map(entry => this.healthCheckDevice({ ip: entry.ip, serialNumber: entry.serialNumber }, false, false).catch(() => { }))
-        );
     }
 
     private notifyFocusLost() {

--- a/src/deviceDiscovery/DeviceManager.ts
+++ b/src/deviceDiscovery/DeviceManager.ts
@@ -634,23 +634,23 @@ export class DeviceManager {
      * execution: broadcast reasons by one scan (staleness-gated when stale-only), reconcile
      * reasons by one health-check sweep (cache bypassed when `refresh-clicked` is among them).
      *
-     * @param options.types - which order types to fulfill; defaults to BOTH. Views with
-     *   per-type policy (e.g. the quick pick's 7s fallback only wants broadcasts) narrow it.
+     * @param options.types - which order types to fulfill. Callers state their policy
+     *   explicitly — e.g. the tree view fulfills both, the quick pick's 7s fallback only wants
+     *   broadcasts, live handlers pass the submitted order's type.
      * @param options.except - reasons that do not TRIGGER fulfillment on their own, e.g.
      *   `{ except: ['stale'] }` — see {@link Orders.take} for the full semantics.
      */
-    public fulfillOrders(options?: { types?: OrderType[]; except?: Array<BroadcastReason | ReconcileReason> }): { scanStarted: boolean; reconciled: boolean } {
-        const types = options?.types ?? ['broadcast', 'reconcile'];
+    public fulfillOrders(options: { types: OrderType[]; except?: Array<BroadcastReason | ReconcileReason> }): { scanStarted: boolean; reconciled: boolean } {
         const result = { scanStarted: false, reconciled: false };
 
-        if (types.includes('broadcast')) {
-            const reasons = this.orders.take('broadcast', options?.except as BroadcastReason[]);
+        if (options.types.includes('broadcast')) {
+            const reasons = this.orders.take('broadcast', options.except as BroadcastReason[]);
             if (reasons) {
                 result.scanStarted = this.broadcast(reasons);
             }
         }
-        if (types.includes('reconcile')) {
-            const reasons = this.orders.take('reconcile', options?.except as ReconcileReason[]);
+        if (options.types.includes('reconcile')) {
+            const reasons = this.orders.take('reconcile', options.except as ReconcileReason[]);
             if (reasons) {
                 this.reconcile(reasons);
                 result.reconciled = true;

--- a/src/deviceDiscovery/DeviceManager.ts
+++ b/src/deviceDiscovery/DeviceManager.ts
@@ -40,8 +40,7 @@ export class DeviceManager {
             if (event?.affectsConfiguration('brightscript.deviceDiscovery.enabled')) {
                 if (this.deviceDiscoveryEnabled) {
                     //order a broadcast + reconcile so the views discover/health-check once enabled
-                    this.submitBroadcast('startup');
-                    this.submitReconcile('startup');
+                    this.submitOrder('startup');
                     this.systemSleepMonitor.start();
                     void this.activateMonitoring();
                 } else {
@@ -59,7 +58,7 @@ export class DeviceManager {
             //local) and order a health check for the views to fulfill when one is visible
             if (event?.affectsConfiguration('brightscript.devices')) {
                 this.loadConfiguredDevices().catch(() => { });
-                this.submitReconcile('config-changed');
+                this.submitOrder('config-changed');
             }
 
             //if the `defaultDevicePassword` setting was changed, refresh any device views that rely on it
@@ -88,8 +87,7 @@ export class DeviceManager {
     private setupMonitors() {
         this.systemSleepMonitor = new SystemSleepMonitor(() => {
             //order a broadcast + reconcile so the views rescan/health-check on wake
-            this.submitBroadcast('sleep');
-            this.submitReconcile('sleep');
+            this.submitOrder('sleep');
         });
         this.networkChangeMonitor = new NetworkChangeMonitor(() => {
             this.networkId = getNetworkHash();
@@ -111,8 +109,7 @@ export class DeviceManager {
             this.restartRokuFinder();
 
             //order a broadcast + reconcile so the views rescan/health-check on the new network
-            this.submitBroadcast('network');
-            this.submitReconcile('network');
+            this.submitOrder('network');
         });
     }
 
@@ -137,8 +134,7 @@ export class DeviceManager {
             //order a broadcast + reconcile for the views to fulfill when they open.
             //No proactive scan here even on a cold cache — per the design doc, no network
             //traffic happens until a view is actually visible to consume these orders.
-            this.submitBroadcast('startup');
-            this.submitReconcile('startup');
+            this.submitOrder('startup');
 
             this.activateMonitoring().catch((e) => {
                 console.error(e);
@@ -680,14 +676,22 @@ export class DeviceManager {
     }
 
     /**
-     * The "user clicked refresh / scan" interaction (spec: Clicking refresh) — the only order
-     * submission views can make. Always submits a broadcast order AND a reconcile order,
-     * regardless of how recently either ran; the split into order types is internal, like every
-     * other trigger's.
+     * The single order-submission funnel (spec: When are orders submitted?). Callers name the
+     * trigger that happened; the reason determines which order types it implies. Most triggers
+     * imply both, with two exceptions: a config change can't introduce new devices on the
+     * network (reconcile only), and an unhealthy device warrants a rescan, not a health check
+     * of everything else (broadcast only).
+     *
+     * The `stale` timers don't go through here — they submit their single order type directly
+     * because they run on different cadences (broadcast every 30 minutes, reconcile every 5).
      */
-    public submitRefreshOrders(): void {
-        this.submitBroadcast('refresh-clicked');
-        this.submitReconcile('refresh-clicked');
+    public submitOrder(reason: OrderReason): void {
+        if (reason !== 'config-changed') {
+            this.submitBroadcast(reason as BroadcastReason);
+        }
+        if (reason !== 'unhealthy-device') {
+            this.submitReconcile(reason as ReconcileReason);
+        }
     }
     // #endregion
 
@@ -818,7 +822,7 @@ export class DeviceManager {
         if (this.timeSinceLastScan < this.UNHEALTHY_BROADCAST_MIN_INTERVAL_MS) {
             return;
         }
-        this.submitBroadcast('unhealthy-device');
+        this.submitOrder('unhealthy-device');
     }
 
     /**
@@ -1705,6 +1709,11 @@ export type ReconcileReason =
     | 'refresh-clicked'
     | 'config-changed'
     | 'stale';
+
+/**
+ * Any trigger accepted by the single submission funnel, {@link DeviceManager.submitOrder}.
+ */
+export type OrderReason = BroadcastReason | ReconcileReason;
 
 /**
  * A unit of deferred work: queued by triggers, fulfilled by visible views.

--- a/src/deviceDiscovery/DeviceManager.ts
+++ b/src/deviceDiscovery/DeviceManager.ts
@@ -176,12 +176,11 @@ export class DeviceManager {
     // failure) - ensureDeviceFresh callers state how old that knowledge may be (maxAgeMs)
     private deviceCheckSequence = new Map<string, number>();
     private lastCheckedByIp = new Map<string, number>();
-    private readonly DEVICE_INFO_CACHE_MS = 5 * 60 * 1_000; // 5 minutes - default freshness requirement for ensureDeviceFresh
-    private readonly FRESH_CACHE_THRESHOLD_MS = 5 * 60 * 1_000; // 5 minutes - cache fresher than this = online on load
+    private readonly ON_WRITE_TRUST_MS = 5 * 60 * 1_000; // 5 minutes - refresh paths (sweeps, load-time state seeding) trust knowledge this old
     private static readonly HEALTH_CHECK_TIMEOUT_MS = 2_000; // 2 seconds
 
-    // Lazy hydration (background device-info refresh triggered by view reads)
-    private readonly HYDRATION_MAX_CACHE_AGE_MS = 8 * 60 * 60 * 1_000; // 8 hours - hydration's freshness requirement
+    // Reads are the backstop, not the freshness engine (orders are) - so they tolerate old knowledge
+    private readonly ON_READ_TRUST_MS = 8 * 60 * 60 * 1_000; // 8 hours - reads trust knowledge this old
 
     // Notifications and event debouncing
     private readonly DEVICES_CHANGED_DEBOUNCE_MS = 50;
@@ -223,7 +222,7 @@ export class DeviceManager {
     public getDevice(key: string): RokuDevice | undefined;
     /**
      * Get device by IP or serial number.
-     * Returns device with deviceInfo hydrated from cache.
+     * Returns device with deviceInfo populated from cache.
      *
      * @param lookup - Object with optional ip and/or serialNumber
      * @returns Device with deviceInfo or undefined if not found
@@ -242,7 +241,7 @@ export class DeviceManager {
 
         if (device) {
             //background freshness: return immediately, updates arrive via devices-changed
-            void this.ensureDeviceFresh(device, { maxAgeMs: this.HYDRATION_MAX_CACHE_AGE_MS, syntheticDelay: false }).catch(() => { });
+            void this.ensureDeviceFresh(device, { maxAgeMs: this.ON_READ_TRUST_MS, syntheticDelay: false }).catch(() => { });
         }
         return device;
     }
@@ -267,7 +266,7 @@ export class DeviceManager {
     public getAllDevices(): RokuDevice[] {
         const devices = this.buildAllDevices();
         for (const device of devices) {
-            void this.ensureDeviceFresh(device, { maxAgeMs: this.HYDRATION_MAX_CACHE_AGE_MS, syntheticDelay: false }).catch(() => { });
+            void this.ensureDeviceFresh(device, { maxAgeMs: this.ON_READ_TRUST_MS, syntheticDelay: false }).catch(() => { });
         }
         return devices;
     }
@@ -489,7 +488,7 @@ export class DeviceManager {
             } else {
                 // For non-online devices, check cache freshness
                 const cached = lookup.serialNumber ? this.globalStateManager.getCachedDevice(lookup.serialNumber) : undefined;
-                const isFreshCache = cached && (now - cached.createdAt < this.FRESH_CACHE_THRESHOLD_MS);
+                const isFreshCache = cached && (now - cached.createdAt < this.ON_WRITE_TRUST_MS);
                 resolvedState = isFreshCache ? 'online' : 'unknown';
             }
         }
@@ -953,7 +952,7 @@ export class DeviceManager {
      * A device in state `unknown` has no trustable knowledge, so it always fetches.
      */
     private async ensureDeviceFresh(device: RokuDevice | { ip: string; serialNumber?: string }, options?: { maxAgeMs?: number; syntheticDelay?: boolean }): Promise<boolean> {
-        const maxAgeMs = options?.maxAgeMs ?? this.DEVICE_INFO_CACHE_MS;
+        const maxAgeMs = options?.maxAgeMs ?? this.ON_WRITE_TRUST_MS;
         const syntheticDelay = options?.syntheticDelay ?? true;
 
         // Extract serial from device if available (for proper state key management)
@@ -1363,7 +1362,7 @@ export class DeviceManager {
 
     /**
      * Handle device-online event from RokuFinder. Shows a notification if enabled.
-     * Does not eagerly device-info the device - lazy hydration on read handles that
+     * Does not eagerly device-info the device - the background refresh on read handles that
      * once a view actually asks for the device list (spec: Passive SSDP announcements).
      */
     private handleDeviceOnline(ip: string, serialNumber?: string): void {
@@ -1437,7 +1436,7 @@ export class DeviceManager {
         this.finder.on('found', (ip: string, options?: { serialNumber?: string }) => {
             this.setDiscoveredDevice(ip, options?.serialNumber);
             //no eager resolve here - a responder that lands in `unknown` is picked up by lazy
-            //hydration on the next visible read
+            //background refresh on the next visible read
             this.emitDevicesChanged();
         });
 

--- a/src/deviceDiscovery/DeviceManager.ts
+++ b/src/deviceDiscovery/DeviceManager.ts
@@ -628,8 +628,9 @@ export class DeviceManager {
 
     /**
      * Atomically consume AND execute the pending broadcast order, if any. The one-call
-     * fulfillment API for views: take + broadcast in a single step, with the force policy owned
-     * here — forced for every reason except `stale`, which stays staleness-gated.
+     * fulfillment API for views: take + broadcast in a single step. The order's reason travels
+     * into {@link broadcast}, which decides the urgency internally (a `stale` timer-tick stays
+     * staleness-gated; every real trigger scans now).
      *
      * Consumption is atomic: when two visible views react to the same order event, the first
      * caller fulfills it and later callers find the slot empty and do nothing.
@@ -644,13 +645,14 @@ export class DeviceManager {
             return false;
         }
         this.pendingBroadcast = null;
-        return this.broadcast(pending.reason !== 'stale');
+        return this.broadcast(pending.reason);
     }
 
     /**
      * Atomically consume AND execute the pending reconcile order, if any. One-call twin of
-     * {@link fulfillPendingBroadcast}; the force policy here is: forced only for
-     * `refresh-clicked` (an explicit "I want fresh data now" from the user).
+     * {@link fulfillPendingBroadcast}; the reason travels into {@link reconcile}, which decides
+     * internally whether the per-device cache trust window is bypassed (only for
+     * `refresh-clicked` — an explicit "I want fresh data now" from the user).
      */
     public fulfillPendingReconcile(options?: { except?: ReconcileReason[] }): boolean {
         const pending = this.pendingReconcile;
@@ -658,31 +660,40 @@ export class DeviceManager {
             return false;
         }
         this.pendingReconcile = null;
-        this.reconcile(pending.reason === 'refresh-clicked');
+        this.reconcile(pending.reason);
         return true;
     }
     // #endregion
 
     /**
      * Broadcast an SSDP M-SEARCH to discover devices on the network. Does NOT health-check
-     * existing devices — that's {@link reconcile}. Non-forced calls are staleness-gated (no
-     * scan when the last scan is younger than STALE_SCAN_THRESHOLD_MS) and blocked while
-     * device discovery is disabled.
+     * existing devices — that's {@link reconcile}. The reason decides the urgency: every real
+     * trigger scans now, while a `stale` timer-tick is only a "things might be old" hint — it
+     * scans only when discovery is enabled AND the last scan is older than
+     * STALE_SCAN_THRESHOLD_MS. Reachable only through order fulfillment.
      * @returns true if a scan was started
      */
-    public broadcast(force = false): boolean {
-        if (!force && !this.deviceDiscoveryEnabled) {
-            return false;
+    private broadcast(reason: BroadcastReason): boolean {
+        if (reason === 'stale') {
+            if (!this.deviceDiscoveryEnabled || this.timeSinceLastScan <= this.STALE_SCAN_THRESHOLD_MS) {
+                return false;
+            }
         }
-        return this.discoverAll(force);
+        this.lastScanDate = new Date();
+        this.finder.scan();
+        return true;
     }
 
     /**
      * Health-check every known device (configured + discovered), marking them online/offline.
-     * Does NOT scan for new devices — that's {@link broadcast}.
+     * Does NOT scan for new devices — that's {@link broadcast}. The reason decides the urgency:
+     * only an explicit user click bypasses each device's cache trust window — a bypassing
+     * reconcile is one HTTP request per known device, so only "I want fresh data NOW" earns
+     * that. Reachable only through order fulfillment.
      */
-    public reconcile(force = false, doSyntheticDelay = true): void {
-        this.healthCheckAllDevices(force, doSyntheticDelay).catch(() => { });
+    private reconcile(reason: ReconcileReason): void {
+        const bypassDeviceCache = reason === 'refresh-clicked';
+        this.healthCheckAllDevices(bypassDeviceCache, true).catch(() => { });
     }
 
     /**
@@ -1287,19 +1298,6 @@ export class DeviceManager {
             return undefined;
         }
     }
-
-    /**
-     * Discover all Roku devices on the network and watch for new ones that connect
-     */
-    private discoverAll(force: boolean): boolean {
-        if (force || this.timeSinceLastScan > this.STALE_SCAN_THRESHOLD_MS) {
-            this.lastScanDate = new Date();
-            this.finder.scan();
-            return true;
-        }
-        return false;
-    }
-
 
     /**
      * Add or update a device in the discoveredDevices array.

--- a/src/deviceDiscovery/DeviceManager.ts
+++ b/src/deviceDiscovery/DeviceManager.ts
@@ -700,10 +700,12 @@ export class DeviceManager {
      * picker, or is about to launch to it (spec: "explicit engagement with that specific
      * device"). Freshens the device now (bypassing its cache trust window) and reports whether
      * it responded. Fire-and-forget callers can ignore the result; callers that need to know
-     * (picker validation, pre-launch checks) await it.
+     * (picker validation, pre-launch checks) await it. Accepts anything {@link getDevice} can
+     * look up (encoded tree key, ip/serial lookup) or a device object; an unknown device is
+     * simply reported unhealthy.
      */
-    public async deviceEngaged(deviceOrLookup: RokuDevice | { ip?: string; serialNumber?: string }): Promise<boolean> {
-        return this.healthCheckDevice(deviceOrLookup, true, false);
+    public async deviceEngaged(deviceKeyOrLookup: RokuDevice | string | { ip?: string; serialNumber?: string }): Promise<boolean> {
+        return this.healthCheckDevice(deviceKeyOrLookup, true, false);
     }
 
     /**
@@ -790,11 +792,16 @@ export class DeviceManager {
         this.clearCurrentDeviceList();
     }
 
-    private async healthCheckDevice(deviceOrLookup: RokuDevice | { ip?: string; serialNumber?: string }, force = false, doSyntheticDelay = true): Promise<boolean> {
+    private async healthCheckDevice(deviceKeyOrLookup: RokuDevice | string | { ip?: string; serialNumber?: string }, force = false, doSyntheticDelay = true): Promise<boolean> {
         // If already a device object with deviceState, use it directly; otherwise look it up
-        const device = 'deviceState' in deviceOrLookup
-            ? deviceOrLookup
-            : this.getDevice(deviceOrLookup);
+        let device: RokuDevice | undefined;
+        if (typeof deviceKeyOrLookup === 'string') {
+            device = this.getDevice(deviceKeyOrLookup);
+        } else if ('deviceState' in deviceKeyOrLookup) {
+            device = deviceKeyOrLookup;
+        } else {
+            device = this.getDevice(deviceKeyOrLookup);
+        }
 
         if (!device) {
             return false;

--- a/src/deviceDiscovery/DeviceManager.ts
+++ b/src/deviceDiscovery/DeviceManager.ts
@@ -251,7 +251,7 @@ export class DeviceManager {
      */
     public async validateAndAddDevice(ip: string): Promise<RokuDevice | undefined> {
         this.setDiscoveredDevice(ip, undefined);
-        await this.resolveDevice({ ip: ip }, false);
+        await this.resolveDevice({ ip: ip }, { syntheticDelay: false });
         return this.getDevice({ ip: ip });
     }
 
@@ -315,8 +315,8 @@ export class DeviceManager {
             //timestamp at queue time so even instantly-failing attempts are rate-limited
             this.hydrationLastAttempt.set(device.ip, now);
             this.hydrationInFlight.add(device.ip);
-            //silent background refresh: no synthetic delay, not forced (offline cooldown applies)
-            void this.resolveDevice({ ip: device.ip, serialNumber: device.serialNumber }, false, false)
+            //silent background refresh: no synthetic delay, cache trusted (offline cooldown applies)
+            void this.resolveDevice({ ip: device.ip, serialNumber: device.serialNumber }, { syntheticDelay: false })
                 .catch(() => { })
                 .finally(() => {
                     this.hydrationInFlight.delete(device.ip);
@@ -720,7 +720,7 @@ export class DeviceManager {
         }
 
         // Engagement wants a real answer now: bypass the cache trust window, no synthetic delay
-        const isHealthy = await this.resolveDevice(device, false, true);
+        const isHealthy = await this.resolveDevice(device, { bypassCache: true, syntheticDelay: false });
         if (!isHealthy && device.isDiscovered) {
             // a discovered device went dark — order a rescan for the views to fulfill
             this.submitUnhealthyDeviceBroadcast();
@@ -1105,17 +1105,22 @@ export class DeviceManager {
         this.emitDevicesChanged();
     }
 
-    private async resolveDevice(device: RokuDevice | { ip: string; serialNumber?: string }, doSyntheticDelay = true, force = false): Promise<boolean> {
+    private async resolveDevice(device: RokuDevice | { ip: string; serialNumber?: string }, options?: { bypassCache?: boolean; syntheticDelay?: boolean }): Promise<boolean> {
+        // bypassCache: skip the cache trust window AND the offline cooldown — "I want a real
+        // answer from the network NOW" (user engagement, refresh-clicked reconciles).
+        const bypassCache = options?.bypassCache ?? false;
+        const syntheticDelay = options?.syntheticDelay ?? true;
+
         // Extract serial from device if available (for proper state key management)
         const knownSerial = 'serialNumber' in device ? device.serialNumber : undefined;
 
         const currentStateObject = this.getDeviceState({ ip: device.ip, serialNumber: knownSerial });
 
-        // Offline cooldown: if device is offline and we recently checked, skip unless forced
+        // Offline cooldown: if device is offline and we recently checked, skip the re-check.
         // This prevents the loop: healthCheck → resolve → offline → emit → refresh → healthCheck...
         const isOffline = currentStateObject.state === 'offline';
         const recentlyCheckedOffline = isOffline && (Date.now() - currentStateObject.lastUpdated < this.OFFLINE_COOLDOWN_MS);
-        if (!force && recentlyCheckedOffline) {
+        if (!bypassCache && recentlyCheckedOffline) {
             return false;
         }
 
@@ -1135,10 +1140,10 @@ export class DeviceManager {
         const cacheIsFresh = cached && (Date.now() - cached.createdAt < this.DEVICE_INFO_CACHE_MS) && cachedIp === device.ip;
 
         // Use cache only if:
-        // - Not forced
+        // - The caller didn't ask to bypass it
         // - Cache is fresh
         // - Device is not offline (offline devices should always hit network to check if back online)
-        if (!force && cacheIsFresh && !isOffline) {
+        if (!bypassCache && cacheIsFresh && !isOffline) {
             // Use cached data
             deviceInfo = cached.deviceInfo as DeviceInfoRaw;
         } else {
@@ -1153,7 +1158,7 @@ export class DeviceManager {
             try {
                 deviceInfo = await this.fetchDeviceInfo(device.ip, 8060);
 
-                if (doSyntheticDelay) {
+                if (syntheticDelay) {
                     await this.randomDelay(400, 1_000);
                 }
             } catch {
@@ -1260,7 +1265,7 @@ export class DeviceManager {
         }
     }
 
-    private async healthCheckAllDevices(force = false): Promise<void> {
+    private async healthCheckAllDevices(bypassDeviceCache = false): Promise<void> {
         // Collect all unique IPs from both sources (same serial at different IPs = different entries to check)
         const discoveredIpSet = new Set(this.discoveredDevices.map(entry => entry.ip));
         const allIps = new Set([
@@ -1281,7 +1286,7 @@ export class DeviceManager {
         // Health check all devices - if any discovered device is unhealthy, order a scan
         let needsScan = false;
         await Promise.all([...allIps].map(async (ip) => {
-            const isHealthy = await this.resolveDevice({ ip: ip }, true, force);
+            const isHealthy = await this.resolveDevice({ ip: ip }, { bypassCache: bypassDeviceCache });
             if (!isHealthy && discoveredIpSet.has(ip)) {
                 needsScan = true;
             }

--- a/src/deviceDiscovery/DeviceManager.ts
+++ b/src/deviceDiscovery/DeviceManager.ts
@@ -634,18 +634,19 @@ export class DeviceManager {
      * Consumption is atomic: when two visible views react to the same order event, the first
      * caller fulfills it and later callers find the set empty and do nothing.
      *
-     * @param options.except - reasons to leave QUEUED (not consumed) for another view, e.g.
+     * @param options.except - reasons that do not TRIGGER fulfillment on their own, e.g.
      *   `{ except: ['stale'] }`. A blacklist on purpose: new reasons are acted on by default.
+     *   When a non-excepted reason does trigger execution, the whole set is cleared — the scan
+     *   satisfies every queued reason, excepted ones included.
      * @returns true if orders were consumed and a scan actually started
      */
     public fulfillPendingBroadcast(options?: { except?: BroadcastReason[] }): boolean {
-        const reasons = this.getPendingBroadcastReasons().filter(x => !options?.except?.includes(x));
-        if (reasons.length === 0) {
+        const triggers = this.getPendingBroadcastReasons().filter(x => !options?.except?.includes(x));
+        if (triggers.length === 0) {
             return false;
         }
-        for (const reason of reasons) {
-            this.pendingBroadcastReasons.delete(reason);
-        }
+        const reasons = this.getPendingBroadcastReasons();
+        this.pendingBroadcastReasons.clear();
         return this.broadcast(reasons);
     }
 
@@ -656,13 +657,12 @@ export class DeviceManager {
      * `refresh-clicked` is among them — an explicit "I want fresh data now" from the user).
      */
     public fulfillPendingReconcile(options?: { except?: ReconcileReason[] }): boolean {
-        const reasons = this.getPendingReconcileReasons().filter(x => !options?.except?.includes(x));
-        if (reasons.length === 0) {
+        const triggers = this.getPendingReconcileReasons().filter(x => !options?.except?.includes(x));
+        if (triggers.length === 0) {
             return false;
         }
-        for (const reason of reasons) {
-            this.pendingReconcileReasons.delete(reason);
-        }
+        const reasons = this.getPendingReconcileReasons();
+        this.pendingReconcileReasons.clear();
         this.reconcile(reasons);
         return true;
     }

--- a/src/deviceDiscovery/DeviceManager.ts
+++ b/src/deviceDiscovery/DeviceManager.ts
@@ -903,7 +903,6 @@ export class DeviceManager {
         // Check if the serial was last seen at this IP (don't trust cache if device moved)
         const cachedIp = serialForCache ? this.globalStateManager.getIpForSerial(serialForCache, this.networkId) : undefined;
         const cacheIsFresh = cached && (Date.now() - cached.createdAt < this.DEVICE_INFO_CACHE_MS) && cachedIp === device.ip;
-        console.log('[TRACE] resolveDevice', device.ip, 'serialForCache=', serialForCache, 'cachedIp=', cachedIp, 'cacheIsFresh=', cacheIsFresh);
 
         // Use cache only if:
         // - Not forced
@@ -1104,10 +1103,35 @@ export class DeviceManager {
     }
 
     /**
-     * Fetch device info from the network. Always makes a network request.
-     * Caches the result in globalStateManager for future lookups.
+     * In-flight device-info requests by `ip:port`. This is the design doc's "de-dupe rule":
+     * within a single refresh flow a device only gets device-info'd once — concurrent callers
+     * (e.g. the broadcast response and the reconcile racing on the same device) share one HTTP
+     * request instead of each issuing their own. First one in wins; everyone else joins it.
      */
-    private async fetchDeviceInfo(ip: string, port: number): Promise<DeviceInfoRaw> {
+    private inFlightDeviceInfo = new Map<string, Promise<DeviceInfoRaw | undefined>>();
+
+    /**
+     * Fetch device info from the network, sharing any request already in flight for the same
+     * ip:port (see the de-dupe rule in docs/device-discovery.md). Never rejects — failures
+     * return undefined. Success caches the result in globalStateManager for future lookups.
+     */
+    private fetchDeviceInfo(ip: string, port: number): Promise<DeviceInfoRaw | undefined> {
+        const key = `${ip}:${port}`;
+        let inFlight = this.inFlightDeviceInfo.get(key);
+        if (inFlight === undefined) {
+            //safe to share: fetchDeviceInfoInner never rejects (it catches and returns undefined)
+            inFlight = this.fetchDeviceInfoInner(ip, port).finally(() => {
+                this.inFlightDeviceInfo.delete(key);
+            });
+            this.inFlightDeviceInfo.set(key, inFlight);
+        }
+        return inFlight;
+    }
+
+    /**
+     * Fetch device info from the network. Always makes a network request.
+     */
+    private async fetchDeviceInfoInner(ip: string, port: number): Promise<DeviceInfoRaw> {
         try {
             const info = await rokuDeploy.getDeviceInfo({
                 host: ip,
@@ -1493,7 +1517,7 @@ export class DeviceManager {
     }, this.DEVICES_CHANGED_DEBOUNCE_MS);
 
     private async randomDelay(min: number, max: number) {
-        const randomness = Math.random() * ((max - min) + min);
+        const randomness = min + (Math.random() * (max - min));
         await util.sleep(randomness);
     }
 }

--- a/src/deviceDiscovery/DeviceManager.ts
+++ b/src/deviceDiscovery/DeviceManager.ts
@@ -597,7 +597,7 @@ export class DeviceManager {
      * set when it opens. Reasons accumulate independently (e.g. `stale` and `sleep` can both
      * be pending) but the same reason never queues twice.
      */
-    public submitBroadcast(reason: BroadcastReason): void {
+    private submitBroadcast(reason: BroadcastReason): void {
         this.pendingBroadcastReasons.add(reason);
         const order: BroadcastOrder = { reason: reason, timestamp: Date.now() };
         this.emitter.emit('broadcast-ordered', order);
@@ -607,7 +607,7 @@ export class DeviceManager {
      * Submit a reconcile (health-check-all) order. Same set + event semantics as
      * {@link submitBroadcast}.
      */
-    public submitReconcile(reason: ReconcileReason): void {
+    private submitReconcile(reason: ReconcileReason): void {
         this.pendingReconcileReasons.add(reason);
         const order: ReconcileOrder = { reason: reason, timestamp: Date.now() };
         this.emitter.emit('reconcile-ordered', order);
@@ -680,9 +680,10 @@ export class DeviceManager {
     }
 
     /**
-     * The "user clicked refresh / scan" interaction (spec: Clicking refresh): always submits a
-     * broadcast order AND a reconcile order, regardless of how recently either ran. Views report
-     * the interaction; which order types it implies is the manager's business.
+     * The "user clicked refresh / scan" interaction (spec: Clicking refresh) — the only order
+     * submission views can make. Always submits a broadcast order AND a reconcile order,
+     * regardless of how recently either ran; the split into order types is internal, like every
+     * other trigger's.
      */
     public submitRefreshOrders(): void {
         this.submitBroadcast('refresh-clicked');

--- a/src/deviceDiscovery/DeviceManager.ts
+++ b/src/deviceDiscovery/DeviceManager.ts
@@ -107,6 +107,8 @@ export class DeviceManager {
 
             //clear and reload discovered devices anytime this network changes (state goes with them)
             this.discoveredDevices = [];
+            //in-session knowledge is network-specific - same IP may be a different device now
+            this.lastCheckedByIp.clear();
             this.loadLastSeenDevices();
 
             //re-point the active device at its IP on this network (found by serial number)
@@ -170,18 +172,16 @@ export class DeviceManager {
     private networkChangeMonitor: NetworkChangeMonitor;
     private finder = new RokuFinder(this.globalStateManager, this.makeFinderLogger());
 
-    // Health check tracking and cooldowns
-    private resolveDeviceSequence = new Map<string, number>();
-    private readonly DEVICE_INFO_CACHE_MS = 5 * 60 * 1_000; // 5 minutes - cache duration for fetchDeviceInfo
+    // Health check tracking. lastCheckedByIp is when we last attempted a check (success or
+    // failure) - ensureDeviceFresh callers state how old that knowledge may be (maxAgeMs)
+    private deviceCheckSequence = new Map<string, number>();
+    private lastCheckedByIp = new Map<string, number>();
+    private readonly DEVICE_INFO_CACHE_MS = 5 * 60 * 1_000; // 5 minutes - default freshness requirement for ensureDeviceFresh
     private readonly FRESH_CACHE_THRESHOLD_MS = 5 * 60 * 1_000; // 5 minutes - cache fresher than this = online on load
-    private readonly OFFLINE_COOLDOWN_MS = 5_000; // 5 seconds - minimum time between resolve attempts for offline devices
     private static readonly HEALTH_CHECK_TIMEOUT_MS = 2_000; // 2 seconds
 
     // Lazy hydration (background device-info refresh triggered by view reads)
-    private readonly HYDRATION_MAX_CACHE_AGE_MS = 8 * 60 * 60 * 1_000; // 8 hours - cache older than this re-hydrates on read
-    private readonly HYDRATION_RETRY_COOLDOWN_MS = 5 * 60 * 1_000; // 5 minutes - minimum time between hydration attempts per IP
-    private hydrationInFlight = new Set<string>();
-    private hydrationLastAttempt = new Map<string, number>();
+    private readonly HYDRATION_MAX_CACHE_AGE_MS = 8 * 60 * 60 * 1_000; // 8 hours - hydration's freshness requirement
 
     // Notifications and event debouncing
     private readonly DEVICES_CHANGED_DEBOUNCE_MS = 50;
@@ -241,7 +241,8 @@ export class DeviceManager {
         }
 
         if (device) {
-            this.queueHydration([device]);
+            //background freshness: return immediately, updates arrive via devices-changed
+            void this.ensureDeviceFresh(device, { maxAgeMs: this.HYDRATION_MAX_CACHE_AGE_MS, syntheticDelay: false }).catch(() => { });
         }
         return device;
     }
@@ -255,69 +256,20 @@ export class DeviceManager {
      */
     public async validateAndAddDevice(ip: string): Promise<RokuDevice | undefined> {
         this.setDiscoveredDevice(ip, undefined);
-        await this.resolveDevice({ ip: ip }, { syntheticDelay: false });
+        await this.ensureDeviceFresh({ ip: ip }, { syntheticDelay: false });
         return this.getDevice({ ip: ip });
     }
 
     /**
      * Get a list of all roku devices. Returns immediately from in-memory data; stale devices
-     * hydrate in the background and fire `devices-changed` when fresh data arrives.
+     * refresh in the background and fire `devices-changed` when fresh data arrives.
      */
     public getAllDevices(): RokuDevice[] {
         const devices = this.buildAllDevices();
-        this.queueHydration(devices);
-        return devices;
-    }
-
-    /**
-     * Does this device need a background device-info refresh? Yes when it has never been
-     * confirmed this session (`unknown`), or its cached info is older than
-     * HYDRATION_MAX_CACHE_AGE_MS.
-     */
-    private needsHydration(device: RokuDevice): boolean {
-        //pending means a resolve is already in flight - without this guard a pending device
-        //would re-queue on every read
-        if (device.deviceState === 'pending') {
-            return false;
-        }
-        if (device.deviceState === 'unknown') {
-            return true;
-        }
-        const cached = device.serialNumber ? this.globalStateManager.getCachedDevice(device.serialNumber) : undefined;
-        if (!cached) {
-            return false;
-        }
-        return Date.now() - cached.createdAt > this.HYDRATION_MAX_CACHE_AGE_MS;
-    }
-
-    /**
-     * Lazy hydration on read: queue background device-info fetches for devices that need one.
-     * Must converge even though resolves emit devices-changed (which triggers more reads) -
-     * the in-flight set and per-IP cooldown below are that guard.
-     */
-    private queueHydration(devices: RokuDevice[]): void {
-        const now = Date.now();
         for (const device of devices) {
-            if (!this.needsHydration(device)) {
-                continue;
-            }
-            if (this.hydrationInFlight.has(device.ip)) {
-                continue;
-            }
-            const lastAttempt = this.hydrationLastAttempt.get(device.ip);
-            if (lastAttempt !== undefined && now - lastAttempt < this.HYDRATION_RETRY_COOLDOWN_MS) {
-                continue;
-            }
-
-            //timestamp at queue time so even instantly-failing attempts are rate-limited
-            this.hydrationLastAttempt.set(device.ip, now);
-            this.hydrationInFlight.add(device.ip);
-            void this.resolveDevice({ ip: device.ip, serialNumber: device.serialNumber }, { syntheticDelay: false })
-                .catch(() => { })
-                .finally(() => {
-                    this.hydrationInFlight.delete(device.ip);
-                });
+            void this.ensureDeviceFresh(device, { maxAgeMs: this.HYDRATION_MAX_CACHE_AGE_MS, syntheticDelay: false }).catch(() => { });
         }
+        return devices;
     }
 
     /**
@@ -646,8 +598,9 @@ export class DeviceManager {
      * Only an explicit user refresh bypasses each device's cache trust window.
      */
     private reconcile(reasons: ReconcileReason[]): void {
-        const bypassDeviceCache = reasons.includes('refresh-clicked');
-        this.healthCheckAllDevices(bypassDeviceCache).catch((e) => {
+        //an explicit user refresh demands data fresher than anything we have (maxAgeMs 0)
+        const maxAgeMs = reasons.includes('refresh-clicked') ? 0 : undefined;
+        this.healthCheckAllDevices(maxAgeMs).catch((e) => {
             console.error('[DeviceManager] reconcile health check failed', e);
         });
     }
@@ -687,8 +640,8 @@ export class DeviceManager {
 
         // Clear all timestamps and per-device state
         this.lastScanDate = null;
-        this.resolveDeviceSequence.clear();
-        this.hydrationLastAttempt.clear();
+        this.deviceCheckSequence.clear();
+        this.lastCheckedByIp.clear();
 
         // Reset configured device states to unknown
         for (const entry of this.configuredDevices) {
@@ -992,9 +945,15 @@ export class DeviceManager {
         this.emitDevicesChanged();
     }
 
-    private async resolveDevice(device: RokuDevice | { ip: string; serialNumber?: string }, options?: { bypassCache?: boolean; syntheticDelay?: boolean }): Promise<boolean> {
-        //bypassCache skips the cache trust window AND the offline cooldown
-        const bypassCache = options?.bypassCache ?? false;
+    /**
+     * Check a single device and apply the result to the device list (online/offline states,
+     * discovered-device removal, devices-changed). `maxAgeMs` is the caller's freshness
+     * requirement: when our knowledge of the device (last successful fetch OR last failed
+     * attempt) is younger than this, return the current state without touching the network.
+     * A device in state `unknown` has no trustable knowledge, so it always fetches.
+     */
+    private async ensureDeviceFresh(device: RokuDevice | { ip: string; serialNumber?: string }, options?: { maxAgeMs?: number; syntheticDelay?: boolean }): Promise<boolean> {
+        const maxAgeMs = options?.maxAgeMs ?? this.DEVICE_INFO_CACHE_MS;
         const syntheticDelay = options?.syntheticDelay ?? true;
 
         // Extract serial from device if available (for proper state key management)
@@ -1002,58 +961,45 @@ export class DeviceManager {
 
         const currentStateObject = this.getDeviceState({ ip: device.ip, serialNumber: knownSerial });
 
-        // Offline cooldown: if device is offline and we recently checked, skip the re-check.
-        // This prevents the loop: healthCheck → resolve → offline → emit → refresh → healthCheck...
-        const isOffline = currentStateObject.state === 'offline';
-        const recentlyCheckedOffline = isOffline && (Date.now() - currentStateObject.lastUpdated < this.OFFLINE_COOLDOWN_MS);
-        if (!bypassCache && recentlyCheckedOffline) {
-            return false;
+        // How old is our knowledge of this device? In-session attempts win; otherwise fall
+        // back to the persisted cache write (but don't trust cache if the device moved IPs)
+        const serialForCache = knownSerial ?? this.globalStateManager.getSerialNumberForIp(device.ip, this.networkId);
+        const cached = serialForCache ? this.globalStateManager.getCachedDevice(serialForCache) : undefined;
+        const cachedIp = serialForCache ? this.globalStateManager.getIpForSerial(serialForCache, this.networkId) : undefined;
+        const lastChecked = this.lastCheckedByIp.get(device.ip) ?? (cachedIp === device.ip ? cached?.createdAt : undefined) ?? 0;
+
+        // Fresh enough for this caller (and not `unknown`): answer from what we already know
+        if (currentStateObject.state !== 'unknown' && Date.now() - lastChecked < maxAgeMs) {
+            return currentStateObject.state === 'online' || currentStateObject.state === 'pending';
         }
+
+        // Stamp the attempt up front so even instantly-failing checks count as knowledge
+        this.lastCheckedByIp.set(device.ip, Date.now());
 
         // Increment and capture sequence number to handle concurrent refresh calls
         // Use IP for sequence tracking (primary key)
-        const currentSeq = (this.resolveDeviceSequence.get(device.ip) ?? 0) + 1;
-        this.resolveDeviceSequence.set(device.ip, currentSeq);
+        const currentSeq = (this.deviceCheckSequence.get(device.ip) ?? 0) + 1;
+        this.deviceCheckSequence.set(device.ip, currentSeq);
 
-        // Get device info from cache or network
+        // Set to pending before making network call
+        if (currentStateObject.state !== 'pending') {
+            this.setDeviceState({ ip: device.ip, serialNumber: knownSerial }, 'pending');
+            this.emitDevicesChanged();
+        }
+
         let deviceInfo: DeviceInfoRaw | undefined;
+        try {
+            deviceInfo = await this.getDeviceInfo(device.ip);
 
-        // Try to find cached data via serial number
-        const serialForCache = knownSerial ?? this.globalStateManager.getSerialNumberForIp(device.ip, this.networkId);
-        const cached = serialForCache ? this.globalStateManager.getCachedDevice(serialForCache) : undefined;
-        // Check if the serial was last seen at this IP (don't trust cache if device moved)
-        const cachedIp = serialForCache ? this.globalStateManager.getIpForSerial(serialForCache, this.networkId) : undefined;
-        const cacheIsFresh = cached && (Date.now() - cached.createdAt < this.DEVICE_INFO_CACHE_MS) && cachedIp === device.ip;
-
-        // Use cache only if:
-        // - The caller didn't ask to bypass it
-        // - Cache is fresh
-        // - Device is not offline (offline devices should always hit network to check if back online)
-        if (!bypassCache && cacheIsFresh && !isOffline) {
-            // Use cached data
-            deviceInfo = cached.deviceInfo as DeviceInfoRaw;
-        } else {
-            // Set to pending before making network call
-            // This prevents unnecessary state flicker (online→pending→online) when using cache
-            if (currentStateObject.state !== 'pending') {
-                this.setDeviceState({ ip: device.ip, serialNumber: knownSerial }, 'pending');
-                this.emitDevicesChanged();
+            if (syntheticDelay) {
+                await this.randomDelay(400, 1_000);
             }
-
-            // Fetch fresh data from network
-            try {
-                deviceInfo = await this.getDeviceInfo(device.ip);
-
-                if (syntheticDelay) {
-                    await this.randomDelay(400, 1_000);
-                }
-            } catch {
-                deviceInfo = undefined;
-            }
+        } catch {
+            deviceInfo = undefined;
         }
 
         // Only apply result if this is still the latest request for this device
-        if (this.resolveDeviceSequence.get(device.ip) !== currentSeq) {
+        if (this.deviceCheckSequence.get(device.ip) !== currentSeq) {
             // Stale response - a newer check was started, ignore this result
             return !!deviceInfo;
         }
@@ -1151,7 +1097,7 @@ export class DeviceManager {
         }
     }
 
-    private async healthCheckAllDevices(bypassDeviceCache = false): Promise<void> {
+    private async healthCheckAllDevices(maxAgeMs?: number): Promise<void> {
         // Collect all unique IPs from both sources (same serial at different IPs = different entries to check)
         const discoveredIpSet = new Set(this.discoveredDevices.map(entry => entry.ip));
         const allIps = new Set([
@@ -1163,16 +1109,10 @@ export class DeviceManager {
             return;
         }
 
-        // Set all to pending and emit before async work
-        for (const ip of allIps) {
-            this.setDeviceState({ ip: ip }, 'pending');
-        }
-        this.emitDevicesChanged();
-
         // Health check all devices - if any discovered device is unhealthy, order a scan
         let needsScan = false;
         await Promise.all([...allIps].map(async (ip) => {
-            const isHealthy = await this.resolveDevice({ ip: ip }, { bypassCache: bypassDeviceCache });
+            const isHealthy = await this.ensureDeviceFresh({ ip: ip }, { maxAgeMs: maxAgeMs });
             if (!isHealthy && discoveredIpSet.has(ip)) {
                 needsScan = true;
             }

--- a/src/deviceDiscovery/DeviceManager.ts
+++ b/src/deviceDiscovery/DeviceManager.ts
@@ -706,15 +706,32 @@ export class DeviceManager {
     // #endregion
 
     /**
-     * The user engaged with a specific device — clicked it, expanded it, selected it in the
-     * picker, or is about to launch to it (spec: "explicit engagement with that specific
-     * device"). Freshens the device now (bypassing its cache trust window) and reports whether
-     * it responded. Fire-and-forget callers can ignore the result; callers that need to know
-     * (picker validation, pre-launch checks) await it. Accepts anything {@link getDevice} can
-     * look up (encoded tree key, ip/serial lookup) or a device object; an unknown device is
-     * simply reported unhealthy.
+     * Health-check a single device NOW: bypass its cache trust window, fetch fresh device
+     * info from the network, update the cache (so every view renders the freshest data), and
+     * report whether it responded. Fire-and-forget callers can ignore the result — the cache
+     * update is the point. Accepts anything {@link getDevice} can look up (encoded tree key,
+     * ip/serial lookup) or a device object; an unknown device is simply reported unhealthy.
      */
-    public async deviceEngaged(deviceKeyOrLookup: RokuDevice | string | { ip?: string; serialNumber?: string }): Promise<boolean> {
+    public async healthCheckDevice(deviceKeyOrLookup: RokuDevice | string | { ip?: string; serialNumber?: string }): Promise<boolean> {
+        return (await this.fetchFreshDevice(deviceKeyOrLookup)) !== undefined;
+    }
+
+    /**
+     * Fetch a single device's info fresh from the network NOW. Same work as
+     * {@link healthCheckDevice} (bypass cache trust window, fetch, update cache) — this variant
+     * returns the resulting device info for callers that need it (e.g. pre-launch host
+     * resolution). Returns undefined when the device is unknown or unreachable.
+     */
+    public async getDeviceInfo(deviceKeyOrLookup: RokuDevice | string | { ip?: string; serialNumber?: string }): Promise<Record<string, any> | undefined> {
+        return (await this.fetchFreshDevice(deviceKeyOrLookup))?.deviceInfo;
+    }
+
+    /**
+     * The shared engine behind {@link healthCheckDevice} and {@link getDeviceInfo}: resolve
+     * the device with the cache trust window bypassed and no synthetic delay, then return the
+     * freshly-merged device (or undefined when unknown/unreachable).
+     */
+    private async fetchFreshDevice(deviceKeyOrLookup: RokuDevice | string | { ip?: string; serialNumber?: string }): Promise<RokuDevice | undefined> {
         // If already a device object with deviceState, use it directly; otherwise look it up
         let device: RokuDevice | undefined;
         if (typeof deviceKeyOrLookup === 'string') {
@@ -726,16 +743,20 @@ export class DeviceManager {
         }
 
         if (!device) {
-            return false;
+            return undefined;
         }
 
-        // Engagement wants a real answer now: bypass the cache trust window, no synthetic delay
+        // The caller wants a real answer now: bypass the cache trust window, no synthetic delay
         const isHealthy = await this.resolveDevice(device, { bypassCache: true, syntheticDelay: false });
-        if (!isHealthy && device.isDiscovered) {
-            // a discovered device went dark — order a rescan for the views to fulfill
-            this.submitUnhealthyDeviceBroadcast();
+        if (!isHealthy) {
+            if (device.isDiscovered) {
+                // a discovered device went dark — order a rescan for the views to fulfill
+                this.submitUnhealthyDeviceBroadcast();
+            }
+            return undefined;
         }
-        return isHealthy;
+        // re-read so the returned device carries the just-fetched info
+        return this.getDevice({ ip: device.ip, serialNumber: device.serialNumber });
     }
 
     /**

--- a/src/deviceDiscovery/DeviceManager.ts
+++ b/src/deviceDiscovery/DeviceManager.ts
@@ -7,7 +7,7 @@ import { util as rokuDebugUtil } from 'roku-debug/dist/util';
 import type { GlobalStateManager } from '../GlobalStateManager';
 import { RokuFinder } from './RokuFinder';
 import { Orders } from './Orders';
-import type { Order, OrderType, SubmittedOrder, BroadcastReason, ReconcileReason } from './Orders';
+import type { Order, OrderType, SubmittedOrder, TakenOrders, BroadcastReason, ReconcileReason } from './Orders';
 import { NetworkChangeMonitor, getNetworkHash } from './NetworkChangeMonitor';
 import { SystemSleepMonitor } from './SystemSleepMonitor';
 import { util } from '../util';
@@ -630,33 +630,28 @@ export class DeviceManager {
 
     /**
      * Atomically consume AND execute pending orders — the one-call fulfillment API for views.
-     * The work is idempotent per order type, so all taken reasons are satisfied by a single
-     * execution: broadcast reasons by one scan (staleness-gated when stale-only), reconcile
-     * reasons by one health-check sweep (cache bypassed when `refresh-clicked` is among them).
+     * {@link Orders.take} drains what the options allow; each taken entry is executed once
+     * (all of its reasons are satisfied by that single execution): broadcast by one scan
+     * (staleness-gated when stale-only), reconcile by one health-check sweep (cache bypassed
+     * when `refresh-clicked` is among the reasons).
      *
      * @param options.types - which order types to fulfill. Callers state their policy
      *   explicitly — e.g. the tree view fulfills both, the quick pick's 7s fallback only wants
      *   broadcasts, live handlers pass the submitted order's type.
      * @param options.except - reasons that do not TRIGGER fulfillment on their own, e.g.
      *   `{ except: ['stale'] }` — see {@link Orders.take} for the full semantics.
+     * @returns what was taken and executed, one entry per order type that had work
      */
-    public fulfillOrders(options: { types: OrderType[]; except?: Array<BroadcastReason | ReconcileReason> }): { scanStarted: boolean; reconciled: boolean } {
-        const result = { scanStarted: false, reconciled: false };
-
-        if (options.types.includes('broadcast')) {
-            const reasons = this.orders.take('broadcast', options.except as BroadcastReason[]);
-            if (reasons) {
-                result.scanStarted = this.broadcast(reasons);
+    public fulfillOrders(options: { types: OrderType[]; except?: Array<BroadcastReason | ReconcileReason> }): TakenOrders[] {
+        const taken = this.orders.take(options);
+        for (const orders of taken) {
+            if (orders.type === 'broadcast') {
+                this.broadcast(orders.reasons);
+            } else {
+                this.reconcile(orders.reasons);
             }
         }
-        if (options.types.includes('reconcile')) {
-            const reasons = this.orders.take('reconcile', options.except as ReconcileReason[]);
-            if (reasons) {
-                this.reconcile(reasons);
-                result.reconciled = true;
-            }
-        }
-        return result;
+        return taken;
     }
     // #endregion
 
@@ -1691,7 +1686,7 @@ export class DeviceManager {
 export type DeviceState = 'offline' | 'unknown' | 'pending' | 'online';
 
 //order types live with the Orders class; re-exported here so consumers keep one import site
-export type { Order, OrderType, SubmittedOrder, BroadcastReason, ReconcileReason } from './Orders';
+export type { Order, OrderType, SubmittedOrder, TakenOrders, BroadcastReason, ReconcileReason } from './Orders';
 
 export type PasswordValidationResult = 'ok' | 'bad-password' | 'unreachable';
 

--- a/src/deviceDiscovery/DeviceManager.ts
+++ b/src/deviceDiscovery/DeviceManager.ts
@@ -172,9 +172,8 @@ export class DeviceManager {
     private networkChangeMonitor: NetworkChangeMonitor;
     private finder = new RokuFinder(this.globalStateManager, this.makeFinderLogger());
 
-    // Health check tracking. lastCheckedByIp is when we last attempted a check (success or
-    // failure) - ensureDeviceFresh callers state how old that knowledge may be (maxAgeMs)
-    private deviceCheckSequence = new Map<string, number>();
+    // When we last attempted a check per IP (success or failure) - callers state how old
+    // that knowledge may be (maxAgeMs)
     private lastCheckedByIp = new Map<string, number>();
     private readonly ON_WRITE_TRUST_MS = 5 * 60 * 1_000; // 5 minutes - refresh paths (sweeps, load-time state seeding) trust knowledge this old
     private static readonly HEALTH_CHECK_TIMEOUT_MS = 2_000; // 2 seconds
@@ -571,7 +570,8 @@ export class DeviceManager {
      * Ensure the device still exists on the network
      */
     public async healthCheckDevice(deviceKeyOrLookup: RokuDevice | string | { ip?: string; serialNumber?: string }): Promise<boolean> {
-        return (await this.getDeviceInfo(deviceKeyOrLookup)) !== undefined;
+        const isHealthy = (await this.getDeviceInfo(deviceKeyOrLookup)) !== undefined;
+        return isHealthy;
     }
 
     /**
@@ -639,7 +639,6 @@ export class DeviceManager {
 
         // Clear all timestamps and per-device state
         this.lastScanDate = null;
-        this.deviceCheckSequence.clear();
         this.lastCheckedByIp.clear();
 
         // Reset configured device states to unknown
@@ -955,9 +954,7 @@ export class DeviceManager {
         const maxAgeMs = options?.maxAgeMs ?? this.ON_WRITE_TRUST_MS;
         const syntheticDelay = options?.syntheticDelay ?? true;
 
-        // Extract serial from device if available (for proper state key management)
         const knownSerial = 'serialNumber' in device ? device.serialNumber : undefined;
-
         const currentStateObject = this.getDeviceState({ ip: device.ip, serialNumber: knownSerial });
 
         // How old is our knowledge of this device? In-session attempts win; otherwise fall
@@ -972,68 +969,13 @@ export class DeviceManager {
             return currentStateObject.state === 'online' || currentStateObject.state === 'pending';
         }
 
-        // Stamp the attempt up front so even instantly-failing checks count as knowledge
-        this.lastCheckedByIp.set(device.ip, Date.now());
-
-        // Increment and capture sequence number to handle concurrent refresh calls
-        // Use IP for sequence tracking (primary key)
-        const currentSeq = (this.deviceCheckSequence.get(device.ip) ?? 0) + 1;
-        this.deviceCheckSequence.set(device.ip, currentSeq);
-
-        // Set to pending before making network call
-        if (currentStateObject.state !== 'pending') {
-            this.setDeviceState({ ip: device.ip, serialNumber: knownSerial }, 'pending');
-            this.emitDevicesChanged();
+        // Stagger the request (sweeps fire many of these at once)
+        if (syntheticDelay) {
+            await this.randomDelay(400, 1_000);
         }
 
-        let deviceInfo: DeviceInfoRaw | undefined;
-        try {
-            deviceInfo = await this.getDeviceInfo(device.ip);
-
-            if (syntheticDelay) {
-                await this.randomDelay(400, 1_000);
-            }
-        } catch {
-            deviceInfo = undefined;
-        }
-
-        // Only apply result if this is still the latest request for this device
-        if (this.deviceCheckSequence.get(device.ip) !== currentSeq) {
-            // Stale response - a newer check was started, ignore this result
-            return !!deviceInfo;
-        }
-
-        if (deviceInfo) {
-            // Extract serial from response, fall back to known serial
-            const serial = deviceInfo['serial-number']?.toString?.() ?? knownSerial;
-
-            if (serial) {
-                // Add to last seen devices (successfully resolved with serial)
-                this.globalStateManager.addLastSeenDevice(this.networkId, serial);
-            }
-
-            // Update discoveredDevices array (handles mismatch detection internally)
-            if ('isDiscovered' in device && device.isDiscovered) {
-                this.setDiscoveredDevice(device.ip, serial);
-            }
-
-            // Mark any configured devices at this IP with different serials as offline
-            this.markMismatchedConfiguredDevicesOffline(device.ip, serial);
-
-            // Only emit if state actually changed
-            this.setDeviceState({ ip: device.ip, serialNumber: serial }, 'online');
-            this.emitDevicesChanged();
-            return true;
-        } else {
-            // Remove from discoveredDevices (ephemeral - offline devices are removed)
-            this.removeDiscoveredDevice(device.ip);
-
-            // Set state to offline on any remaining entries at this IP (configured devices persist)
-            this.setDeviceState({ ip: device.ip, serialNumber: knownSerial }, 'offline');
-
-            this.emitDevicesChanged();
-            return false;
-        }
+        // getDeviceInfo applies everything we learn (states, cache, devices-changed)
+        return (await this.getDeviceInfo({ ip: device.ip, serialNumber: knownSerial })) !== undefined;
     }
 
     /**
@@ -1108,18 +1050,9 @@ export class DeviceManager {
             return;
         }
 
-        // Health check all devices - if any discovered device is unhealthy, order a scan
-        let needsScan = false;
-        await Promise.all([...allIps].map(async (ip) => {
-            const isHealthy = await this.ensureDeviceFresh({ ip: ip }, { maxAgeMs: maxAgeMs });
-            if (!isHealthy && discoveredIpSet.has(ip)) {
-                needsScan = true;
-            }
-        }));
-
-        if (needsScan) {
-            this.submitUnhealthyDeviceBroadcast();
-        }
+        //failure consequences (offline states, removal, unhealthy-device rescan orders) are
+        //applied by getDeviceInfo as each check settles
+        await Promise.all([...allIps].map(ip => this.ensureDeviceFresh({ ip: ip }, { maxAgeMs: maxAgeMs })));
     }
 
     private inFlightDeviceInfo = new Map<string, Promise<DeviceInfoRaw | undefined>>();
@@ -1143,34 +1076,72 @@ export class DeviceManager {
             return Promise.resolve(undefined);
         }
 
+        //a serial hint for state keying when the fetch fails (the response carries its own on success)
+        const serialHint = typeof deviceKeyOrLookup === 'string'
+            ? this.getDevice(deviceKeyOrLookup)?.serialNumber
+            : deviceKeyOrLookup.serialNumber;
+
         const key = `${ip}:${port}`;
         let inFlight = this.inFlightDeviceInfo.get(key);
-        if (inFlight === undefined) {
-            inFlight = (async () => {
-                try {
-                    const info = await rokuDeploy.getDeviceInfo({
-                        host: ip,
-                        remotePort: port,
-                        timeout: DeviceManager.HEALTH_CHECK_TIMEOUT_MS
-                    });
-                    if (info['serial-number']) {
-                        this.globalStateManager.setCachedDevice(info['serial-number'], {
-                            serialNumber: info['serial-number'],
-                            deviceInfo: info,
-                            createdAt: Date.now()
-                        });
-                        this.globalStateManager.setSerialNumberForIp(this.networkId, ip, info['serial-number']);
-                    }
-                    return info;
-                } catch (e) {
-                    console.error(e);
-                    return undefined;
-                } finally {
-                    this.inFlightDeviceInfo.delete(key);
-                }
-            })();
-            this.inFlightDeviceInfo.set(key, inFlight);
+        if (inFlight !== undefined) {
+            return inFlight;
         }
+
+        //every attempt counts as knowledge for the freshness gate, even an instant failure
+        this.lastCheckedByIp.set(ip, Date.now());
+        const currentState = this.getDeviceState({ ip: ip, serialNumber: serialHint });
+        if (currentState.state !== 'pending') {
+            this.setDeviceState({ ip: ip, serialNumber: serialHint }, 'pending');
+            this.emitDevicesChanged();
+        }
+
+        inFlight = (async () => {
+            let info: DeviceInfoRaw | undefined;
+            try {
+                info = await rokuDeploy.getDeviceInfo({
+                    host: ip,
+                    remotePort: port,
+                    timeout: DeviceManager.HEALTH_CHECK_TIMEOUT_MS
+                });
+            } catch (e) {
+                console.error(e);
+                info = undefined;
+            } finally {
+                this.inFlightDeviceInfo.delete(key);
+            }
+
+            //apply what we learned - this runs exactly once per real network request, so
+            //results can never race or land out of order (concurrent callers share this promise)
+            if (info) {
+                const serial = info['serial-number']?.toString?.() ?? serialHint;
+                if (serial) {
+                    this.globalStateManager.setCachedDevice(serial, {
+                        serialNumber: serial,
+                        deviceInfo: info,
+                        createdAt: Date.now()
+                    });
+                    this.globalStateManager.setSerialNumberForIp(this.networkId, ip, serial);
+                    this.globalStateManager.addLastSeenDevice(this.networkId, serial);
+                }
+                //keep the discovered entry's serial current (handles mismatch detection internally)
+                if (this.discoveredDevices.some(d => d.ip === ip)) {
+                    this.setDiscoveredDevice(ip, serial);
+                }
+                this.markMismatchedConfiguredDevicesOffline(ip, serial);
+                this.setDeviceState({ ip: ip, serialNumber: serial }, 'online');
+            } else {
+                const wasDiscovered = this.discoveredDevices.some(d => d.ip === ip);
+                this.removeDiscoveredDevice(ip);
+                this.setDeviceState({ ip: ip, serialNumber: serialHint }, 'offline');
+                if (wasDiscovered) {
+                    //a discovered device went dark - order a rescan for the views to fulfill
+                    this.submitUnhealthyDeviceBroadcast();
+                }
+            }
+            this.emitDevicesChanged();
+            return info;
+        })();
+        this.inFlightDeviceInfo.set(key, inFlight);
         return inFlight;
     }
 

--- a/src/deviceDiscovery/DeviceManager.ts
+++ b/src/deviceDiscovery/DeviceManager.ts
@@ -6,6 +6,8 @@ import { rokuDeploy, DeviceUnreachableError, type DeviceInfoRaw } from 'roku-dep
 import { util as rokuDebugUtil } from 'roku-debug/dist/util';
 import type { GlobalStateManager } from '../GlobalStateManager';
 import { RokuFinder } from './RokuFinder';
+import { Orders } from './Orders';
+import type { Order, BroadcastReason, ReconcileReason } from './Orders';
 import { NetworkChangeMonitor, getNetworkHash } from './NetworkChangeMonitor';
 import { SystemSleepMonitor } from './SystemSleepMonitor';
 import { util } from '../util';
@@ -40,7 +42,7 @@ export class DeviceManager {
             if (event?.affectsConfiguration('brightscript.deviceDiscovery.enabled')) {
                 if (this.deviceDiscoveryEnabled) {
                     //order a broadcast + reconcile so the views discover/health-check once enabled
-                    this.submitOrder('startup');
+                    this.submitOrders([{ type: 'broadcast', reason: 'startup' }, { type: 'reconcile', reason: 'startup' }]);
                     this.systemSleepMonitor.start();
                     void this.activateMonitoring();
                 } else {
@@ -58,7 +60,7 @@ export class DeviceManager {
             //local) and order a health check for the views to fulfill when one is visible
             if (event?.affectsConfiguration('brightscript.devices')) {
                 this.loadConfiguredDevices().catch(() => { });
-                this.submitOrder('config-changed');
+                this.submitOrders([{ type: 'reconcile', reason: 'config-changed' }]);
             }
 
             //if the `defaultDevicePassword` setting was changed, refresh any device views that rely on it
@@ -87,7 +89,7 @@ export class DeviceManager {
     private setupMonitors() {
         this.systemSleepMonitor = new SystemSleepMonitor(() => {
             //order a broadcast + reconcile so the views rescan/health-check on wake
-            this.submitOrder('sleep');
+            this.submitOrders([{ type: 'broadcast', reason: 'sleep' }, { type: 'reconcile', reason: 'sleep' }]);
         });
         this.networkChangeMonitor = new NetworkChangeMonitor(() => {
             this.networkId = getNetworkHash();
@@ -109,7 +111,7 @@ export class DeviceManager {
             this.restartRokuFinder();
 
             //order a broadcast + reconcile so the views rescan/health-check on the new network
-            this.submitOrder('network');
+            this.submitOrders([{ type: 'broadcast', reason: 'network' }, { type: 'reconcile', reason: 'network' }]);
         });
     }
 
@@ -134,7 +136,7 @@ export class DeviceManager {
             //order a broadcast + reconcile for the views to fulfill when they open.
             //No proactive scan here even on a cold cache — per the design doc, no network
             //traffic happens until a view is actually visible to consume these orders.
-            this.submitOrder('startup');
+            this.submitOrders([{ type: 'broadcast', reason: 'startup' }, { type: 'reconcile', reason: 'startup' }]);
 
             this.activateMonitoring().catch((e) => {
                 console.error(e);
@@ -150,11 +152,11 @@ export class DeviceManager {
     private networkId: string;
 
     // Orders (see docs/device-discovery.md "Orders"): deferred work submitted by triggers and
-    // fulfilled by visible views. Pending orders are a set of reasons per order type — the work
-    // is idempotent (one scan satisfies every queued "please scan"), so reasons accumulate and
-    // fulfillment executes once with everything it takes. A reason can't queue twice.
-    private pendingBroadcastReasons = new Set<BroadcastReason>();
-    private pendingReconcileReasons = new Set<ReconcileReason>();
+    // fulfilled by visible views. Each submitted order is announced on the emitter so live
+    // views can fulfill immediately; hidden views drain the pending sets when they open.
+    private orders = new Orders((order, timestamp) => {
+        this.emitter.emit(`${order.type}-ordered`, { reason: order.reason, timestamp: timestamp });
+    });
     private broadcastStaleTimer: ReturnType<typeof setInterval> | undefined;
     private reconcileStaleTimer: ReturnType<typeof setInterval> | undefined;
 
@@ -594,36 +596,26 @@ export class DeviceManager {
 
     // #region Orders (docs/device-discovery.md "Orders" / "When are orders submitted?")
     /**
-     * Submit a broadcast (SSDP scan) order. Adds the reason to the pending set AND emits
-     * `broadcast-ordered` so a visible view can fulfill it live; a hidden view consumes the
-     * set when it opens. Reasons accumulate independently (e.g. `stale` and `sleep` can both
-     * be pending) but the same reason never queues twice.
+     * Submit orders. Each caller states exactly which order types its trigger implies — e.g.
+     * a refresh click submits both types, a config change submits only a reconcile (an edit
+     * can't add network devices), an unhealthy device submits only a broadcast (rescan, don't
+     * hammer every device). Every submitted order is announced
+     * (`broadcast-ordered`/`reconcile-ordered`) so a visible view fulfills it live; hidden
+     * views drain the pending sets when they open.
      */
-    private submitBroadcast(reason: BroadcastReason): void {
-        this.pendingBroadcastReasons.add(reason);
-        const order: BroadcastOrder = { reason: reason, timestamp: Date.now() };
-        this.emitter.emit('broadcast-ordered', order);
-    }
-
-    /**
-     * Submit a reconcile (health-check-all) order. Same set + event semantics as
-     * {@link submitBroadcast}.
-     */
-    private submitReconcile(reason: ReconcileReason): void {
-        this.pendingReconcileReasons.add(reason);
-        const order: ReconcileOrder = { reason: reason, timestamp: Date.now() };
-        this.emitter.emit('reconcile-ordered', order);
+    public submitOrders(orders: Order[]): void {
+        this.orders.submit(orders);
     }
 
     /**
      * The reasons of all pending broadcast orders that no view has fulfilled yet.
      */
     public getPendingBroadcastReasons(): BroadcastReason[] {
-        return [...this.pendingBroadcastReasons];
+        return this.orders.getPending('broadcast');
     }
 
     public getPendingReconcileReasons(): ReconcileReason[] {
-        return [...this.pendingReconcileReasons];
+        return this.orders.getPending('reconcile');
     }
 
     /**
@@ -633,24 +625,15 @@ export class DeviceManager {
      * decides the urgency internally (only-`stale` stays staleness-gated; any real trigger
      * scans now).
      *
-     * Consumption is atomic: when two visible views react to the same order event, the first
-     * caller fulfills it and later callers find the set empty and do nothing.
-     *
      * @param options.except - reasons that do not TRIGGER fulfillment on their own, e.g.
-     *   `{ except: ['stale'] }`. A blacklist on purpose: new reasons are acted on by default.
-     *   When a non-excepted reason does trigger execution, the whole set is cleared — the scan
-     *   satisfies every queued reason, excepted ones included.
+     *   `{ except: ['stale'] }` — see {@link Orders.take} for the full semantics.
      * @returns true if orders were consumed and a scan actually started
      */
     public fulfillPendingBroadcast(options?: { except?: BroadcastReason[] }): boolean {
-        const triggers = this.getPendingBroadcastReasons().filter(x => !options?.except?.includes(x));
-        if (triggers.length === 0) {
-            if (this.pendingBroadcastReasons.size > 0) {
-            }
+        const reasons = this.orders.take('broadcast', options?.except);
+        if (!reasons) {
             return false;
         }
-        const reasons = this.getPendingBroadcastReasons();
-        this.pendingBroadcastReasons.clear();
         return this.broadcast(reasons);
     }
 
@@ -661,14 +644,10 @@ export class DeviceManager {
      * `refresh-clicked` is among them — an explicit "I want fresh data now" from the user).
      */
     public fulfillPendingReconcile(options?: { except?: ReconcileReason[] }): boolean {
-        const triggers = this.getPendingReconcileReasons().filter(x => !options?.except?.includes(x));
-        if (triggers.length === 0) {
-            if (this.pendingReconcileReasons.size > 0) {
-            }
+        const reasons = this.orders.take('reconcile', options?.except);
+        if (!reasons) {
             return false;
         }
-        const reasons = this.getPendingReconcileReasons();
-        this.pendingReconcileReasons.clear();
         this.reconcile(reasons);
         return true;
     }
@@ -683,25 +662,6 @@ export class DeviceManager {
             scanStarted: this.fulfillPendingBroadcast({ except: options?.except as BroadcastReason[] }),
             reconciled: this.fulfillPendingReconcile({ except: options?.except as ReconcileReason[] })
         };
-    }
-
-    /**
-     * The single order-submission funnel (spec: When are orders submitted?). Callers name the
-     * trigger that happened; the reason determines which order types it implies. Most triggers
-     * imply both, with two exceptions: a config change can't introduce new devices on the
-     * network (reconcile only), and an unhealthy device warrants a rescan, not a health check
-     * of everything else (broadcast only).
-     *
-     * The `stale` timers don't go through here — they submit their single order type directly
-     * because they run on different cadences (broadcast every 30 minutes, reconcile every 5).
-     */
-    public submitOrder(reason: OrderReason): void {
-        if (reason !== 'config-changed') {
-            this.submitBroadcast(reason as BroadcastReason);
-        }
-        if (reason !== 'unhealthy-device') {
-            this.submitReconcile(reason as ReconcileReason);
-        }
     }
     // #endregion
 
@@ -814,7 +774,7 @@ export class DeviceManager {
 
         //this is a user-initiated action, so order a health check of the remaining (configured)
         //devices rather than running one directly — a visible view fulfills it immediately
-        this.submitReconcile('refresh-clicked');
+        this.submitOrders([{ type: 'reconcile', reason: 'refresh-clicked' }]);
         this.emitDevicesChanged();
     }
 
@@ -860,7 +820,7 @@ export class DeviceManager {
         if (this.timeSinceLastScan < this.UNHEALTHY_BROADCAST_MIN_INTERVAL_MS) {
             return;
         }
-        this.submitOrder('unhealthy-device');
+        this.submitOrders([{ type: 'broadcast', reason: 'unhealthy-device' }]);
     }
 
     /**
@@ -1611,10 +1571,10 @@ export class DeviceManager {
         //how to fulfill them — visible views deliberately ignore live `stale` orders)
         this.stopStaleTimers();
         this.broadcastStaleTimer = setInterval(() => {
-            this.submitBroadcast('stale');
+            this.submitOrders([{ type: 'broadcast', reason: 'stale' }]);
         }, this.STALE_SCAN_THRESHOLD_MS);
         this.reconcileStaleTimer = setInterval(() => {
-            this.submitReconcile('stale');
+            this.submitOrders([{ type: 'reconcile', reason: 'stale' }]);
         }, this.STALE_RECONCILE_INTERVAL_MS);
         //don't keep the process alive just for these timers
         this.broadcastStaleTimer?.unref?.();
@@ -1735,45 +1695,21 @@ export class DeviceManager {
 
 export type DeviceState = 'offline' | 'unknown' | 'pending' | 'online';
 
-/**
- * Why a broadcast (SSDP scan) was ordered. Views filter on this — e.g. a visible view ignores
- * `stale` (timer-driven) orders to avoid surprise scans. (See docs/device-discovery.md "Orders")
- */
-export type BroadcastReason =
-    | 'startup'
-    | 'network'
-    | 'sleep'
-    | 'refresh-clicked'
-    | 'unhealthy-device'
-    | 'stale';
+//order types live with the Orders class; re-exported here so consumers keep one import site
+export type { Order, OrderType, BroadcastReason, ReconcileReason } from './Orders';
 
 /**
- * Why a reconcile (health-check-all) was ordered.
- */
-export type ReconcileReason =
-    | 'startup'
-    | 'network'
-    | 'sleep'
-    | 'refresh-clicked'
-    | 'config-changed'
-    | 'stale';
-
-/**
- * Any trigger accepted by the single submission funnel, {@link DeviceManager.submitOrder}.
- */
-export type OrderReason = BroadcastReason | ReconcileReason;
-
-/**
- * A unit of deferred work: queued by triggers, fulfilled by visible views.
+ * Payload of the `broadcast-ordered` event: the submitted order's reason plus when it was
+ * submitted (ms epoch).
  */
 export interface BroadcastOrder {
     reason: BroadcastReason;
-    /**
-     * When the order was submitted (ms epoch)
-     */
     timestamp: number;
 }
 
+/**
+ * Payload of the `reconcile-ordered` event.
+ */
 export interface ReconcileOrder {
     reason: ReconcileReason;
     timestamp: number;

--- a/src/deviceDiscovery/DeviceManager.ts
+++ b/src/deviceDiscovery/DeviceManager.ts
@@ -143,7 +143,7 @@ export class DeviceManager {
             this.systemSleepMonitor.start();
 
             //order a broadcast + reconcile for the views to fulfill when they open.
-            //No proactive scan here even on a cold cache — per the design doc, no network
+            //No proactive scan here even on a cold cache - per the design doc, no network
             //traffic happens until a view is actually visible to consume these orders.
             this.submitOrders([
                 { type: 'broadcast', reason: 'startup' },
@@ -184,7 +184,7 @@ export class DeviceManager {
     private readonly OFFLINE_COOLDOWN_MS = 5_000; // 5 seconds - minimum time between resolve attempts for offline devices
     private static readonly HEALTH_CHECK_TIMEOUT_MS = 2_000; // 2 seconds
 
-    // Lazy hydration (background device-info refresh triggered by view reads — spec:
+    // Lazy hydration (background device-info refresh triggered by view reads - spec:
     // "Lazy hydration on read")
     private readonly HYDRATION_MAX_CACHE_AGE_MS = 8 * 60 * 60 * 1_000; // 8 hours - cache older than this re-hydrates on read
     private readonly HYDRATION_RETRY_COOLDOWN_MS = 5 * 60 * 1_000; // 5 minutes - minimum time between hydration attempts per IP
@@ -197,7 +197,7 @@ export class DeviceManager {
 
     // Scan state management. STALE_SCAN_THRESHOLD_MS is both the stale-only broadcast gate
     // ("don't scan if the last scan is younger than this") and the `stale` broadcast timer
-    // interval — one definition of "it's been a while".
+    // interval - one definition of "it's been a while".
     private readonly STALE_SCAN_THRESHOLD_MS = 30 * 60 * 1_000; // 30 minutes
     private readonly STALE_RECONCILE_INTERVAL_MS = 5 * 60 * 1_000; // 5 minutes - the spec's stale reconcile timer
     private readonly UNHEALTHY_BROADCAST_MIN_INTERVAL_MS = 60_000; // 1 minute - suppress unhealthy-device orders this soon after a scan
@@ -282,7 +282,7 @@ export class DeviceManager {
 
     /**
      * Does this device need a background device-info refresh? (spec: Lazy hydration on read)
-     * - state `unknown` — never confirmed this session (e.g. folded in from a scan response,
+     * - state `unknown` - never confirmed this session (e.g. folded in from a scan response,
      *   ssdp:alive, or the last-seen cache with info older than the 5-min freshness check).
      *   Cache age doesn't matter here: cached info can render the row, but only a resolve can
      *   confirm the device is actually there.
@@ -314,7 +314,7 @@ export class DeviceManager {
      * - while a fetch is in flight the device is `pending` and its IP is in `hydrationInFlight`
      * - success renews the cache timestamp, so neither hydration condition holds anymore
      * - failure removes discovered entries entirely; configured entries go `offline`
-     * - failure with a still-old cache would re-qualify — `hydrationLastAttempt` caps that at
+     * - failure with a still-old cache would re-qualify - `hydrationLastAttempt` caps that at
      *   one attempt per IP per {@link HYDRATION_RETRY_COOLDOWN_MS}
      */
     private queueHydration(devices: RokuDevice[]): void {
@@ -512,7 +512,7 @@ export class DeviceManager {
     /**
      * Find the highest-priority state-bearing entry across discovered then configured
      * sources. Within each source, try the IP first (skipping IP matches whose serial
-     * points to a different device — otherwise changing a configured device's serial to
+     * points to a different device - otherwise changing a configured device's serial to
      * a new value at an IP that already hosts an online discovered device would briefly
      * inherit that online state), then fall back to a serial-only match. Returns the
      * first entry that actually has a `state` set.
@@ -522,7 +522,7 @@ export class DeviceManager {
         if (lookup.ip) {
             match = entries.find(entry => {
                 const ipMatches = (entry as DiscoveredDeviceEntry).ip === lookup.ip || (entry as ConfiguredDeviceEntry).host === lookup.ip || (entry as ConfiguredDeviceEntry).resolvedIp === lookup.ip;
-                // when both sides carry a serial, they must agree — otherwise this IP belongs to a different device
+                // when both sides carry a serial, they must agree - otherwise this IP belongs to a different device
                 const serialMatches = !lookup.serialNumber || !entry.serialNumber || entry.serialNumber === lookup.serialNumber;
                 return ipMatches && serialMatches;
             });
@@ -607,11 +607,9 @@ export class DeviceManager {
 
     // #region Orders (docs/device-discovery.md "Orders" / "When are orders submitted?")
     /**
-     * Submit orders. Each caller states exactly which order types its trigger implies — e.g.
-     * a refresh click submits both types, a config change submits only a reconcile (an edit
-     * can't add network devices), an unhealthy device submits only a broadcast (rescan, don't
-     * hammer every device). Every submitted order is announced (`order-submitted`) so a
-     * visible view fulfills it live; hidden views drain the pending sets when they open.
+     * Submit orders. Each caller states which order types its trigger implies. Every
+     * submitted order is announced (`order-submitted`) so a visible view fulfills it live;
+     * hidden views drain the pending sets when they open.
      */
     public submitOrders(orders: Order[]): void {
         this.orders.submit(orders);
@@ -629,17 +627,12 @@ export class DeviceManager {
     }
 
     /**
-     * Atomically consume AND execute pending orders — the one-call fulfillment API for views.
-     * {@link Orders.take} drains what the options allow; each taken entry is executed once
-     * (all of its reasons are satisfied by that single execution): broadcast by one scan
-     * (staleness-gated when stale-only), reconcile by one health-check sweep (cache bypassed
-     * when `refresh-clicked` is among the reasons).
+     * Atomically consume AND execute pending orders. Each taken entry is executed once:
+     * broadcast by one scan, reconcile by one health-check sweep.
      *
-     * @param options.types - which order types to fulfill. Callers state their policy
-     *   explicitly — e.g. the tree view fulfills both, the quick pick's 7s fallback only wants
-     *   broadcasts, live handlers pass the submitted order's type.
-     * @param options.except - reasons that do not TRIGGER fulfillment on their own, e.g.
-     *   `{ except: ['stale'] }` — see {@link Orders.take} for the full semantics.
+     * @param options.types - which order types to fulfill
+     * @param options.except - reasons that do not trigger fulfillment on their own
+     *   (see {@link Orders.take})
      * @returns what was taken and executed, one entry per order type that had work
      */
     public fulfillOrders(options: { types: OrderType[]; except?: Array<BroadcastReason | ReconcileReason> }): TakenOrders[] {
@@ -656,30 +649,25 @@ export class DeviceManager {
     // #endregion
 
     /**
-     * Health-check a single device NOW: bypass its cache trust window, fetch fresh device
-     * info from the network, update the cache (so every view renders the freshest data), and
-     * report whether it responded. Fire-and-forget callers can ignore the result — the cache
-     * update is the point. Accepts anything {@link getDevice} can look up (encoded tree key,
-     * ip/serial lookup) or a device object; an unknown device is simply reported unhealthy.
+     * Ensure the device still exists on the network. Accepts anything {@link getDevice} can
+     * look up (encoded tree key, ip/serial lookup) or a device object; an unknown device is
+     * reported unhealthy.
      */
     public async healthCheckDevice(deviceKeyOrLookup: RokuDevice | string | { ip?: string; serialNumber?: string }): Promise<boolean> {
         return (await this.fetchFreshDevice(deviceKeyOrLookup)) !== undefined;
     }
 
     /**
-     * Fetch a single device's info fresh from the network NOW. Same work as
-     * {@link healthCheckDevice} (bypass cache trust window, fetch, update cache) — this variant
-     * returns the resulting device info for callers that need it (e.g. pre-launch host
-     * resolution). Returns undefined when the device is unknown or unreachable.
+     * Get a device's current info, fresh from the device itself. Returns undefined when the
+     * device is unknown or unreachable.
      */
     public async getDeviceInfo(deviceKeyOrLookup: RokuDevice | string | { ip?: string; serialNumber?: string }): Promise<Record<string, any> | undefined> {
         return (await this.fetchFreshDevice(deviceKeyOrLookup))?.deviceInfo;
     }
 
     /**
-     * The shared engine behind {@link healthCheckDevice} and {@link getDeviceInfo}: resolve
-     * the device with the cache trust window bypassed and no synthetic delay, then return the
-     * freshly-merged device (or undefined when unknown/unreachable).
+     * Resolve a device with the cache trust window bypassed and no synthetic delay, then
+     * return the freshly-merged device (or undefined when unknown/unreachable).
      */
     private async fetchFreshDevice(deviceKeyOrLookup: RokuDevice | string | { ip?: string; serialNumber?: string }): Promise<RokuDevice | undefined> {
         // If already a device object with deviceState, use it directly; otherwise look it up
@@ -700,7 +688,7 @@ export class DeviceManager {
         const isHealthy = await this.resolveDevice(device, { bypassCache: true, syntheticDelay: false });
         if (!isHealthy) {
             if (device.isDiscovered) {
-                // a discovered device went dark — order a rescan for the views to fulfill
+                // a discovered device went dark - order a rescan for the views to fulfill
                 this.submitUnhealthyDeviceBroadcast();
             }
             return undefined;
@@ -711,8 +699,8 @@ export class DeviceManager {
 
     /**
      * Broadcast an SSDP M-SEARCH to discover devices on the network. Does NOT health-check
-     * existing devices — that's {@link reconcile}. The reasons decide the urgency: any real
-     * trigger scans now, while a `stale` timer-tick is only a "things might be old" hint — a
+     * existing devices - that's {@link reconcile}. The reasons decide the urgency: any real
+     * trigger scans now, while a `stale` timer-tick is only a "things might be old" hint - a
      * stale-only fulfillment scans only when discovery is enabled AND the last scan is older
      * than STALE_SCAN_THRESHOLD_MS. Reachable only through order fulfillment.
      * @returns true if a scan was started
@@ -731,14 +719,16 @@ export class DeviceManager {
 
     /**
      * Health-check every known device (configured + discovered), marking them online/offline.
-     * Does NOT scan for new devices — that's {@link broadcast}. The reasons decide the urgency:
-     * only an explicit user click bypasses each device's cache trust window — a bypassing
+     * Does NOT scan for new devices - that's {@link broadcast}. The reasons decide the urgency:
+     * only an explicit user click bypasses each device's cache trust window - a bypassing
      * reconcile is one HTTP request per known device, so only "I want fresh data NOW" earns
      * that. Reachable only through order fulfillment.
      */
     private reconcile(reasons: ReconcileReason[]): void {
         const bypassDeviceCache = reasons.includes('refresh-clicked');
-        this.healthCheckAllDevices(bypassDeviceCache).catch(() => { });
+        this.healthCheckAllDevices(bypassDeviceCache).catch((e) => {
+            console.error('[DeviceManager] reconcile health check failed', e);
+        });
     }
 
     /**
@@ -763,7 +753,7 @@ export class DeviceManager {
         this.globalStateManager.setLastSeenDevices(this.networkId, []);
 
         //this is a user-initiated action, so order a health check of the remaining (configured)
-        //devices rather than running one directly — a visible view fulfills it immediately
+        //devices rather than running one directly - a visible view fulfills it immediately
         this.submitOrders([{ type: 'reconcile', reason: 'refresh-clicked' }]);
         this.emitDevicesChanged();
     }
@@ -771,7 +761,7 @@ export class DeviceManager {
     public clearAllCache() {
 
         // End any in-progress scan (emits scan-ended) so late responses don't instantly
-        // repopulate the just-cleared state — but keep the passive SSDP listener running,
+        // repopulate the just-cleared state - but keep the passive SSDP listener running,
         // otherwise the device list stays empty until the next explicit scan
         this.finder.stopScan();
 
@@ -800,7 +790,7 @@ export class DeviceManager {
     /**
      * Submit an `unhealthy-device` broadcast order (a discovered device failed a health check,
      * so the network picture may have changed). Rate-limited: suppressed when discovery is
-     * disabled or when a scan ran within the last minute — the terminating guard for the
+     * disabled or when a scan ran within the last minute - the terminating guard for the
      * potential scan → health-check → fail → scan feedback loop.
      */
     private submitUnhealthyDeviceBroadcast(): void {
@@ -817,9 +807,9 @@ export class DeviceManager {
      * Validate a developer password against the device at `host`.
      *
      * Returns:
-     * - `'ok'` — credentials accepted
-     * - `'bad-password'` — device reachable, credentials rejected
-     * - `'unreachable'` — device could not be contacted (transient; don't treat as wrong password)
+     * - `'ok'` - credentials accepted
+     * - `'bad-password'` - device reachable, credentials rejected
+     * - `'unreachable'` - device could not be contacted (transient; don't treat as wrong password)
      */
     public async validateDevicePassword(host: string, password: string): Promise<PasswordValidationResult> {
         try {
@@ -829,7 +819,7 @@ export class DeviceManager {
             if (e instanceof DeviceUnreachableError) {
                 return 'unreachable';
             }
-            // Unexpected response code or any other failure — treat as unreachable so the caller retries/prompts rather than discarding credentials.
+            // Unexpected response code or any other failure - treat as unreachable so the caller retries/prompts rather than discarding credentials.
             return 'unreachable';
         }
     }
@@ -1091,7 +1081,7 @@ export class DeviceManager {
     }
 
     private async resolveDevice(device: RokuDevice | { ip: string; serialNumber?: string }, options?: { bypassCache?: boolean; syntheticDelay?: boolean }): Promise<boolean> {
-        // bypassCache: skip the cache trust window AND the offline cooldown — "I want a real
+        // bypassCache: skip the cache trust window AND the offline cooldown - "I want a real
         // answer from the network NOW" (user engagement, refresh-clicked reconciles).
         const bypassCache = options?.bypassCache ?? false;
         const syntheticDelay = options?.syntheticDelay ?? true;
@@ -1284,7 +1274,7 @@ export class DeviceManager {
 
     /**
      * In-flight device-info requests by `ip:port`. This is the design doc's "de-dupe rule":
-     * within a single refresh flow a device only gets device-info'd once — concurrent callers
+     * within a single refresh flow a device only gets device-info'd once - concurrent callers
      * (e.g. the broadcast response and the reconcile racing on the same device) share one HTTP
      * request instead of each issuing their own. First one in wins; everyone else joins it.
      */
@@ -1292,19 +1282,17 @@ export class DeviceManager {
 
     /**
      * Fetch device info from the network, sharing any request already in flight for the same
-     * ip:port (see the de-dupe rule in docs/device-discovery.md). Never rejects — failures
+     * ip:port (see the de-dupe rule in docs/device-discovery.md). Never rejects - failures
      * return undefined. Success caches the result in globalStateManager for future lookups.
      */
     private fetchDeviceInfo(ip: string, port: number): Promise<DeviceInfoRaw | undefined> {
         const key = `${ip}:${port}`;
         let inFlight = this.inFlightDeviceInfo.get(key);
         if (inFlight === undefined) {
-            //safe to share: fetchDeviceInfoInner never rejects (it catches and returns undefined)
             inFlight = this.fetchDeviceInfoInner(ip, port).finally(() => {
                 this.inFlightDeviceInfo.delete(key);
             });
             this.inFlightDeviceInfo.set(key, inFlight);
-        } else {
         }
         return inFlight;
     }
@@ -1523,7 +1511,7 @@ export class DeviceManager {
 
     /**
      * Handle device-online event from RokuFinder. Shows a notification if enabled.
-     * Does not eagerly device-info the device — lazy hydration on read handles that
+     * Does not eagerly device-info the device - lazy hydration on read handles that
      * once a view actually asks for the device list (spec: Passive SSDP announcements).
      */
     private handleDeviceOnline(ip: string, serialNumber?: string): void {
@@ -1558,7 +1546,7 @@ export class DeviceManager {
 
         //periodically submit `stale` broadcast/reconcile orders so long-lived sessions
         //eventually refresh (the spec's "it's been a while" timers; views decide whether and
-        //how to fulfill them — visible views deliberately ignore live `stale` orders)
+        //how to fulfill them - visible views deliberately ignore live `stale` orders)
         this.stopStaleTimers();
         this.broadcastStaleTimer = setInterval(() => {
             this.submitOrders([{ type: 'broadcast', reason: 'stale' }]);
@@ -1600,7 +1588,7 @@ export class DeviceManager {
         this.finder.on('found', (ip: string, options?: { serialNumber?: string }) => {
             this.setDiscoveredDevice(ip, options?.serialNumber);
             //no eager resolve here: this emit makes any visible view re-read the list, and a
-            //responder whose cache missed the 5-min freshness check lands in `unknown` — which
+            //responder whose cache missed the 5-min freshness check lands in `unknown` - which
             //lazy hydration on read always resolves (spec: "hydrate it immediately", routed
             //through the views-as-the-gate read path)
             this.emitDevicesChanged();
@@ -1622,7 +1610,7 @@ export class DeviceManager {
 
         this.finder.on('scan-ended', () => {
             this.emitter.emit('scan-ended');
-            //devices that didn't respond to the scan are NOT eagerly health-checked here —
+            //devices that didn't respond to the scan are NOT eagerly health-checked here -
             //lazy hydration on read covers them the next time a view asks for the list
         });
     }
@@ -1658,7 +1646,7 @@ export class DeviceManager {
     private async startRokuFinder() {
         await this.finder.start();
         const ts = new Date().toLocaleTimeString();
-        this.makeFinderLogger()(`[${ts}] RokuFinder started — passive ssdp:alive monitoring active`);
+        this.makeFinderLogger()(`[${ts}] RokuFinder started - passive ssdp:alive monitoring active`);
     }
 
     private stopRokuFinder() {
@@ -1732,7 +1720,7 @@ interface ConfiguredDeviceEntry extends ConfiguredDevice {
     state?: DeviceState;
     /**
      * Previous state, updated by setDeviceState before each transition. Undefined when no
-     * state has been recorded yet — readers should treat that as 'unknown'.
+     * state has been recorded yet - readers should treat that as 'unknown'.
      */
     lastState?: DeviceState;
     /**
@@ -1760,7 +1748,7 @@ interface DiscoveredDeviceEntry {
     state?: DeviceState;
     /**
      * Previous state, updated by setDeviceState before each transition. Undefined when no
-     * state has been recorded yet — readers should treat that as 'unknown'.
+     * state has been recorded yet - readers should treat that as 'unknown'.
      */
     lastState?: DeviceState;
     /**

--- a/src/deviceDiscovery/DeviceManager.ts
+++ b/src/deviceDiscovery/DeviceManager.ts
@@ -254,8 +254,7 @@ export class DeviceManager {
      */
     public async validateAndAddDevice(ip: string): Promise<RokuDevice | undefined> {
         this.setDiscoveredDevice(ip, undefined);
-        await this.ensureDeviceFresh({ ip: ip }, { syntheticDelay: false });
-        return this.getDevice({ ip: ip });
+        return this.ensureDeviceFresh({ ip: ip }, { syntheticDelay: false });
     }
 
     /**
@@ -950,7 +949,7 @@ export class DeviceManager {
      * attempt) is younger than this, return the current state without touching the network.
      * A device in state `unknown` has no trustable knowledge, so it always fetches.
      */
-    private async ensureDeviceFresh(device: RokuDevice | { ip: string; serialNumber?: string }, options?: { maxAgeMs?: number; syntheticDelay?: boolean }): Promise<boolean> {
+    private async ensureDeviceFresh(device: RokuDevice | { ip: string; serialNumber?: string }, options?: { maxAgeMs?: number; syntheticDelay?: boolean }): Promise<RokuDevice | undefined> {
         const maxAgeMs = options?.maxAgeMs ?? this.ON_WRITE_TRUST_MS;
         const syntheticDelay = options?.syntheticDelay ?? true;
 
@@ -966,7 +965,8 @@ export class DeviceManager {
 
         // Fresh enough for this caller (and not `unknown`): answer from what we already know
         if (currentStateObject.state !== 'unknown' && Date.now() - lastChecked < maxAgeMs) {
-            return currentStateObject.state === 'online' || currentStateObject.state === 'pending';
+            const isHealthy = currentStateObject.state === 'online' || currentStateObject.state === 'pending';
+            return isHealthy ? this.getDeviceWithoutRefresh(device.ip) : undefined;
         }
 
         // Stagger the request (sweeps fire many of these at once)
@@ -975,7 +975,17 @@ export class DeviceManager {
         }
 
         // getDeviceInfo applies everything we learn (states, cache, devices-changed)
-        return (await this.getDeviceInfo({ ip: device.ip, serialNumber: knownSerial })) !== undefined;
+        const info = await this.getDeviceInfo({ ip: device.ip, serialNumber: knownSerial });
+        return info ? this.getDeviceWithoutRefresh(device.ip) : undefined;
+    }
+
+    /**
+     * Read a device without kicking the background refresh (getDevice would re-enter
+     * ensureDeviceFresh, which calls this)
+     */
+    private getDeviceWithoutRefresh(ip: string): RokuDevice | undefined {
+        const { configured, discovered } = this.findDeviceEntries({ ip: ip });
+        return this.buildMergedDevice(configured, discovered);
     }
 
     /**

--- a/src/deviceDiscovery/DeviceManager.ts
+++ b/src/deviceDiscovery/DeviceManager.ts
@@ -269,7 +269,10 @@ export class DeviceManager {
 
     /**
      * Does this device need a background device-info refresh? (spec: Lazy hydration on read)
-     * - never resolved (`unknown` with no cached deviceInfo), or
+     * - state `unknown` — never confirmed this session (e.g. folded in from a scan response,
+     *   ssdp:alive, or the last-seen cache with info older than the 5-min freshness check).
+     *   Cache age doesn't matter here: cached info can render the row, but only a resolve can
+     *   confirm the device is actually there.
      * - cached info older than {@link HYDRATION_MAX_CACHE_AGE_MS} (regardless of state)
      */
     private needsHydration(device: RokuDevice): boolean {
@@ -278,9 +281,12 @@ export class DeviceManager {
         if (device.deviceState === 'pending') {
             return false;
         }
+        if (device.deviceState === 'unknown') {
+            return true;
+        }
         const cached = device.serialNumber ? this.globalStateManager.getCachedDevice(device.serialNumber) : undefined;
         if (!cached) {
-            return device.deviceState === 'unknown';
+            return false;
         }
         return Date.now() - cached.createdAt > this.HYDRATION_MAX_CACHE_AGE_MS;
     }
@@ -639,6 +645,8 @@ export class DeviceManager {
     public fulfillPendingBroadcast(options?: { except?: BroadcastReason[] }): boolean {
         const triggers = this.getPendingBroadcastReasons().filter(x => !options?.except?.includes(x));
         if (triggers.length === 0) {
+            if (this.pendingBroadcastReasons.size > 0) {
+            }
             return false;
         }
         const reasons = this.getPendingBroadcastReasons();
@@ -655,6 +663,8 @@ export class DeviceManager {
     public fulfillPendingReconcile(options?: { except?: ReconcileReason[] }): boolean {
         const triggers = this.getPendingReconcileReasons().filter(x => !options?.except?.includes(x));
         if (triggers.length === 0) {
+            if (this.pendingReconcileReasons.size > 0) {
+            }
             return false;
         }
         const reasons = this.getPendingReconcileReasons();
@@ -788,13 +798,17 @@ export class DeviceManager {
     }
 
     public clearAllCache() {
-        // Stop any in-progress scan (finder.stop() emits scan-ended if scanning)
-        this.finder.stop();
+
+        // End any in-progress scan (emits scan-ended) so late responses don't instantly
+        // repopulate the just-cleared state — but keep the passive SSDP listener running,
+        // otherwise the device list stays empty until the next explicit scan
+        this.finder.stopScan();
 
         // Clear persisted global state
         this.globalStateManager.clearLastSeenDevices();
         this.globalStateManager.clearDeviceCache();
         this.globalStateManager.clearSerialNumberByIpForNetwork();
+
 
         // Clear all timestamps and per-device state
         this.lastScanDate = null;
@@ -1319,6 +1333,7 @@ export class DeviceManager {
                 this.inFlightDeviceInfo.delete(key);
             });
             this.inFlightDeviceInfo.set(key, inFlight);
+        } else {
         }
         return inFlight;
     }
@@ -1613,6 +1628,10 @@ export class DeviceManager {
         this.finder.removeAllListeners();
         this.finder.on('found', (ip: string, options?: { serialNumber?: string }) => {
             this.setDiscoveredDevice(ip, options?.serialNumber);
+            //no eager resolve here: this emit makes any visible view re-read the list, and a
+            //responder whose cache missed the 5-min freshness check lands in `unknown` — which
+            //lazy hydration on read always resolves (spec: "hydrate it immediately", routed
+            //through the views-as-the-gate read path)
             this.emitDevicesChanged();
         });
 

--- a/src/deviceDiscovery/DeviceManager.ts
+++ b/src/deviceDiscovery/DeviceManager.ts
@@ -654,47 +654,7 @@ export class DeviceManager {
      * reported unhealthy.
      */
     public async healthCheckDevice(deviceKeyOrLookup: RokuDevice | string | { ip?: string; serialNumber?: string }): Promise<boolean> {
-        return (await this.fetchFreshDevice(deviceKeyOrLookup)) !== undefined;
-    }
-
-    /**
-     * Get a device's current info, fresh from the device itself. Returns undefined when the
-     * device is unknown or unreachable.
-     */
-    public async getDeviceInfo(deviceKeyOrLookup: RokuDevice | string | { ip?: string; serialNumber?: string }): Promise<Record<string, any> | undefined> {
-        return (await this.fetchFreshDevice(deviceKeyOrLookup))?.deviceInfo;
-    }
-
-    /**
-     * Resolve a device with the cache trust window bypassed and no synthetic delay, then
-     * return the freshly-merged device (or undefined when unknown/unreachable).
-     */
-    private async fetchFreshDevice(deviceKeyOrLookup: RokuDevice | string | { ip?: string; serialNumber?: string }): Promise<RokuDevice | undefined> {
-        // If already a device object with deviceState, use it directly; otherwise look it up
-        let device: RokuDevice | undefined;
-        if (typeof deviceKeyOrLookup === 'string') {
-            device = this.getDevice(deviceKeyOrLookup);
-        } else if ('deviceState' in deviceKeyOrLookup) {
-            device = deviceKeyOrLookup;
-        } else {
-            device = this.getDevice(deviceKeyOrLookup);
-        }
-
-        if (!device) {
-            return undefined;
-        }
-
-        // The caller wants a real answer now: bypass the cache trust window, no synthetic delay
-        const isHealthy = await this.resolveDevice(device, { bypassCache: true, syntheticDelay: false });
-        if (!isHealthy) {
-            if (device.isDiscovered) {
-                // a discovered device went dark - order a rescan for the views to fulfill
-                this.submitUnhealthyDeviceBroadcast();
-            }
-            return undefined;
-        }
-        // re-read so the returned device carries the just-fetched info
-        return this.getDevice({ ip: device.ip, serialNumber: device.serialNumber });
+        return (await this.getDeviceInfo(deviceKeyOrLookup)) !== undefined;
     }
 
     /**
@@ -1131,7 +1091,7 @@ export class DeviceManager {
 
             // Fetch fresh data from network
             try {
-                deviceInfo = await this.fetchDeviceInfo(device.ip, 8060);
+                deviceInfo = await this.getDeviceInfo(device.ip);
 
                 if (syntheticDelay) {
                     await this.randomDelay(400, 1_000);
@@ -1281,46 +1241,61 @@ export class DeviceManager {
     private inFlightDeviceInfo = new Map<string, Promise<DeviceInfoRaw | undefined>>();
 
     /**
-     * Fetch device info from the network, sharing any request already in flight for the same
-     * ip:port (see the de-dupe rule in docs/device-discovery.md). Never rejects - failures
-     * return undefined. Success caches the result in globalStateManager for future lookups.
+     * Get device info directly from the device. Never returns cached data - this always hits
+     * the network. Concurrent callers for the same ip:port piggyback on the in-flight request
+     * and get the same answer (the de-dupe rule in docs/device-discovery.md). Never rejects -
+     * failures return undefined.
+     *
+     * This does NOT update the device list or device states - those are maintained by the
+     * reconcile sweeps and lazy hydration. Use {@link getDevice} to read what's already known.
+     *
+     * Accepts an ip, an encoded tree key ("s:{serial}" / "i:{ip}"), an ip/serial lookup, or a
+     * device object. Returns undefined when the input can't be resolved to an ip.
      */
-    private fetchDeviceInfo(ip: string, port: number): Promise<DeviceInfoRaw | undefined> {
+    public getDeviceInfo(deviceKeyOrLookup: RokuDevice | string | { ip?: string; serialNumber?: string }, port = 8060): Promise<DeviceInfoRaw | undefined> {
+        //normalize the input down to an ip
+        let ip: string | undefined;
+        if (typeof deviceKeyOrLookup === 'string') {
+            //encoded tree keys resolve through the device list; any other string is already an ip
+            ip = deviceKeyOrLookup.startsWith('s:') || deviceKeyOrLookup.startsWith('i:')
+                ? this.getDevice(deviceKeyOrLookup)?.ip
+                : deviceKeyOrLookup;
+        } else {
+            ip = deviceKeyOrLookup.ip ?? this.getDevice(deviceKeyOrLookup)?.ip;
+        }
+        if (!ip) {
+            return Promise.resolve(undefined);
+        }
+
         const key = `${ip}:${port}`;
         let inFlight = this.inFlightDeviceInfo.get(key);
         if (inFlight === undefined) {
-            inFlight = this.fetchDeviceInfoInner(ip, port).finally(() => {
-                this.inFlightDeviceInfo.delete(key);
-            });
+            inFlight = (async () => {
+                try {
+                    const info = await rokuDeploy.getDeviceInfo({
+                        host: ip,
+                        remotePort: port,
+                        timeout: DeviceManager.HEALTH_CHECK_TIMEOUT_MS
+                    });
+                    if (info['serial-number']) {
+                        this.globalStateManager.setCachedDevice(info['serial-number'], {
+                            serialNumber: info['serial-number'],
+                            deviceInfo: info,
+                            createdAt: Date.now()
+                        });
+                        this.globalStateManager.setSerialNumberForIp(this.networkId, ip, info['serial-number']);
+                    }
+                    return info;
+                } catch (e) {
+                    console.error(e);
+                    return undefined;
+                } finally {
+                    this.inFlightDeviceInfo.delete(key);
+                }
+            })();
             this.inFlightDeviceInfo.set(key, inFlight);
         }
         return inFlight;
-    }
-
-    /**
-     * Fetch device info from the network. Always makes a network request.
-     */
-    private async fetchDeviceInfoInner(ip: string, port: number): Promise<DeviceInfoRaw> {
-        try {
-            const info = await rokuDeploy.getDeviceInfo({
-                host: ip,
-                remotePort: port,
-                timeout: DeviceManager.HEALTH_CHECK_TIMEOUT_MS
-            });
-            if (info['serial-number']) {
-                this.globalStateManager.setCachedDevice(info['serial-number'], {
-                    serialNumber: info['serial-number'],
-                    deviceInfo: info,
-                    createdAt: Date.now()
-                });
-                this.globalStateManager.setSerialNumberForIp(this.networkId, ip, info['serial-number']);
-            }
-
-            return info;
-        } catch (e) {
-            console.error(e);
-            return undefined;
-        }
     }
 
     /**

--- a/src/deviceDiscovery/DeviceManager.ts
+++ b/src/deviceDiscovery/DeviceManager.ts
@@ -168,7 +168,7 @@ export class DeviceManager {
     private readonly DEVICE_INFO_CACHE_MS = 5 * 60 * 1_000; // 5 minutes - cache duration for fetchDeviceInfo
     private readonly FRESH_CACHE_THRESHOLD_MS = 5 * 60 * 1_000; // 5 minutes - cache fresher than this = online on load
     private readonly OFFLINE_COOLDOWN_MS = 5_000; // 5 seconds - minimum time between resolve attempts for offline devices
-    public static readonly HEALTH_CHECK_TIMEOUT_MS = 2_000; // 2 seconds
+    private static readonly HEALTH_CHECK_TIMEOUT_MS = 2_000; // 2 seconds
 
     // Lazy hydration (background device-info refresh triggered by view reads — spec:
     // "Lazy hydration on read")
@@ -181,7 +181,7 @@ export class DeviceManager {
     private readonly DEVICES_CHANGED_DEBOUNCE_MS = 50;
     private deviceOnlineNotifiers = new Map<string, ReturnType<typeof debounce>>();
 
-    // Scan state management. STALE_SCAN_THRESHOLD_MS is both the non-forced broadcast gate
+    // Scan state management. STALE_SCAN_THRESHOLD_MS is both the stale-only broadcast gate
     // ("don't scan if the last scan is younger than this") and the `stale` broadcast timer
     // interval — one definition of "it's been a while".
     private readonly STALE_SCAN_THRESHOLD_MS = 30 * 60 * 1_000; // 30 minutes
@@ -477,7 +477,7 @@ export class DeviceManager {
      * @param lookup - Device lookup by serial and/or IP
      * @returns The device state, defaulting to 'unknown' if not found
      */
-    public getDeviceState(lookup: { serialNumber?: string; ip?: string }): DeviceStateEntry {
+    private getDeviceState(lookup: { serialNumber?: string; ip?: string }): DeviceStateEntry {
         let match = this.findStateEntry(this.discoveredDevices, lookup);
         if (match) {
             return { state: match.state, lastUpdated: match.stateLastUpdated ?? Date.now() };
@@ -527,7 +527,7 @@ export class DeviceManager {
      * @param lookup - Device lookup by IP (and optionally serial for cache lookup)
      * @param state - Explicit state to set, or undefined for intelligent default
      */
-    public setDeviceState(lookup: { serialNumber?: string; ip?: string }, state?: DeviceState): void {
+    private setDeviceState(lookup: { serialNumber?: string; ip?: string }, state?: DeviceState): void {
         const now = Date.now();
         let resolvedState: DeviceState;
 
@@ -705,7 +705,27 @@ export class DeviceManager {
      * simply reported unhealthy.
      */
     public async deviceEngaged(deviceKeyOrLookup: RokuDevice | string | { ip?: string; serialNumber?: string }): Promise<boolean> {
-        return this.healthCheckDevice(deviceKeyOrLookup, true, false);
+        // If already a device object with deviceState, use it directly; otherwise look it up
+        let device: RokuDevice | undefined;
+        if (typeof deviceKeyOrLookup === 'string') {
+            device = this.getDevice(deviceKeyOrLookup);
+        } else if ('deviceState' in deviceKeyOrLookup) {
+            device = deviceKeyOrLookup;
+        } else {
+            device = this.getDevice(deviceKeyOrLookup);
+        }
+
+        if (!device) {
+            return false;
+        }
+
+        // Engagement wants a real answer now: bypass the cache trust window, no synthetic delay
+        const isHealthy = await this.resolveDevice(device, false, true);
+        if (!isHealthy && device.isDiscovered) {
+            // a discovered device went dark — order a rescan for the views to fulfill
+            this.submitUnhealthyDeviceBroadcast();
+        }
+        return isHealthy;
     }
 
     /**
@@ -737,7 +757,7 @@ export class DeviceManager {
      */
     private reconcile(reasons: ReconcileReason[]): void {
         const bypassDeviceCache = reasons.includes('refresh-clicked');
-        this.healthCheckAllDevices(bypassDeviceCache, true).catch(() => { });
+        this.healthCheckAllDevices(bypassDeviceCache).catch(() => { });
     }
 
     /**
@@ -790,30 +810,6 @@ export class DeviceManager {
 
         // Clear discovered devices (state goes with them)
         this.clearCurrentDeviceList();
-    }
-
-    private async healthCheckDevice(deviceKeyOrLookup: RokuDevice | string | { ip?: string; serialNumber?: string }, force = false, doSyntheticDelay = true): Promise<boolean> {
-        // If already a device object with deviceState, use it directly; otherwise look it up
-        let device: RokuDevice | undefined;
-        if (typeof deviceKeyOrLookup === 'string') {
-            device = this.getDevice(deviceKeyOrLookup);
-        } else if ('deviceState' in deviceKeyOrLookup) {
-            device = deviceKeyOrLookup;
-        } else {
-            device = this.getDevice(deviceKeyOrLookup);
-        }
-
-        if (!device) {
-            return false;
-        }
-
-        // Cooldown is handled by fetchDeviceInfo cache; force bypasses it
-        const isHealthy = await this.resolveDevice(device, doSyntheticDelay, force);
-        if (!isHealthy && device.isDiscovered) {
-            // a discovered device went dark — order a rescan for the views to fulfill
-            this.submitUnhealthyDeviceBroadcast();
-        }
-        return isHealthy;
     }
 
     /**
@@ -1264,7 +1260,7 @@ export class DeviceManager {
         }
     }
 
-    private async healthCheckAllDevices(force = false, doSyntheticDelay = true): Promise<void> {
+    private async healthCheckAllDevices(force = false): Promise<void> {
         // Collect all unique IPs from both sources (same serial at different IPs = different entries to check)
         const discoveredIpSet = new Set(this.discoveredDevices.map(entry => entry.ip));
         const allIps = new Set([
@@ -1285,7 +1281,7 @@ export class DeviceManager {
         // Health check all devices - if any discovered device is unhealthy, order a scan
         let needsScan = false;
         await Promise.all([...allIps].map(async (ip) => {
-            const isHealthy = await this.resolveDevice({ ip: ip }, doSyntheticDelay, force);
+            const isHealthy = await this.resolveDevice({ ip: ip }, true, force);
             if (!isHealthy && discoveredIpSet.has(ip)) {
                 needsScan = true;
             }

--- a/src/deviceDiscovery/DeviceManager.ts
+++ b/src/deviceDiscovery/DeviceManager.ts
@@ -154,10 +154,11 @@ export class DeviceManager {
     private networkId: string;
 
     // Orders (see docs/device-discovery.md "Orders"): deferred work submitted by triggers and
-    // fulfilled by visible views. One pending slot per order type — a newer order replaces the
-    // slot, except a `stale` order never downgrades a pending real trigger.
-    private pendingBroadcast: BroadcastOrder | null = null;
-    private pendingReconcile: ReconcileOrder | null = null;
+    // fulfilled by visible views. Pending orders are a set of reasons per order type — the work
+    // is idempotent (one scan satisfies every queued "please scan"), so reasons accumulate and
+    // fulfillment executes once with everything it takes. A reason can't queue twice.
+    private pendingBroadcastReasons = new Set<BroadcastReason>();
+    private pendingReconcileReasons = new Set<ReconcileReason>();
     private broadcastStaleTimer: ReturnType<typeof setInterval> | undefined;
     private reconcileStaleTimer: ReturnType<typeof setInterval> | undefined;
 
@@ -591,90 +592,93 @@ export class DeviceManager {
 
     // #region Orders (docs/device-discovery.md "Orders" / "When are orders submitted?")
     /**
-     * Submit a broadcast (SSDP scan) order. Fills the pending slot AND emits `broadcast-ordered`
-     * so a visible view can fulfill it live; a hidden view consumes the slot when it opens.
-     * A `stale` submission never overwrites a pending real trigger.
+     * Submit a broadcast (SSDP scan) order. Adds the reason to the pending set AND emits
+     * `broadcast-ordered` so a visible view can fulfill it live; a hidden view consumes the
+     * set when it opens. Reasons accumulate independently (e.g. `stale` and `sleep` can both
+     * be pending) but the same reason never queues twice.
      */
     public submitBroadcast(reason: BroadcastReason): void {
+        this.pendingBroadcastReasons.add(reason);
         const order: BroadcastOrder = { reason: reason, timestamp: Date.now() };
-        if (!(this.pendingBroadcast && this.pendingBroadcast.reason !== 'stale' && reason === 'stale')) {
-            this.pendingBroadcast = order;
-        }
         this.emitter.emit('broadcast-ordered', order);
     }
 
     /**
-     * Submit a reconcile (health-check-all) order. Same slot + event semantics as
+     * Submit a reconcile (health-check-all) order. Same set + event semantics as
      * {@link submitBroadcast}.
      */
     public submitReconcile(reason: ReconcileReason): void {
+        this.pendingReconcileReasons.add(reason);
         const order: ReconcileOrder = { reason: reason, timestamp: Date.now() };
-        if (!(this.pendingReconcile && this.pendingReconcile.reason !== 'stale' && reason === 'stale')) {
-            this.pendingReconcile = order;
-        }
         this.emitter.emit('reconcile-ordered', order);
     }
 
     /**
-     * The pending broadcast order, if a trigger queued one that no view has fulfilled yet.
+     * The reasons of all pending broadcast orders that no view has fulfilled yet.
      */
-    public getPendingBroadcast(): BroadcastOrder | null {
-        return this.pendingBroadcast;
+    public getPendingBroadcastReasons(): BroadcastReason[] {
+        return [...this.pendingBroadcastReasons];
     }
 
-    public getPendingReconcile(): ReconcileOrder | null {
-        return this.pendingReconcile;
+    public getPendingReconcileReasons(): ReconcileReason[] {
+        return [...this.pendingReconcileReasons];
     }
 
     /**
-     * Atomically consume AND execute the pending broadcast order, if any. The one-call
-     * fulfillment API for views: take + broadcast in a single step. The order's reason travels
-     * into {@link broadcast}, which decides the urgency internally (a `stale` timer-tick stays
-     * staleness-gated; every real trigger scans now).
+     * Atomically consume AND execute pending broadcast orders. The one-call fulfillment API
+     * for views: take + broadcast in a single step. The work is idempotent, so all taken
+     * reasons are satisfied by a single scan; the reasons travel into {@link broadcast}, which
+     * decides the urgency internally (only-`stale` stays staleness-gated; any real trigger
+     * scans now).
      *
      * Consumption is atomic: when two visible views react to the same order event, the first
-     * caller fulfills it and later callers find the slot empty and do nothing.
+     * caller fulfills it and later callers find the set empty and do nothing.
      *
      * @param options.except - reasons to leave QUEUED (not consumed) for another view, e.g.
      *   `{ except: ['stale'] }`. A blacklist on purpose: new reasons are acted on by default.
-     * @returns true if an order was consumed and a scan actually started
+     * @returns true if orders were consumed and a scan actually started
      */
     public fulfillPendingBroadcast(options?: { except?: BroadcastReason[] }): boolean {
-        const pending = this.pendingBroadcast;
-        if (!pending || options?.except?.includes(pending.reason)) {
+        const reasons = this.getPendingBroadcastReasons().filter(x => !options?.except?.includes(x));
+        if (reasons.length === 0) {
             return false;
         }
-        this.pendingBroadcast = null;
-        return this.broadcast(pending.reason);
+        for (const reason of reasons) {
+            this.pendingBroadcastReasons.delete(reason);
+        }
+        return this.broadcast(reasons);
     }
 
     /**
-     * Atomically consume AND execute the pending reconcile order, if any. One-call twin of
-     * {@link fulfillPendingBroadcast}; the reason travels into {@link reconcile}, which decides
-     * internally whether the per-device cache trust window is bypassed (only for
-     * `refresh-clicked` — an explicit "I want fresh data now" from the user).
+     * Atomically consume AND execute pending reconcile orders. One-call twin of
+     * {@link fulfillPendingBroadcast}; the reasons travel into {@link reconcile}, which decides
+     * internally whether the per-device cache trust window is bypassed (only when
+     * `refresh-clicked` is among them — an explicit "I want fresh data now" from the user).
      */
     public fulfillPendingReconcile(options?: { except?: ReconcileReason[] }): boolean {
-        const pending = this.pendingReconcile;
-        if (!pending || options?.except?.includes(pending.reason)) {
+        const reasons = this.getPendingReconcileReasons().filter(x => !options?.except?.includes(x));
+        if (reasons.length === 0) {
             return false;
         }
-        this.pendingReconcile = null;
-        this.reconcile(pending.reason);
+        for (const reason of reasons) {
+            this.pendingReconcileReasons.delete(reason);
+        }
+        this.reconcile(reasons);
         return true;
     }
     // #endregion
 
     /**
      * Broadcast an SSDP M-SEARCH to discover devices on the network. Does NOT health-check
-     * existing devices — that's {@link reconcile}. The reason decides the urgency: every real
-     * trigger scans now, while a `stale` timer-tick is only a "things might be old" hint — it
-     * scans only when discovery is enabled AND the last scan is older than
-     * STALE_SCAN_THRESHOLD_MS. Reachable only through order fulfillment.
+     * existing devices — that's {@link reconcile}. The reasons decide the urgency: any real
+     * trigger scans now, while a `stale` timer-tick is only a "things might be old" hint — a
+     * stale-only fulfillment scans only when discovery is enabled AND the last scan is older
+     * than STALE_SCAN_THRESHOLD_MS. Reachable only through order fulfillment.
      * @returns true if a scan was started
      */
-    private broadcast(reason: BroadcastReason): boolean {
-        if (reason === 'stale') {
+    private broadcast(reasons: BroadcastReason[]): boolean {
+        const staleOnly = reasons.every(x => x === 'stale');
+        if (staleOnly) {
             if (!this.deviceDiscoveryEnabled || this.timeSinceLastScan <= this.STALE_SCAN_THRESHOLD_MS) {
                 return false;
             }
@@ -686,13 +690,13 @@ export class DeviceManager {
 
     /**
      * Health-check every known device (configured + discovered), marking them online/offline.
-     * Does NOT scan for new devices — that's {@link broadcast}. The reason decides the urgency:
+     * Does NOT scan for new devices — that's {@link broadcast}. The reasons decide the urgency:
      * only an explicit user click bypasses each device's cache trust window — a bypassing
      * reconcile is one HTTP request per known device, so only "I want fresh data NOW" earns
      * that. Reachable only through order fulfillment.
      */
-    private reconcile(reason: ReconcileReason): void {
-        const bypassDeviceCache = reason === 'refresh-clicked';
+    private reconcile(reasons: ReconcileReason[]): void {
+        const bypassDeviceCache = reasons.includes('refresh-clicked');
         this.healthCheckAllDevices(bypassDeviceCache, true).catch(() => { });
     }
 

--- a/src/deviceDiscovery/Orders.spec.ts
+++ b/src/deviceDiscovery/Orders.spec.ts
@@ -1,0 +1,94 @@
+import { expect } from 'chai';
+import { createSandbox } from 'sinon';
+import { Orders } from './Orders';
+import type { Order } from './Orders';
+
+const sinon = createSandbox();
+
+describe('Orders', () => {
+    afterEach(() => {
+        sinon.restore();
+    });
+
+    it('submit lands each order in its type\'s pending set and announces it', () => {
+        const onSubmit = sinon.spy();
+        const orders = new Orders(onSubmit);
+
+        orders.submit([
+            { type: 'broadcast', reason: 'network' },
+            { type: 'reconcile', reason: 'config-changed' }
+        ]);
+
+        expect(orders.getPending('broadcast')).to.eql(['network']);
+        expect(orders.getPending('reconcile')).to.eql(['config-changed']);
+        expect(onSubmit.callCount).to.equal(2);
+        expect(onSubmit.firstCall.args[0]).to.eql({ type: 'broadcast', reason: 'network' });
+        expect(onSubmit.firstCall.args[1]).to.be.a('number');
+    });
+
+    it('the same reason never queues twice; different reasons accumulate', () => {
+        const orders = new Orders(() => { });
+
+        orders.submit([
+            { type: 'broadcast', reason: 'stale' },
+            { type: 'broadcast', reason: 'stale' },
+            { type: 'broadcast', reason: 'sleep' }
+        ]);
+
+        expect(orders.getPending('broadcast')).to.have.members(['stale', 'sleep']);
+    });
+
+    it('take drains the whole set and returns every reason', () => {
+        const orders = new Orders(() => { });
+        orders.submit([
+            { type: 'broadcast', reason: 'sleep' },
+            { type: 'broadcast', reason: 'network' }
+        ]);
+
+        const taken = orders.take('broadcast');
+
+        expect(taken).to.have.members(['sleep', 'network']);
+        expect(orders.getPending('broadcast')).to.be.empty;
+    });
+
+    it('take returns undefined and keeps the set when only excepted reasons are pending', () => {
+        const orders = new Orders(() => { });
+        orders.submit([{ type: 'broadcast', reason: 'stale' }]);
+
+        expect(orders.take('broadcast', ['stale'])).to.be.undefined;
+        expect(orders.getPending('broadcast')).to.eql(['stale']);
+    });
+
+    it('an excepted reason rides along when a non-excepted reason triggers the take', () => {
+        const orders = new Orders(() => { });
+        orders.submit([
+            { type: 'broadcast', reason: 'stale' },
+            { type: 'broadcast', reason: 'network' }
+        ]);
+
+        const taken = orders.take('broadcast', ['stale']);
+
+        expect(taken).to.have.members(['stale', 'network']);
+        expect(orders.getPending('broadcast')).to.be.empty;
+    });
+
+    it('take is atomic: a second take finds nothing', () => {
+        const orders = new Orders(() => { });
+        orders.submit([{ type: 'reconcile', reason: 'network' }]);
+
+        expect(orders.take('reconcile')).to.eql(['network']);
+        expect(orders.take('reconcile')).to.be.undefined;
+    });
+
+    it('the two order types are independent', () => {
+        const orders = new Orders(() => { });
+        const submitted: Order[] = [
+            { type: 'broadcast', reason: 'network' },
+            { type: 'reconcile', reason: 'network' }
+        ];
+        orders.submit(submitted);
+
+        expect(orders.take('broadcast')).to.eql(['network']);
+        expect(orders.getPending('reconcile')).to.eql(['network']);
+    });
+});

--- a/src/deviceDiscovery/Orders.spec.ts
+++ b/src/deviceDiscovery/Orders.spec.ts
@@ -38,24 +38,26 @@ describe('Orders', () => {
         expect(orders.getPending('broadcast')).to.have.members(['stale', 'sleep']);
     });
 
-    it('take drains the whole set and returns every reason', () => {
+    it('take drains the whole set and returns one entry with every reason', () => {
         const orders = new Orders(() => { });
         orders.submit([
             { type: 'broadcast', reason: 'sleep' },
             { type: 'broadcast', reason: 'network' }
         ]);
 
-        const taken = orders.take('broadcast');
+        const taken = orders.take({ types: ['broadcast'] });
 
-        expect(taken).to.have.members(['sleep', 'network']);
+        expect(taken).to.have.length(1);
+        expect(taken[0].type).to.equal('broadcast');
+        expect(taken[0].reasons).to.have.members(['sleep', 'network']);
         expect(orders.getPending('broadcast')).to.be.empty;
     });
 
-    it('take returns undefined and keeps the set when only excepted reasons are pending', () => {
+    it('take returns nothing and keeps the set when only excepted reasons are pending', () => {
         const orders = new Orders(() => { });
         orders.submit([{ type: 'broadcast', reason: 'stale' }]);
 
-        expect(orders.take('broadcast', ['stale'])).to.be.undefined;
+        expect(orders.take({ types: ['broadcast'], except: ['stale'] })).to.be.empty;
         expect(orders.getPending('broadcast')).to.eql(['stale']);
     });
 
@@ -66,18 +68,19 @@ describe('Orders', () => {
             { type: 'broadcast', reason: 'network' }
         ]);
 
-        const taken = orders.take('broadcast', ['stale']);
+        const taken = orders.take({ types: ['broadcast'], except: ['stale'] });
 
-        expect(taken).to.have.members(['stale', 'network']);
+        expect(taken).to.have.length(1);
+        expect(taken[0].reasons).to.have.members(['stale', 'network']);
         expect(orders.getPending('broadcast')).to.be.empty;
     });
 
-    it('take is atomic: a second take finds nothing', () => {
+    it('take is atomic per type: a second take finds nothing', () => {
         const orders = new Orders(() => { });
         orders.submit([{ type: 'reconcile', reason: 'network' }]);
 
-        expect(orders.take('reconcile')).to.eql(['network']);
-        expect(orders.take('reconcile')).to.be.undefined;
+        expect(orders.take({ types: ['reconcile'] })).to.eql([{ type: 'reconcile', reasons: ['network'] }]);
+        expect(orders.take({ types: ['reconcile'] })).to.be.empty;
     });
 
     it('the two order types are independent', () => {
@@ -88,7 +91,7 @@ describe('Orders', () => {
         ];
         orders.submit(submitted);
 
-        expect(orders.take('broadcast')).to.eql(['network']);
+        expect(orders.take({ types: ['broadcast'] })).to.eql([{ type: 'broadcast', reasons: ['network'] }]);
         expect(orders.getPending('reconcile')).to.eql(['network']);
     });
 });

--- a/src/deviceDiscovery/Orders.ts
+++ b/src/deviceDiscovery/Orders.ts
@@ -1,6 +1,5 @@
 /**
- * Why a broadcast (SSDP scan) was ordered. Views filter on this - e.g. a visible view ignores
- * `stale` (timer-driven) orders to avoid surprise scans. (See docs/device-discovery.md "Orders")
+ * Why a broadcast (SSDP scan) was ordered
  */
 export type BroadcastReason =
     | 'startup'
@@ -11,7 +10,7 @@ export type BroadcastReason =
     | 'stale';
 
 /**
- * Why a reconcile (health-check-all) was ordered.
+ * Why a reconcile (health-check-all) was ordered
  */
 export type ReconcileReason =
     | 'startup'
@@ -24,21 +23,19 @@ export type ReconcileReason =
 export type OrderType = 'broadcast' | 'reconcile';
 
 /**
- * A unit of deferred work: submitted by triggers, fulfilled by visible views.
- * The discriminated union keeps each order type paired with its own reason vocabulary.
+ * A unit of deferred work: submitted by triggers, fulfilled by visible views
  */
 export type Order =
     | { type: 'broadcast'; reason: BroadcastReason }
     | { type: 'reconcile'; reason: ReconcileReason };
 
 /**
- * Payload of the `order-submitted` event: the order plus when it was submitted (ms epoch).
+ * Payload of the `order-submitted` event
  */
 export type SubmittedOrder = Order & { timestamp: number };
 
 /**
- * What a take drained for one order type: every reason that was pending. The taker is
- * expected to execute the type's work once - a single execution satisfies all of them.
+ * Everything a take drained for one order type; a single execution satisfies all of it
  */
 export type TakenOrders =
     | { type: 'broadcast'; reasons: BroadcastReason[] }
@@ -46,15 +43,13 @@ export type TakenOrders =
 
 /**
  * The pending-orders store (docs/device-discovery.md "Orders"): one set of reasons per order
- * type. The work is idempotent (one scan satisfies every queued "please scan"), so reasons
- * accumulate - different reasons coexist, the same reason never queues twice - and a take
- * drains everything at once for a single execution.
+ * type. Reasons accumulate (the same reason never queues twice) and a take drains everything
+ * at once for a single execution.
  */
 export class Orders {
     public constructor(
         /**
-         * Called once per submitted order, after it lands in the pending set - the hook the
-         * owner uses to notify live views.
+         * Called once per submitted order
          */
         private onSubmit: (order: Order, timestamp: number) => void
     ) { }
@@ -64,10 +59,6 @@ export class Orders {
         reconcile: new Set<ReconcileReason>()
     };
 
-    /**
-     * Submit orders. Each order's reason is added to its type's pending set (a reason never
-     * queues twice) and announced via the onSubmit hook so visible views can fulfill live.
-     */
     public submit(orders: Order[]): void {
         for (const order of orders) {
             (this.pending[order.type] as Set<string>).add(order.reason);
@@ -75,9 +66,6 @@ export class Orders {
         }
     }
 
-    /**
-     * The reasons currently pending for an order type (nothing is consumed).
-     */
     public getPending(type: 'broadcast'): BroadcastReason[];
     public getPending(type: 'reconcile'): ReconcileReason[];
     public getPending(type: OrderType): string[] {
@@ -85,18 +73,11 @@ export class Orders {
     }
 
     /**
-     * Atomically take the pending reasons for the requested order types. Returns one entry
-     * per type that actually had something to take - the caller executes each entry's work
-     * once (a single execution satisfies all of its reasons).
-     *
-     * `except` lists reasons that cannot TRIGGER a take on their own (a blacklist on purpose:
-     * new reasons act by default). When any non-excepted reason is present for a type, that
-     * type's WHOLE set is drained - the execution satisfies every queued reason, excepted
-     * ones included. When only excepted reasons (or nothing) are pending, the type is omitted
-     * from the result and its set is left untouched.
-     *
-     * Atomic per type: when two visible views react to the same order event, the first taker
-     * gets the reasons and later callers find the set empty.
+     * Atomically take the pending reasons for the requested order types, one entry per type
+     * that had something to take. `except` reasons can't trigger a take on their own, but when
+     * another reason triggers one, the type's WHOLE set is drained (the single execution that
+     * follows satisfies excepted reasons too). Atomic per type: concurrent takers can't drain
+     * the same set twice.
      */
     public take(options: { types: OrderType[]; except?: Array<BroadcastReason | ReconcileReason> }): TakenOrders[] {
         const except = options.except as string[] | undefined;

--- a/src/deviceDiscovery/Orders.ts
+++ b/src/deviceDiscovery/Orders.ts
@@ -32,6 +32,11 @@ export type Order =
     | { type: 'reconcile'; reason: ReconcileReason };
 
 /**
+ * Payload of the `order-submitted` event: the order plus when it was submitted (ms epoch).
+ */
+export type SubmittedOrder = Order & { timestamp: number };
+
+/**
  * The pending-orders store (docs/device-discovery.md "Orders"): one set of reasons per order
  * type. The work is idempotent (one scan satisfies every queued "please scan"), so reasons
  * accumulate — different reasons coexist, the same reason never queues twice — and a take

--- a/src/deviceDiscovery/Orders.ts
+++ b/src/deviceDiscovery/Orders.ts
@@ -37,6 +37,14 @@ export type Order =
 export type SubmittedOrder = Order & { timestamp: number };
 
 /**
+ * What a take drained for one order type: every reason that was pending. The taker is
+ * expected to execute the type's work once — a single execution satisfies all of them.
+ */
+export type TakenOrders =
+    | { type: 'broadcast'; reasons: BroadcastReason[] }
+    | { type: 'reconcile'; reasons: ReconcileReason[] };
+
+/**
  * The pending-orders store (docs/device-discovery.md "Orders"): one set of reasons per order
  * type. The work is idempotent (one scan satisfies every queued "please scan"), so reasons
  * accumulate — different reasons coexist, the same reason never queues twice — and a take
@@ -77,27 +85,32 @@ export class Orders {
     }
 
     /**
-     * Atomically take every pending reason for an order type, or nothing at all.
+     * Atomically take the pending reasons for the requested order types. Returns one entry
+     * per type that actually had something to take — the caller executes each entry's work
+     * once (a single execution satisfies all of its reasons).
      *
      * `except` lists reasons that cannot TRIGGER a take on their own (a blacklist on purpose:
-     * new reasons act by default). When any non-excepted reason is present, the WHOLE set is
-     * returned and cleared — the single execution that follows satisfies every queued reason,
-     * excepted ones included. When only excepted reasons (or nothing) are pending, returns
-     * undefined and leaves the set untouched.
+     * new reasons act by default). When any non-excepted reason is present for a type, that
+     * type's WHOLE set is drained — the execution satisfies every queued reason, excepted
+     * ones included. When only excepted reasons (or nothing) are pending, the type is omitted
+     * from the result and its set is left untouched.
      *
-     * Atomic: when two visible views react to the same order event, the first taker gets the
-     * reasons and later callers find the set empty.
+     * Atomic per type: when two visible views react to the same order event, the first taker
+     * gets the reasons and later callers find the set empty.
      */
-    public take(type: 'broadcast', except?: BroadcastReason[]): BroadcastReason[] | undefined;
-    public take(type: 'reconcile', except?: ReconcileReason[]): ReconcileReason[] | undefined;
-    public take(type: OrderType, except?: string[]): string[] | undefined {
-        const set = this.pending[type] as Set<string>;
-        const triggers = [...set].filter(x => !except?.includes(x));
-        if (triggers.length === 0) {
-            return undefined;
+    public take(options: { types: OrderType[]; except?: Array<BroadcastReason | ReconcileReason> }): TakenOrders[] {
+        const except = options.except as string[] | undefined;
+        const taken: TakenOrders[] = [];
+        for (const type of options.types) {
+            const set = this.pending[type] as Set<string>;
+            const triggers = [...set].filter(x => !except?.includes(x));
+            if (triggers.length === 0) {
+                continue;
+            }
+            const reasons = [...set];
+            set.clear();
+            taken.push({ type: type, reasons: reasons } as TakenOrders);
         }
-        const reasons = [...set];
-        set.clear();
-        return reasons;
+        return taken;
     }
 }

--- a/src/deviceDiscovery/Orders.ts
+++ b/src/deviceDiscovery/Orders.ts
@@ -1,5 +1,5 @@
 /**
- * Why a broadcast (SSDP scan) was ordered. Views filter on this — e.g. a visible view ignores
+ * Why a broadcast (SSDP scan) was ordered. Views filter on this - e.g. a visible view ignores
  * `stale` (timer-driven) orders to avoid surprise scans. (See docs/device-discovery.md "Orders")
  */
 export type BroadcastReason =
@@ -38,7 +38,7 @@ export type SubmittedOrder = Order & { timestamp: number };
 
 /**
  * What a take drained for one order type: every reason that was pending. The taker is
- * expected to execute the type's work once — a single execution satisfies all of them.
+ * expected to execute the type's work once - a single execution satisfies all of them.
  */
 export type TakenOrders =
     | { type: 'broadcast'; reasons: BroadcastReason[] }
@@ -47,13 +47,13 @@ export type TakenOrders =
 /**
  * The pending-orders store (docs/device-discovery.md "Orders"): one set of reasons per order
  * type. The work is idempotent (one scan satisfies every queued "please scan"), so reasons
- * accumulate — different reasons coexist, the same reason never queues twice — and a take
+ * accumulate - different reasons coexist, the same reason never queues twice - and a take
  * drains everything at once for a single execution.
  */
 export class Orders {
     public constructor(
         /**
-         * Called once per submitted order, after it lands in the pending set — the hook the
+         * Called once per submitted order, after it lands in the pending set - the hook the
          * owner uses to notify live views.
          */
         private onSubmit: (order: Order, timestamp: number) => void
@@ -86,12 +86,12 @@ export class Orders {
 
     /**
      * Atomically take the pending reasons for the requested order types. Returns one entry
-     * per type that actually had something to take — the caller executes each entry's work
+     * per type that actually had something to take - the caller executes each entry's work
      * once (a single execution satisfies all of its reasons).
      *
      * `except` lists reasons that cannot TRIGGER a take on their own (a blacklist on purpose:
      * new reasons act by default). When any non-excepted reason is present for a type, that
-     * type's WHOLE set is drained — the execution satisfies every queued reason, excepted
+     * type's WHOLE set is drained - the execution satisfies every queued reason, excepted
      * ones included. When only excepted reasons (or nothing) are pending, the type is omitted
      * from the result and its set is left untouched.
      *

--- a/src/deviceDiscovery/Orders.ts
+++ b/src/deviceDiscovery/Orders.ts
@@ -1,0 +1,98 @@
+/**
+ * Why a broadcast (SSDP scan) was ordered. Views filter on this — e.g. a visible view ignores
+ * `stale` (timer-driven) orders to avoid surprise scans. (See docs/device-discovery.md "Orders")
+ */
+export type BroadcastReason =
+    | 'startup'
+    | 'network'
+    | 'sleep'
+    | 'refresh-clicked'
+    | 'unhealthy-device'
+    | 'stale';
+
+/**
+ * Why a reconcile (health-check-all) was ordered.
+ */
+export type ReconcileReason =
+    | 'startup'
+    | 'network'
+    | 'sleep'
+    | 'refresh-clicked'
+    | 'config-changed'
+    | 'stale';
+
+export type OrderType = 'broadcast' | 'reconcile';
+
+/**
+ * A unit of deferred work: submitted by triggers, fulfilled by visible views.
+ * The discriminated union keeps each order type paired with its own reason vocabulary.
+ */
+export type Order =
+    | { type: 'broadcast'; reason: BroadcastReason }
+    | { type: 'reconcile'; reason: ReconcileReason };
+
+/**
+ * The pending-orders store (docs/device-discovery.md "Orders"): one set of reasons per order
+ * type. The work is idempotent (one scan satisfies every queued "please scan"), so reasons
+ * accumulate — different reasons coexist, the same reason never queues twice — and a take
+ * drains everything at once for a single execution.
+ */
+export class Orders {
+    public constructor(
+        /**
+         * Called once per submitted order, after it lands in the pending set — the hook the
+         * owner uses to notify live views.
+         */
+        private onSubmit: (order: Order, timestamp: number) => void
+    ) { }
+
+    private pending = {
+        broadcast: new Set<BroadcastReason>(),
+        reconcile: new Set<ReconcileReason>()
+    };
+
+    /**
+     * Submit orders. Each order's reason is added to its type's pending set (a reason never
+     * queues twice) and announced via the onSubmit hook so visible views can fulfill live.
+     */
+    public submit(orders: Order[]): void {
+        for (const order of orders) {
+            (this.pending[order.type] as Set<string>).add(order.reason);
+            this.onSubmit(order, Date.now());
+        }
+    }
+
+    /**
+     * The reasons currently pending for an order type (nothing is consumed).
+     */
+    public getPending(type: 'broadcast'): BroadcastReason[];
+    public getPending(type: 'reconcile'): ReconcileReason[];
+    public getPending(type: OrderType): string[] {
+        return [...this.pending[type]];
+    }
+
+    /**
+     * Atomically take every pending reason for an order type, or nothing at all.
+     *
+     * `except` lists reasons that cannot TRIGGER a take on their own (a blacklist on purpose:
+     * new reasons act by default). When any non-excepted reason is present, the WHOLE set is
+     * returned and cleared — the single execution that follows satisfies every queued reason,
+     * excepted ones included. When only excepted reasons (or nothing) are pending, returns
+     * undefined and leaves the set untouched.
+     *
+     * Atomic: when two visible views react to the same order event, the first taker gets the
+     * reasons and later callers find the set empty.
+     */
+    public take(type: 'broadcast', except?: BroadcastReason[]): BroadcastReason[] | undefined;
+    public take(type: 'reconcile', except?: ReconcileReason[]): ReconcileReason[] | undefined;
+    public take(type: OrderType, except?: string[]): string[] | undefined {
+        const set = this.pending[type] as Set<string>;
+        const triggers = [...set].filter(x => !except?.includes(x));
+        if (triggers.length === 0) {
+            return undefined;
+        }
+        const reasons = [...set];
+        set.clear();
+        return reasons;
+    }
+}

--- a/src/deviceDiscovery/RokuFinder.ts
+++ b/src/deviceDiscovery/RokuFinder.ts
@@ -154,8 +154,7 @@ export class RokuFinder extends EventEmitter {
     }
 
     /**
-     * End any in-progress scan (emitting scan-ended) WITHOUT stopping the passive SSDP
-     * listener — alive/byebye announcements keep flowing.
+     * End any in-progress scan (emitting scan-ended) without stopping the passive SSDP listener
      */
     public stopScan(): void {
         if (this.isScanning) {

--- a/src/deviceDiscovery/RokuFinder.ts
+++ b/src/deviceDiscovery/RokuFinder.ts
@@ -154,6 +154,16 @@ export class RokuFinder extends EventEmitter {
     }
 
     /**
+     * End any in-progress scan (emitting scan-ended) WITHOUT stopping the passive SSDP
+     * listener — alive/byebye announcements keep flowing.
+     */
+    public stopScan(): void {
+        if (this.isScanning) {
+            this.endScan();
+        }
+    }
+
+    /**
      * Stop listening for SSDP advertisements.
      * Also ends any in-progress scan (emitting scan-ended).
      */

--- a/src/managers/UserInputManager.spec.ts
+++ b/src/managers/UserInputManager.spec.ts
@@ -452,7 +452,7 @@ describe('UserInputManager', () => {
                 'software-version': '11.5.0'
             };
             //manual entry probes the device the same way, so the gathered device info comes back too
-            sinon.stub(userInputManager, 'promptForHostManual').resolves({ host: '9.8.7.6', deviceInfo: deviceInfo });
+            sinon.stub(userInputManager as any, 'promptForHostManual').returns(Promise.resolve({ host: '9.8.7.6', deviceInfo: deviceInfo }) as any);
 
             const promptPromise = userInputManager.promptForHost();
 
@@ -478,7 +478,7 @@ describe('UserInputManager', () => {
             };
             const validateStub = sinon.stub(deviceManager, 'validateAndAddDevice').resolves({ ip: '4.3.2.1', deviceInfo: deviceInfo } as any);
 
-            const result = await userInputManager.promptForHostManual();
+            const result = await userInputManager['promptForHostManual']();
 
             expect(validateStub.calledWith('4.3.2.1')).to.be.true;
             expect(result).to.eql({ host: '4.3.2.1', deviceInfo: deviceInfo });
@@ -488,7 +488,7 @@ describe('UserInputManager', () => {
             sinon.stub(vscode.window, 'showInputBox').resolves(undefined);
             const validateStub = sinon.stub(deviceManager, 'validateAndAddDevice');
 
-            const result = await userInputManager.promptForHostManual();
+            const result = await userInputManager['promptForHostManual']();
 
             expect(result).to.be.undefined;
             expect(validateStub.called).to.be.false;

--- a/src/managers/UserInputManager.spec.ts
+++ b/src/managers/UserInputManager.spec.ts
@@ -260,7 +260,7 @@ describe('UserInputManager', () => {
             });
 
             //queue a broadcast order as if the network changed while no view was visible
-            deviceManager['submitBroadcast']('network');
+            deviceManager.submitOrders([{ type: 'broadcast', reason: 'network' }]);
 
             const promptPromise = userInputManager.promptForHost();
             await new Promise<void>(resolve => {
@@ -289,7 +289,7 @@ describe('UserInputManager', () => {
             });
 
             //the 30-minute timer queued a routine freshness order while no view was visible
-            deviceManager['submitBroadcast']('stale');
+            deviceManager.submitOrders([{ type: 'broadcast', reason: 'stale' }]);
 
             const promptPromise = userInputManager.promptForHost();
 
@@ -346,7 +346,7 @@ describe('UserInputManager', () => {
             });
 
             //queue a reconcile order as if the network changed while no view was visible
-            deviceManager['submitReconcile']('network');
+            deviceManager.submitOrders([{ type: 'reconcile', reason: 'network' }]);
 
             const promptPromise = userInputManager.promptForHost();
             await new Promise<void>(resolve => {
@@ -371,7 +371,7 @@ describe('UserInputManager', () => {
                 return quickPick;
             });
 
-            deviceManager['submitReconcile']('stale');
+            deviceManager.submitOrders([{ type: 'reconcile', reason: 'stale' }]);
 
             const promptPromise = userInputManager.promptForHost();
             await new Promise<void>(resolve => {
@@ -402,7 +402,7 @@ describe('UserInputManager', () => {
             expect(reconcileSpy.called).to.be.false;
 
             //a trigger fires while the picker is open
-            deviceManager['submitReconcile']('sleep');
+            deviceManager.submitOrders([{ type: 'reconcile', reason: 'sleep' }]);
 
             expect(reconcileSpy.calledOnce).to.be.true;
             expect(deviceManager.getPendingReconcileReasons()).to.be.empty;

--- a/src/managers/UserInputManager.spec.ts
+++ b/src/managers/UserInputManager.spec.ts
@@ -260,7 +260,7 @@ describe('UserInputManager', () => {
             });
 
             //queue a broadcast order as if the network changed while no view was visible
-            deviceManager.submitBroadcast('network');
+            deviceManager['submitBroadcast']('network');
 
             const promptPromise = userInputManager.promptForHost();
             await new Promise<void>(resolve => {
@@ -289,7 +289,7 @@ describe('UserInputManager', () => {
             });
 
             //the 30-minute timer queued a routine freshness order while no view was visible
-            deviceManager.submitBroadcast('stale');
+            deviceManager['submitBroadcast']('stale');
 
             const promptPromise = userInputManager.promptForHost();
 
@@ -346,7 +346,7 @@ describe('UserInputManager', () => {
             });
 
             //queue a reconcile order as if the network changed while no view was visible
-            deviceManager.submitReconcile('network');
+            deviceManager['submitReconcile']('network');
 
             const promptPromise = userInputManager.promptForHost();
             await new Promise<void>(resolve => {
@@ -371,7 +371,7 @@ describe('UserInputManager', () => {
                 return quickPick;
             });
 
-            deviceManager.submitReconcile('stale');
+            deviceManager['submitReconcile']('stale');
 
             const promptPromise = userInputManager.promptForHost();
             await new Promise<void>(resolve => {
@@ -402,7 +402,7 @@ describe('UserInputManager', () => {
             expect(reconcileSpy.called).to.be.false;
 
             //a trigger fires while the picker is open
-            deviceManager.submitReconcile('sleep');
+            deviceManager['submitReconcile']('sleep');
 
             expect(reconcileSpy.calledOnce).to.be.true;
             expect(deviceManager.getPendingReconcileReasons()).to.be.empty;

--- a/src/managers/UserInputManager.spec.ts
+++ b/src/managers/UserInputManager.spec.ts
@@ -267,8 +267,8 @@ describe('UserInputManager', () => {
                 setTimeout(resolve, 10);
             });
 
-            expect(broadcastStub.calledOnceWith('network')).to.be.true;
-            expect(deviceManager.getPendingBroadcast()).to.be.null;
+            expect(broadcastStub.calledOnceWith(['network'])).to.be.true;
+            expect(deviceManager.getPendingBroadcastReasons()).to.be.empty;
 
             quickPick?.hide();
             await promptPromise.catch(() => { });
@@ -295,7 +295,7 @@ describe('UserInputManager', () => {
 
             //opening the picker does NOT consume the stale order — routine freshness is
             //the fallback's job, so a fresh open causes no immediate network activity
-            expect(deviceManager.getPendingBroadcast()).to.include({ reason: 'stale' });
+            expect(deviceManager.getPendingBroadcastReasons()).to.include('stale');
             expect(broadcastStub.called).to.be.false;
 
             //once the picker has been open past the fallback window with no broadcast, the
@@ -304,8 +304,8 @@ describe('UserInputManager', () => {
             await new Promise<void>(resolve => {
                 setTimeout(resolve, 50);
             });
-            expect(deviceManager.getPendingBroadcast()).to.be.null;
-            expect(broadcastStub.calledOnceWith('stale')).to.be.true;
+            expect(deviceManager.getPendingBroadcastReasons()).to.be.empty;
+            expect(broadcastStub.calledOnceWith(['stale'])).to.be.true;
 
             quickPick?.hide();
             await promptPromise.catch(() => { });
@@ -354,8 +354,8 @@ describe('UserInputManager', () => {
             });
 
             expect(reconcileSpy.calledOnce).to.be.true;
-            expect(reconcileSpy.firstCall.args[0]).to.equal('network');
-            expect(deviceManager.getPendingReconcile()).to.be.null;
+            expect(reconcileSpy.firstCall.args[0]).to.eql(['network']);
+            expect(deviceManager.getPendingReconcileReasons()).to.be.empty;
 
             quickPick?.hide();
             await promptPromise.catch(() => { });
@@ -379,7 +379,7 @@ describe('UserInputManager', () => {
             });
 
             expect(reconcileSpy.called).to.be.false;
-            expect(deviceManager.getPendingReconcile()).to.include({ reason: 'stale' });
+            expect(deviceManager.getPendingReconcileReasons()).to.include('stale');
 
             quickPick?.hide();
             await promptPromise.catch(() => { });
@@ -405,7 +405,7 @@ describe('UserInputManager', () => {
             deviceManager.submitReconcile('sleep');
 
             expect(reconcileSpy.calledOnce).to.be.true;
-            expect(deviceManager.getPendingReconcile()).to.be.null;
+            expect(deviceManager.getPendingReconcileReasons()).to.be.empty;
 
             quickPick?.hide();
             await promptPromise.catch(() => { });

--- a/src/managers/UserInputManager.spec.ts
+++ b/src/managers/UserInputManager.spec.ts
@@ -220,8 +220,8 @@ describe('UserInputManager', () => {
 
     describe('promptForHost', () => {
         it('does not scan or reconcile on open when no orders are pending', async () => {
-            const broadcastSpy = sinon.spy(deviceManager, 'broadcast');
-            const reconcileSpy = sinon.spy(deviceManager, 'reconcile');
+            const broadcastSpy = sinon.spy(deviceManager as any, 'broadcast');
+            const reconcileSpy = sinon.spy(deviceManager as any, 'reconcile');
 
             // Capture the quickPick instance when created
             let quickPick: any;
@@ -248,9 +248,9 @@ describe('UserInputManager', () => {
             await promptPromise.catch(() => { });
         });
 
-        it('fulfills a queued non-stale broadcast order (forced) when the picker opens', async () => {
+        it('fulfills a queued non-stale broadcast order when the picker opens', async () => {
             //stub (not spy) so no real RokuFinder scan with real timers starts
-            const broadcastStub = sinon.stub(deviceManager, 'broadcast').returns(true);
+            const broadcastStub = sinon.stub(deviceManager as any, 'broadcast').returns(true);
 
             let quickPick: any;
             const originalCreateQuickPick = vscode.window.createQuickPick;
@@ -267,7 +267,7 @@ describe('UserInputManager', () => {
                 setTimeout(resolve, 10);
             });
 
-            expect(broadcastStub.calledOnceWith(true)).to.be.true;
+            expect(broadcastStub.calledOnceWith('network')).to.be.true;
             expect(deviceManager.getPendingBroadcast()).to.be.null;
 
             quickPick?.hide();
@@ -275,9 +275,9 @@ describe('UserInputManager', () => {
         });
 
         it('leaves a queued stale broadcast untouched on open, then the 7s fallback fulfills it (staleness-gated)', async () => {
-            //stub (not spy): this test is about order consumption and the force flag, not the
-            //scan machinery — don't start a real RokuFinder scan with real timers
-            const broadcastStub = sinon.stub(deviceManager, 'broadcast').returns(false);
+            //stub (not spy): this test is about order consumption, not the scan machinery —
+            //don't start a real RokuFinder scan with real timers
+            const broadcastStub = sinon.stub(deviceManager as any, 'broadcast').returns(false);
             //shrink the 7s fallback so the test can wait it out with real timers
             userInputManager['scanTimeoutMs'] = 20;
 
@@ -299,20 +299,20 @@ describe('UserInputManager', () => {
             expect(broadcastStub.called).to.be.false;
 
             //once the picker has been open past the fallback window with no broadcast, the
-            //fallback fulfills everything pending — the queued stale order runs without force,
-            //so the staleness gate decides whether a scan actually happens
+            //fallback fulfills everything pending — the queued stale order reaches broadcast
+            //with its reason, so the staleness gate decides whether a scan actually happens
             await new Promise<void>(resolve => {
                 setTimeout(resolve, 50);
             });
             expect(deviceManager.getPendingBroadcast()).to.be.null;
-            expect(broadcastStub.calledOnceWith(false)).to.be.true;
+            expect(broadcastStub.calledOnceWith('stale')).to.be.true;
 
             quickPick?.hide();
             await promptPromise.catch(() => { });
         });
 
         it('7s fallback does nothing when no orders are pending', async () => {
-            const broadcastStub = sinon.stub(deviceManager, 'broadcast').returns(false);
+            const broadcastStub = sinon.stub(deviceManager as any, 'broadcast').returns(false);
             userInputManager['scanTimeoutMs'] = 20;
 
             let quickPick: any;
@@ -336,7 +336,7 @@ describe('UserInputManager', () => {
         });
 
         it('fulfills a queued non-stale reconcile order when the picker opens', async () => {
-            const reconcileSpy = sinon.spy(deviceManager, 'reconcile');
+            const reconcileSpy = sinon.spy(deviceManager as any, 'reconcile');
 
             let quickPick: any;
             const originalCreateQuickPick = vscode.window.createQuickPick;
@@ -354,7 +354,7 @@ describe('UserInputManager', () => {
             });
 
             expect(reconcileSpy.calledOnce).to.be.true;
-            expect(reconcileSpy.firstCall.args[0]).to.be.false; //non-refresh-clicked → not forced
+            expect(reconcileSpy.firstCall.args[0]).to.equal('network');
             expect(deviceManager.getPendingReconcile()).to.be.null;
 
             quickPick?.hide();
@@ -362,7 +362,7 @@ describe('UserInputManager', () => {
         });
 
         it('leaves a queued stale reconcile order untouched when the picker opens', async () => {
-            const reconcileSpy = sinon.spy(deviceManager, 'reconcile');
+            const reconcileSpy = sinon.spy(deviceManager as any, 'reconcile');
 
             let quickPick: any;
             const originalCreateQuickPick = vscode.window.createQuickPick;
@@ -386,7 +386,7 @@ describe('UserInputManager', () => {
         });
 
         it('fulfills a live non-stale reconcile order while the picker is open', async () => {
-            const reconcileSpy = sinon.spy(deviceManager, 'reconcile');
+            const reconcileSpy = sinon.spy(deviceManager as any, 'reconcile');
 
             let quickPick: any;
             const originalCreateQuickPick = vscode.window.createQuickPick;

--- a/src/managers/UserInputManager.spec.ts
+++ b/src/managers/UserInputManager.spec.ts
@@ -219,9 +219,9 @@ describe('UserInputManager', () => {
     });
 
     describe('promptForHost', () => {
-        it('calls scan() instead of refresh() when picker opens', async () => {
-            const scanSpy = sinon.spy(deviceManager, 'scan');
-            const refreshSpy = sinon.spy(deviceManager, 'refresh');
+        it('does not scan or reconcile on open when no orders are pending', async () => {
+            const broadcastSpy = sinon.spy(deviceManager, 'broadcast');
+            const reconcileSpy = sinon.spy(deviceManager, 'reconcile');
 
             // Capture the quickPick instance when created
             let quickPick: any;
@@ -239,11 +239,174 @@ describe('UserInputManager', () => {
                 setTimeout(resolve, 10);
             });
 
-            // Verify scan was called, not refresh
-            expect(scanSpy.called).to.be.true;
-            expect(refreshSpy.called).to.be.false;
+            // Opening the picker is not itself a reason to hit the network
+            expect(broadcastSpy.called).to.be.false;
+            expect(reconcileSpy.called).to.be.false;
 
             // Clean up by hiding the quickpick (triggers rejection)
+            quickPick?.hide();
+            await promptPromise.catch(() => { });
+        });
+
+        it('fulfills a queued non-stale broadcast order (forced) when the picker opens', async () => {
+            //stub (not spy) so no real RokuFinder scan with real timers starts
+            const broadcastStub = sinon.stub(deviceManager, 'broadcast').returns(true);
+
+            let quickPick: any;
+            const originalCreateQuickPick = vscode.window.createQuickPick;
+            sinon.stub(vscode.window, 'createQuickPick').callsFake(() => {
+                quickPick = originalCreateQuickPick();
+                return quickPick;
+            });
+
+            //queue a broadcast order as if the network changed while no view was visible
+            deviceManager.submitBroadcast('network');
+
+            const promptPromise = userInputManager.promptForHost();
+            await new Promise<void>(resolve => {
+                setTimeout(resolve, 10);
+            });
+
+            expect(broadcastStub.calledOnceWith(true)).to.be.true;
+            expect(deviceManager.getPendingBroadcast()).to.be.null;
+
+            quickPick?.hide();
+            await promptPromise.catch(() => { });
+        });
+
+        it('leaves a queued stale broadcast untouched on open, then the 7s fallback fulfills it (staleness-gated)', async () => {
+            //stub (not spy): this test is about order consumption and the force flag, not the
+            //scan machinery — don't start a real RokuFinder scan with real timers
+            const broadcastStub = sinon.stub(deviceManager, 'broadcast').returns(false);
+            //shrink the 7s fallback so the test can wait it out with real timers
+            userInputManager['scanTimeoutMs'] = 20;
+
+            let quickPick: any;
+            const originalCreateQuickPick = vscode.window.createQuickPick;
+            sinon.stub(vscode.window, 'createQuickPick').callsFake(() => {
+                quickPick = originalCreateQuickPick();
+                return quickPick;
+            });
+
+            //the 30-minute timer queued a routine freshness order while no view was visible
+            deviceManager.submitBroadcast('stale');
+
+            const promptPromise = userInputManager.promptForHost();
+
+            //opening the picker does NOT consume the stale order — routine freshness is
+            //the fallback's job, so a fresh open causes no immediate network activity
+            expect(deviceManager.getPendingBroadcast()).to.include({ reason: 'stale' });
+            expect(broadcastStub.called).to.be.false;
+
+            //once the picker has been open past the fallback window with no broadcast, the
+            //fallback fulfills everything pending — the queued stale order runs without force,
+            //so the staleness gate decides whether a scan actually happens
+            await new Promise<void>(resolve => {
+                setTimeout(resolve, 50);
+            });
+            expect(deviceManager.getPendingBroadcast()).to.be.null;
+            expect(broadcastStub.calledOnceWith(false)).to.be.true;
+
+            quickPick?.hide();
+            await promptPromise.catch(() => { });
+        });
+
+        it('7s fallback does nothing when no orders are pending', async () => {
+            const broadcastStub = sinon.stub(deviceManager, 'broadcast').returns(false);
+            userInputManager['scanTimeoutMs'] = 20;
+
+            let quickPick: any;
+            const originalCreateQuickPick = vscode.window.createQuickPick;
+            sinon.stub(vscode.window, 'createQuickPick').callsFake(() => {
+                quickPick = originalCreateQuickPick();
+                return quickPick;
+            });
+
+            const promptPromise = userInputManager.promptForHost();
+            expect(broadcastStub.called).to.be.false;
+
+            //nothing queued → nothing to fulfill → no network activity
+            await new Promise<void>(resolve => {
+                setTimeout(resolve, 50);
+            });
+            expect(broadcastStub.called).to.be.false;
+
+            quickPick?.hide();
+            await promptPromise.catch(() => { });
+        });
+
+        it('fulfills a queued non-stale reconcile order when the picker opens', async () => {
+            const reconcileSpy = sinon.spy(deviceManager, 'reconcile');
+
+            let quickPick: any;
+            const originalCreateQuickPick = vscode.window.createQuickPick;
+            sinon.stub(vscode.window, 'createQuickPick').callsFake(() => {
+                quickPick = originalCreateQuickPick();
+                return quickPick;
+            });
+
+            //queue a reconcile order as if the network changed while no view was visible
+            deviceManager.submitReconcile('network');
+
+            const promptPromise = userInputManager.promptForHost();
+            await new Promise<void>(resolve => {
+                setTimeout(resolve, 10);
+            });
+
+            expect(reconcileSpy.calledOnce).to.be.true;
+            expect(reconcileSpy.firstCall.args[0]).to.be.false; //non-refresh-clicked → not forced
+            expect(deviceManager.getPendingReconcile()).to.be.null;
+
+            quickPick?.hide();
+            await promptPromise.catch(() => { });
+        });
+
+        it('leaves a queued stale reconcile order untouched when the picker opens', async () => {
+            const reconcileSpy = sinon.spy(deviceManager, 'reconcile');
+
+            let quickPick: any;
+            const originalCreateQuickPick = vscode.window.createQuickPick;
+            sinon.stub(vscode.window, 'createQuickPick').callsFake(() => {
+                quickPick = originalCreateQuickPick();
+                return quickPick;
+            });
+
+            deviceManager.submitReconcile('stale');
+
+            const promptPromise = userInputManager.promptForHost();
+            await new Promise<void>(resolve => {
+                setTimeout(resolve, 10);
+            });
+
+            expect(reconcileSpy.called).to.be.false;
+            expect(deviceManager.getPendingReconcile()).to.include({ reason: 'stale' });
+
+            quickPick?.hide();
+            await promptPromise.catch(() => { });
+        });
+
+        it('fulfills a live non-stale reconcile order while the picker is open', async () => {
+            const reconcileSpy = sinon.spy(deviceManager, 'reconcile');
+
+            let quickPick: any;
+            const originalCreateQuickPick = vscode.window.createQuickPick;
+            sinon.stub(vscode.window, 'createQuickPick').callsFake(() => {
+                quickPick = originalCreateQuickPick();
+                return quickPick;
+            });
+
+            const promptPromise = userInputManager.promptForHost();
+            await new Promise<void>(resolve => {
+                setTimeout(resolve, 10);
+            });
+            expect(reconcileSpy.called).to.be.false;
+
+            //a trigger fires while the picker is open
+            deviceManager.submitReconcile('sleep');
+
+            expect(reconcileSpy.calledOnce).to.be.true;
+            expect(deviceManager.getPendingReconcile()).to.be.null;
+
             quickPick?.hide();
             await promptPromise.catch(() => { });
         });

--- a/src/managers/UserInputManager.ts
+++ b/src/managers/UserInputManager.ts
@@ -241,18 +241,14 @@ export class UserInputManager {
 
         let scanTimeoutId: NodeJS.Timeout | null = null;
 
-        // On open: fulfill queued real orders (network/sleep/refresh-clicked/...). Queued
-        // `stale` orders are deliberately left alone — routine freshness is the 7s
-        // fallback's job (below), so opening the picker never scans the network by itself.
-        // (spec's quick-pick table: "on open, fulfills pending orders for any reason except stale")
-        //any broadcast taken here has a real (non-stale) trigger, so a scan definitely started
+        //on open: fulfill queued real orders. `stale` is left alone - routine freshness is the
+        //fallback's job (below), so opening the picker never scans the network by itself
         let hasScanned = this.deviceManager.fulfillOrders({ types: ['broadcast', 'reconcile'], except: ['stale'] })
             .some(taken => taken.type === 'broadcast');
 
         this.deviceManager.on('order-submitted', (order) => {
+            //a real broadcast means a scan is happening - the fallback isn't needed
             if (order.type === 'broadcast' && order.reason !== 'stale') {
-                // Suppress the 7s fallback even if another visible consumer fulfills this
-                // order — a scan is happening either way
                 hasScanned = true;
                 if (scanTimeoutId) {
                     clearTimeout(scanTimeoutId);
@@ -266,17 +262,13 @@ export class UserInputManager {
             if (hasScanned) {
                 return;
             }
-            // Nothing scanned since the picker opened — fulfill any pending broadcast with no
-            // exceptions. When the system is genuinely stale, the 30-minute timer has already
-            // queued a `stale` order (visible views ignore it live, so it waits here); its
-            // fulfillment is staleness-gated, so this never over-scans. If nothing is pending,
-            // nothing happens.
+            //nothing scanned since the picker opened - fulfill any pending broadcast, `stale`
+            //included (its fulfillment is staleness-gated, so this never over-scans)
             this.deviceManager.fulfillOrders({ types: ['broadcast'] });
         }, this.scanTimeoutMs);
 
         function dispose() {
-            // The fallback timer must not outlive the picker — a leaked timer would fire a
-            // broadcast on a picker that's already closed
+            //the fallback timer must not outlive the picker
             if (scanTimeoutId) {
                 clearTimeout(scanTimeoutId);
                 scanTimeoutId = null;
@@ -294,8 +286,6 @@ export class UserInputManager {
                     if (selectedDevice.label === manualLabel) {
                         deferred.resolve({ manual: true });
                     } else if (selectedDevice.label === scanForDevicesLabel) {
-                        //an explicit "scan" click is the refresh-clicked trigger — submit orders;
-                        //this picker (or another visible view) fulfills them immediately
                         this.deviceManager.submitOrders([
                             { type: 'broadcast', reason: 'refresh-clicked' },
                             { type: 'reconcile', reason: 'refresh-clicked' }
@@ -449,8 +439,6 @@ export class UserInputManager {
 
         quickPick.onDidTriggerButton(button => {
             if (button.tooltip === SCAN_FOR_DEVICES) {
-                //an explicit "scan" click is the refresh-clicked trigger — submit orders;
-                //this picker (or another visible view) fulfills them immediately
                 this.deviceManager.submitOrders([
                     { type: 'broadcast', reason: 'refresh-clicked' },
                     { type: 'reconcile', reason: 'refresh-clicked' }

--- a/src/managers/UserInputManager.ts
+++ b/src/managers/UserInputManager.ts
@@ -305,7 +305,7 @@ export class UserInputManager {
                         const device = (selectedDevice as any).device as RokuDevice;
                         // if the selected device isn't healthy, show an error and keep the picker open so they can select a different device
                         setBusy(true);
-                        const isHealthy = await this.deviceManager.deviceEngaged(device);
+                        const isHealthy = await this.deviceManager.healthCheckDevice(device);
                         setBusy(false);
                         if (!isHealthy) {
                             await vscode.window.showErrorMessage(`The selected device (${device.ip}) is not responding.`);

--- a/src/managers/UserInputManager.ts
+++ b/src/managers/UserInputManager.ts
@@ -299,7 +299,7 @@ export class UserInputManager {
                     } else if (selectedDevice.label === scanForDevicesLabel) {
                         //an explicit "scan" click is the refresh-clicked trigger — submit orders;
                         //this picker (or another visible view) fulfills them immediately
-                        this.deviceManager.submitOrder('refresh-clicked');
+                        this.deviceManager.submitOrders([{ type: 'broadcast', reason: 'refresh-clicked' }, { type: 'reconcile', reason: 'refresh-clicked' }]);
                         return;
                     } else {
                         const device = (selectedDevice as any).device as RokuDevice;
@@ -451,7 +451,7 @@ export class UserInputManager {
             if (button.tooltip === SCAN_FOR_DEVICES) {
                 //an explicit "scan" click is the refresh-clicked trigger — submit orders;
                 //this picker (or another visible view) fulfills them immediately
-                this.deviceManager.submitOrder('refresh-clicked');
+                this.deviceManager.submitOrders([{ type: 'broadcast', reason: 'refresh-clicked' }, { type: 'reconcile', reason: 'refresh-clicked' }]);
             } else if (button.tooltip === CLEAR_DEVICE_LIST) {
                 this.deviceManager.clearCurrentDeviceList();
                 void util.showTimedNotification('Clearing device list');

--- a/src/managers/UserInputManager.ts
+++ b/src/managers/UserInputManager.ts
@@ -245,7 +245,7 @@ export class UserInputManager {
         // `stale` orders are deliberately left alone — routine freshness is the 7s
         // fallback's job (below), so opening the picker never scans the network by itself.
         // (spec's quick-pick table: "on open, fulfills pending orders for any reason except stale")
-        let hasScanned = this.deviceManager.fulfillOrders({ except: ['stale'] }).scanStarted;
+        let hasScanned = this.deviceManager.fulfillOrders({ types: ['broadcast', 'reconcile'], except: ['stale'] }).scanStarted;
 
         this.deviceManager.on('order-submitted', (order) => {
             if (order.type === 'broadcast' && order.reason !== 'stale') {

--- a/src/managers/UserInputManager.ts
+++ b/src/managers/UserInputManager.ts
@@ -245,7 +245,9 @@ export class UserInputManager {
         // `stale` orders are deliberately left alone — routine freshness is the 7s
         // fallback's job (below), so opening the picker never scans the network by itself.
         // (spec's quick-pick table: "on open, fulfills pending orders for any reason except stale")
-        let hasScanned = this.deviceManager.fulfillOrders({ types: ['broadcast', 'reconcile'], except: ['stale'] }).scanStarted;
+        //any broadcast taken here has a real (non-stale) trigger, so a scan definitely started
+        let hasScanned = this.deviceManager.fulfillOrders({ types: ['broadcast', 'reconcile'], except: ['stale'] })
+            .some(taken => taken.type === 'broadcast');
 
         this.deviceManager.on('order-submitted', (order) => {
             if (order.type === 'broadcast' && order.reason !== 'stale') {

--- a/src/managers/UserInputManager.ts
+++ b/src/managers/UserInputManager.ts
@@ -241,14 +241,11 @@ export class UserInputManager {
 
         let scanTimeoutId: NodeJS.Timeout | null = null;
 
-        // On open: fulfill a queued real order (network/sleep/refresh-clicked/...), forced. A
-        // queued `stale` order is deliberately left alone — routine freshness is the 7s
+        // On open: fulfill queued real orders (network/sleep/refresh-clicked/...). Queued
+        // `stale` orders are deliberately left alone — routine freshness is the 7s
         // fallback's job (below), so opening the picker never scans the network by itself.
         // (spec's quick-pick table: "on open, fulfills pending orders for any reason except stale")
-        let hasScanned = this.deviceManager.fulfillPendingBroadcast({ except: ['stale'] });
-
-        // On open, also fulfill a queued reconcile order (`stale` stays queued)
-        this.deviceManager.fulfillPendingReconcile({ except: ['stale'] });
+        let hasScanned = this.deviceManager.fulfillPendingOrders({ except: ['stale'] }).scanStarted;
 
         this.deviceManager.on('broadcast-ordered', (order) => {
             if (order.reason === 'stale') {
@@ -302,14 +299,13 @@ export class UserInputManager {
                     } else if (selectedDevice.label === scanForDevicesLabel) {
                         //an explicit "scan" click is the refresh-clicked trigger — submit orders;
                         //this picker (or another visible view) fulfills them immediately
-                        this.deviceManager.submitBroadcast('refresh-clicked');
-                        this.deviceManager.submitReconcile('refresh-clicked');
+                        this.deviceManager.submitRefreshOrders();
                         return;
                     } else {
                         const device = (selectedDevice as any).device as RokuDevice;
                         // if the selected device isn't healthy, show an error and keep the picker open so they can select a different device
                         setBusy(true);
-                        const isHealthy = await this.deviceManager.healthCheckDevice(device, true, false);
+                        const isHealthy = await this.deviceManager.deviceEngaged(device);
                         setBusy(false);
                         if (!isHealthy) {
                             await vscode.window.showErrorMessage(`The selected device (${device.ip}) is not responding.`);
@@ -455,8 +451,7 @@ export class UserInputManager {
             if (button.tooltip === SCAN_FOR_DEVICES) {
                 //an explicit "scan" click is the refresh-clicked trigger — submit orders;
                 //this picker (or another visible view) fulfills them immediately
-                this.deviceManager.submitBroadcast('refresh-clicked');
-                this.deviceManager.submitReconcile('refresh-clicked');
+                this.deviceManager.submitRefreshOrders();
             } else if (button.tooltip === CLEAR_DEVICE_LIST) {
                 this.deviceManager.clearCurrentDeviceList();
                 void util.showTimedNotification('Clearing device list');

--- a/src/managers/UserInputManager.ts
+++ b/src/managers/UserInputManager.ts
@@ -299,7 +299,7 @@ export class UserInputManager {
                     } else if (selectedDevice.label === scanForDevicesLabel) {
                         //an explicit "scan" click is the refresh-clicked trigger — submit orders;
                         //this picker (or another visible view) fulfills them immediately
-                        this.deviceManager.submitRefreshOrders();
+                        this.deviceManager.submitOrder('refresh-clicked');
                         return;
                     } else {
                         const device = (selectedDevice as any).device as RokuDevice;
@@ -451,7 +451,7 @@ export class UserInputManager {
             if (button.tooltip === SCAN_FOR_DEVICES) {
                 //an explicit "scan" click is the refresh-clicked trigger — submit orders;
                 //this picker (or another visible view) fulfills them immediately
-                this.deviceManager.submitRefreshOrders();
+                this.deviceManager.submitOrder('refresh-clicked');
             } else if (button.tooltip === CLEAR_DEVICE_LIST) {
                 this.deviceManager.clearCurrentDeviceList();
                 void util.showTimedNotification('Clearing device list');

--- a/src/managers/UserInputManager.ts
+++ b/src/managers/UserInputManager.ts
@@ -48,6 +48,12 @@ export class UserInputManager {
         private credentialStore: CredentialStore
     ) { }
 
+    /**
+     * How long the picker waits after open with no broadcast before fulfilling any pending
+     * order (including `stale`) as a routine freshness fallback. Overridable for tests.
+     */
+    private scanTimeoutMs = 7_000;
+
     public async promptForHostManual(): Promise<HostWithDeviceInfo | undefined> {
         while (true) {
             const value = await vscode.window.showInputBox({
@@ -233,25 +239,54 @@ export class UserInputManager {
             setBusy(false);
         }, disposables);
 
-        const scanTimeoutMs = 7_000;
         let scanTimeoutId: NodeJS.Timeout | null = null;
-        let hasScanned = this.deviceManager.scan();
-        this.deviceManager.on('scanNeeded-changed', () => {
+
+        // On open: fulfill a queued real order (network/sleep/refresh-clicked/...), forced. A
+        // queued `stale` order is deliberately left alone — routine freshness is the 7s
+        // fallback's job (below), so opening the picker never scans the network by itself.
+        // (spec's quick-pick table: "on open, fulfills pending orders for any reason except stale")
+        let hasScanned = this.deviceManager.fulfillPendingBroadcast({ except: ['stale'] });
+
+        // On open, also fulfill a queued reconcile order (`stale` stays queued)
+        this.deviceManager.fulfillPendingReconcile({ except: ['stale'] });
+
+        this.deviceManager.on('broadcast-ordered', (order) => {
+            if (order.reason === 'stale') {
+                return;
+            }
+            // Suppress the 7s fallback even if another visible consumer fulfills this order —
+            // a scan is happening either way
             hasScanned = true;
             if (scanTimeoutId) {
                 clearTimeout(scanTimeoutId);
                 scanTimeoutId = null;
             }
-            this.deviceManager.scan();
+            this.deviceManager.fulfillPendingBroadcast({ except: ['stale'] });
         }, disposables);
+
+        this.deviceManager.on('reconcile-ordered', () => {
+            this.deviceManager.fulfillPendingReconcile({ except: ['stale'] });
+        }, disposables);
+
         scanTimeoutId = setTimeout(() => {
             if (hasScanned) {
                 return;
             }
-            this.deviceManager.scan();
-        }, scanTimeoutMs);
+            // Nothing scanned since the picker opened — fulfill whatever's pending with no
+            // exceptions. When the system is genuinely stale, the 30-minute timer has already
+            // queued a `stale` order (visible views ignore it live, so it waits here); its
+            // fulfillment is staleness-gated, so this never over-scans. If nothing is pending,
+            // nothing happens.
+            this.deviceManager.fulfillPendingBroadcast();
+        }, this.scanTimeoutMs);
 
         function dispose() {
+            // The fallback timer must not outlive the picker — a leaked timer would fire a
+            // broadcast on a picker that's already closed
+            if (scanTimeoutId) {
+                clearTimeout(scanTimeoutId);
+                scanTimeoutId = null;
+            }
             for (const disposable of disposables) {
                 disposable.dispose();
             }
@@ -265,7 +300,10 @@ export class UserInputManager {
                     if (selectedDevice.label === manualLabel) {
                         deferred.resolve({ manual: true });
                     } else if (selectedDevice.label === scanForDevicesLabel) {
-                        this.deviceManager.refresh(true);
+                        //an explicit "scan" click is the refresh-clicked trigger — submit orders;
+                        //this picker (or another visible view) fulfills them immediately
+                        this.deviceManager.submitBroadcast('refresh-clicked');
+                        this.deviceManager.submitReconcile('refresh-clicked');
                         return;
                     } else {
                         const device = (selectedDevice as any).device as RokuDevice;
@@ -415,9 +453,12 @@ export class UserInputManager {
 
         quickPick.onDidTriggerButton(button => {
             if (button.tooltip === SCAN_FOR_DEVICES) {
-                this.deviceManager.refresh(true);
+                //an explicit "scan" click is the refresh-clicked trigger — submit orders;
+                //this picker (or another visible view) fulfills them immediately
+                this.deviceManager.submitBroadcast('refresh-clicked');
+                this.deviceManager.submitReconcile('refresh-clicked');
             } else if (button.tooltip === CLEAR_DEVICE_LIST) {
-                this.deviceManager.clearCurrentDeviceList().catch(() => { });
+                this.deviceManager.clearCurrentDeviceList();
                 void util.showTimedNotification('Clearing device list');
             } else if (button.tooltip === ENABLE_DEVICE_DISCOVERY) {
                 void util.setConfigurationValueAtUserOrClosestScope('brightscript.deviceDiscovery.enabled', true);

--- a/src/managers/UserInputManager.ts
+++ b/src/managers/UserInputManager.ts
@@ -245,36 +245,31 @@ export class UserInputManager {
         // `stale` orders are deliberately left alone — routine freshness is the 7s
         // fallback's job (below), so opening the picker never scans the network by itself.
         // (spec's quick-pick table: "on open, fulfills pending orders for any reason except stale")
-        let hasScanned = this.deviceManager.fulfillPendingOrders({ except: ['stale'] }).scanStarted;
+        let hasScanned = this.deviceManager.fulfillOrders({ except: ['stale'] }).scanStarted;
 
-        this.deviceManager.on('broadcast-ordered', (order) => {
-            if (order.reason === 'stale') {
-                return;
+        this.deviceManager.on('order-submitted', (order) => {
+            if (order.type === 'broadcast' && order.reason !== 'stale') {
+                // Suppress the 7s fallback even if another visible consumer fulfills this
+                // order — a scan is happening either way
+                hasScanned = true;
+                if (scanTimeoutId) {
+                    clearTimeout(scanTimeoutId);
+                    scanTimeoutId = null;
+                }
             }
-            // Suppress the 7s fallback even if another visible consumer fulfills this order —
-            // a scan is happening either way
-            hasScanned = true;
-            if (scanTimeoutId) {
-                clearTimeout(scanTimeoutId);
-                scanTimeoutId = null;
-            }
-            this.deviceManager.fulfillPendingBroadcast({ except: ['stale'] });
-        }, disposables);
-
-        this.deviceManager.on('reconcile-ordered', () => {
-            this.deviceManager.fulfillPendingReconcile({ except: ['stale'] });
+            this.deviceManager.fulfillOrders({ types: [order.type], except: ['stale'] });
         }, disposables);
 
         scanTimeoutId = setTimeout(() => {
             if (hasScanned) {
                 return;
             }
-            // Nothing scanned since the picker opened — fulfill whatever's pending with no
+            // Nothing scanned since the picker opened — fulfill any pending broadcast with no
             // exceptions. When the system is genuinely stale, the 30-minute timer has already
             // queued a `stale` order (visible views ignore it live, so it waits here); its
             // fulfillment is staleness-gated, so this never over-scans. If nothing is pending,
             // nothing happens.
-            this.deviceManager.fulfillPendingBroadcast();
+            this.deviceManager.fulfillOrders({ types: ['broadcast'] });
         }, this.scanTimeoutMs);
 
         function dispose() {
@@ -299,7 +294,10 @@ export class UserInputManager {
                     } else if (selectedDevice.label === scanForDevicesLabel) {
                         //an explicit "scan" click is the refresh-clicked trigger — submit orders;
                         //this picker (or another visible view) fulfills them immediately
-                        this.deviceManager.submitOrders([{ type: 'broadcast', reason: 'refresh-clicked' }, { type: 'reconcile', reason: 'refresh-clicked' }]);
+                        this.deviceManager.submitOrders([
+                            { type: 'broadcast', reason: 'refresh-clicked' },
+                            { type: 'reconcile', reason: 'refresh-clicked' }
+                        ]);
                         return;
                     } else {
                         const device = (selectedDevice as any).device as RokuDevice;
@@ -451,7 +449,10 @@ export class UserInputManager {
             if (button.tooltip === SCAN_FOR_DEVICES) {
                 //an explicit "scan" click is the refresh-clicked trigger — submit orders;
                 //this picker (or another visible view) fulfills them immediately
-                this.deviceManager.submitOrders([{ type: 'broadcast', reason: 'refresh-clicked' }, { type: 'reconcile', reason: 'refresh-clicked' }]);
+                this.deviceManager.submitOrders([
+                    { type: 'broadcast', reason: 'refresh-clicked' },
+                    { type: 'reconcile', reason: 'refresh-clicked' }
+                ]);
             } else if (button.tooltip === CLEAR_DEVICE_LIST) {
                 this.deviceManager.clearCurrentDeviceList();
                 void util.showTimedNotification('Clearing device list');

--- a/src/managers/UserInputManager.ts
+++ b/src/managers/UserInputManager.ts
@@ -54,7 +54,7 @@ export class UserInputManager {
      */
     private scanTimeoutMs = 7_000;
 
-    public async promptForHostManual(): Promise<HostWithDeviceInfo | undefined> {
+    private async promptForHostManual(): Promise<HostWithDeviceInfo | undefined> {
         while (true) {
             const value = await vscode.window.showInputBox({
                 placeHolder: 'Please enter the IP address of your Roku device',

--- a/src/viewProviders/DevicesViewProvider.spec.ts
+++ b/src/viewProviders/DevicesViewProvider.spec.ts
@@ -99,7 +99,7 @@ describe('DevicesViewProvider', () => {
             getDeviceDisplayName: (device: any) => device.key,
             getIconPath: () => undefined,
             hasDeviceCache: () => false,
-            deviceEngaged: () => Promise.resolve(true),
+            getDeviceInfo: () => Promise.resolve({}),
             broadcast: sinon.stub().returns(true),
             reconcile: sinon.stub(),
             submitBroadcast: (reason: string) => {

--- a/src/viewProviders/DevicesViewProvider.spec.ts
+++ b/src/viewProviders/DevicesViewProvider.spec.ts
@@ -88,6 +88,10 @@ describe('DevicesViewProvider', () => {
 
     function createProvider(devices: any[], options?: { storedPasswords?: Record<string, string> }) {
         const emitter = new EventEmitter();
+        //a real pending-slot implementation backs the fake so the take/fulfill semantics are
+        //exercised for real; execution routes to the broadcast/reconcile stubs below
+        let pendingBroadcast: any = null;
+        let pendingReconcile: any = null;
         const deviceManager: any = {
             on: (event: string, handler: any) => emitter.on(event, handler),
             getAllDevices: () => devices,
@@ -95,8 +99,42 @@ describe('DevicesViewProvider', () => {
             getDeviceDisplayName: (device: any) => device.key,
             getIconPath: () => undefined,
             hasDeviceCache: () => false,
-            refresh: () => undefined,
-            healthCheckDevice: () => Promise.resolve()
+            healthCheckDevice: () => Promise.resolve(),
+            broadcast: sinon.stub().returns(true),
+            reconcile: sinon.stub(),
+            submitBroadcast: (reason: string) => {
+                const order = { reason: reason, timestamp: Date.now() };
+                if (!(pendingBroadcast && pendingBroadcast.reason !== 'stale' && reason === 'stale')) {
+                    pendingBroadcast = order;
+                }
+                emitter.emit('broadcast-ordered', order);
+            },
+            submitReconcile: (reason: string) => {
+                const order = { reason: reason, timestamp: Date.now() };
+                if (!(pendingReconcile && pendingReconcile.reason !== 'stale' && reason === 'stale')) {
+                    pendingReconcile = order;
+                }
+                emitter.emit('reconcile-ordered', order);
+            },
+            getPendingBroadcast: () => pendingBroadcast,
+            getPendingReconcile: () => pendingReconcile,
+            fulfillPendingBroadcast: (fulfillOptions?: { except?: string[] }) => {
+                if (!pendingBroadcast || fulfillOptions?.except?.includes(pendingBroadcast.reason)) {
+                    return false;
+                }
+                const order = pendingBroadcast;
+                pendingBroadcast = null;
+                return deviceManager.broadcast(order.reason !== 'stale');
+            },
+            fulfillPendingReconcile: (fulfillOptions?: { except?: string[] }) => {
+                if (!pendingReconcile || fulfillOptions?.except?.includes(pendingReconcile.reason)) {
+                    return false;
+                }
+                const order = pendingReconcile;
+                pendingReconcile = null;
+                deviceManager.reconcile(order.reason === 'refresh-clicked');
+                return true;
+            }
         };
         const credentialStore: any = {
             on: () => undefined,
@@ -491,6 +529,81 @@ describe('DevicesViewProvider', () => {
             });
 
             expect(treeChanged.called).to.be.false;
+        });
+    });
+
+    describe('order fulfillment (spec: tree-view table)', () => {
+        it('fulfills a live non-stale broadcast order while visible (forced)', () => {
+            const { provider, deviceManager } = createProvider([]);
+            provider['visible'] = true;
+
+            deviceManager.submitBroadcast('network');
+
+            expect(deviceManager.broadcast.calledOnceWith(true)).to.be.true;
+            expect(deviceManager.getPendingBroadcast()).to.be.null;
+        });
+
+        it('fulfills a live reconcile order with force only for refresh-clicked', () => {
+            const { provider, deviceManager } = createProvider([]);
+            provider['visible'] = true;
+
+            deviceManager.submitReconcile('config-changed');
+            expect(deviceManager.reconcile.calledOnceWith(false)).to.be.true;
+
+            deviceManager.reconcile.resetHistory();
+            deviceManager.submitReconcile('refresh-clicked');
+            expect(deviceManager.reconcile.calledOnceWith(true)).to.be.true;
+        });
+
+        it('ignores live stale orders while visible, leaving them pending', () => {
+            const { provider, deviceManager } = createProvider([]);
+            provider['visible'] = true;
+
+            deviceManager.submitBroadcast('stale');
+            deviceManager.submitReconcile('stale');
+
+            expect(deviceManager.broadcast.called).to.be.false;
+            expect(deviceManager.reconcile.called).to.be.false;
+            expect(deviceManager.getPendingBroadcast()).to.include({ reason: 'stale' });
+            expect(deviceManager.getPendingReconcile()).to.include({ reason: 'stale' });
+        });
+
+        it('leaves live orders pending while hidden', () => {
+            const { deviceManager } = createProvider([]);
+
+            deviceManager.submitBroadcast('sleep');
+            deviceManager.submitReconcile('sleep');
+
+            expect(deviceManager.broadcast.called).to.be.false;
+            expect(deviceManager.reconcile.called).to.be.false;
+            expect(deviceManager.getPendingBroadcast()).to.include({ reason: 'sleep' });
+            expect(deviceManager.getPendingReconcile()).to.include({ reason: 'sleep' });
+        });
+
+        it('fulfills orders queued while hidden when the panel becomes visible (ALL reasons)', () => {
+            const { provider, deviceManager } = createProvider([]);
+
+            deviceManager.submitBroadcast('network');
+            deviceManager.submitReconcile('refresh-clicked');
+
+            provider['visible'] = true;
+            provider['fulfillPendingOrders']();
+
+            expect(deviceManager.broadcast.calledOnceWith(true)).to.be.true;
+            expect(deviceManager.reconcile.calledOnceWith(true)).to.be.true;
+            expect(deviceManager.getPendingBroadcast()).to.be.null;
+            expect(deviceManager.getPendingReconcile()).to.be.null;
+        });
+
+        it('fulfills a queued stale broadcast on open without forcing (staleness-gated)', () => {
+            const { provider, deviceManager } = createProvider([]);
+
+            deviceManager.submitBroadcast('stale');
+
+            provider['visible'] = true;
+            provider['fulfillPendingOrders']();
+
+            expect(deviceManager.broadcast.calledOnceWith(false)).to.be.true;
         });
     });
 });

--- a/src/viewProviders/DevicesViewProvider.spec.ts
+++ b/src/viewProviders/DevicesViewProvider.spec.ts
@@ -110,11 +110,11 @@ describe('DevicesViewProvider', () => {
             },
             getPendingBroadcastReasons: () => [...pendingBroadcastReasons],
             getPendingReconcileReasons: () => [...pendingReconcileReasons],
-            fulfillOrders: (fulfillOptions?: { types?: string[]; except?: string[] }) => {
-                const types = fulfillOptions?.types ?? ['broadcast', 'reconcile'];
+            fulfillOrders: (fulfillOptions: { types: string[]; except?: string[] }) => {
+                const types = fulfillOptions.types;
                 const result = { scanStarted: false, reconciled: false };
                 if (types.includes('broadcast')) {
-                    const triggers = [...pendingBroadcastReasons].filter(x => !fulfillOptions?.except?.includes(x));
+                    const triggers = [...pendingBroadcastReasons].filter(x => !fulfillOptions.except?.includes(x));
                     if (triggers.length > 0) {
                         const reasons = [...pendingBroadcastReasons];
                         pendingBroadcastReasons.clear();
@@ -122,7 +122,7 @@ describe('DevicesViewProvider', () => {
                     }
                 }
                 if (types.includes('reconcile')) {
-                    const triggers = [...pendingReconcileReasons].filter(x => !fulfillOptions?.except?.includes(x));
+                    const triggers = [...pendingReconcileReasons].filter(x => !fulfillOptions.except?.includes(x));
                     if (triggers.length > 0) {
                         const reasons = [...pendingReconcileReasons];
                         pendingReconcileReasons.clear();

--- a/src/viewProviders/DevicesViewProvider.spec.ts
+++ b/src/viewProviders/DevicesViewProvider.spec.ts
@@ -582,14 +582,33 @@ describe('DevicesViewProvider', () => {
             expect(deviceManager.getPendingReconcileReasons()).to.include('sleep');
         });
 
+        //a minimal TreeView fake: enough for setTreeView to register handlers and for tests to
+        //toggle visibility through the real onDidChangeVisibility path
+        function createTreeView(visible: boolean) {
+            const emitter = new EventEmitter();
+            const treeView = {
+                visible: visible,
+                onDidChangeVisibility: (cb: (e: { visible: boolean }) => void) => emitter.on('visibility', cb),
+                onDidExpandElement: () => undefined
+            } as any;
+            return {
+                treeView: treeView,
+                setVisible: (value: boolean) => {
+                    treeView.visible = value;
+                    emitter.emit('visibility', { visible: value });
+                }
+            };
+        }
+
         it('fulfills orders queued while hidden when the panel becomes visible (ALL reasons)', () => {
             const { provider, deviceManager } = createProvider([]);
+            const { treeView, setVisible } = createTreeView(false);
+            provider.setTreeView(treeView);
 
             deviceManager.submitBroadcast('network');
             deviceManager.submitReconcile('refresh-clicked');
 
-            provider['visible'] = true;
-            provider['fulfillPendingOrders']();
+            setVisible(true);
 
             expect(deviceManager.broadcast.calledOnceWith(['network'])).to.be.true;
             expect(deviceManager.reconcile.calledOnceWith(['refresh-clicked'])).to.be.true;
@@ -597,27 +616,42 @@ describe('DevicesViewProvider', () => {
             expect(deviceManager.getPendingReconcileReasons()).to.be.empty;
         });
 
+        it('consumes queued startup orders when the panel is already open at activation', () => {
+            const { provider, deviceManager } = createProvider([]);
+
+            deviceManager.submitBroadcast('startup');
+            deviceManager.submitReconcile('startup');
+
+            //panel already visible when setTreeView runs — the startup sync path fulfills
+            provider.setTreeView(createTreeView(true).treeView);
+
+            expect(deviceManager.broadcast.calledOnceWith(['startup'])).to.be.true;
+            expect(deviceManager.reconcile.calledOnceWith(['startup'])).to.be.true;
+        });
+
         it('fulfills a queued stale broadcast on open with its reason intact (staleness-gated inside)', () => {
             const { provider, deviceManager } = createProvider([]);
+            const { treeView, setVisible } = createTreeView(false);
+            provider.setTreeView(treeView);
 
             deviceManager.submitBroadcast('stale');
 
-            provider['visible'] = true;
-            provider['fulfillPendingOrders']();
+            setVisible(true);
 
             expect(deviceManager.broadcast.calledOnceWith(['stale'])).to.be.true;
         });
 
         it('accumulated reasons are fulfilled together in one execution', () => {
             const { provider, deviceManager } = createProvider([]);
+            const { treeView, setVisible } = createTreeView(false);
+            provider.setTreeView(treeView);
 
             //multiple triggers fire while no view is visible — each queues its own reason
             deviceManager.submitBroadcast('stale');
             deviceManager.submitBroadcast('sleep');
             deviceManager.submitBroadcast('network');
 
-            provider['visible'] = true;
-            provider['fulfillPendingOrders']();
+            setVisible(true);
 
             //one scan satisfies all of them
             expect(deviceManager.broadcast.calledOnce).to.be.true;

--- a/src/viewProviders/DevicesViewProvider.spec.ts
+++ b/src/viewProviders/DevicesViewProvider.spec.ts
@@ -102,13 +102,11 @@ describe('DevicesViewProvider', () => {
             getDeviceInfo: () => Promise.resolve({}),
             broadcast: sinon.stub().returns(true),
             reconcile: sinon.stub(),
-            submitBroadcast: (reason: string) => {
-                pendingBroadcastReasons.add(reason);
-                emitter.emit('broadcast-ordered', { reason: reason, timestamp: Date.now() });
-            },
-            submitReconcile: (reason: string) => {
-                pendingReconcileReasons.add(reason);
-                emitter.emit('reconcile-ordered', { reason: reason, timestamp: Date.now() });
+            submitOrders: (orders: Array<{ type: string; reason: string }>) => {
+                for (const order of orders) {
+                    (order.type === 'broadcast' ? pendingBroadcastReasons : pendingReconcileReasons).add(order.reason);
+                    emitter.emit(`${order.type}-ordered`, { reason: order.reason, timestamp: Date.now() });
+                }
             },
             getPendingBroadcastReasons: () => [...pendingBroadcastReasons],
             getPendingReconcileReasons: () => [...pendingReconcileReasons],
@@ -545,7 +543,7 @@ describe('DevicesViewProvider', () => {
             const { provider, deviceManager } = createProvider([]);
             provider['visible'] = true;
 
-            deviceManager.submitBroadcast('network');
+            deviceManager.submitOrders([{ type: 'broadcast', reason: 'network' }]);
 
             expect(deviceManager.broadcast.calledOnceWith(['network'])).to.be.true;
             expect(deviceManager.getPendingBroadcastReasons()).to.be.empty;
@@ -555,11 +553,11 @@ describe('DevicesViewProvider', () => {
             const { provider, deviceManager } = createProvider([]);
             provider['visible'] = true;
 
-            deviceManager.submitReconcile('config-changed');
+            deviceManager.submitOrders([{ type: 'reconcile', reason: 'config-changed' }]);
             expect(deviceManager.reconcile.calledOnceWith(['config-changed'])).to.be.true;
 
             deviceManager.reconcile.resetHistory();
-            deviceManager.submitReconcile('refresh-clicked');
+            deviceManager.submitOrders([{ type: 'reconcile', reason: 'refresh-clicked' }]);
             expect(deviceManager.reconcile.calledOnceWith(['refresh-clicked'])).to.be.true;
         });
 
@@ -567,8 +565,8 @@ describe('DevicesViewProvider', () => {
             const { provider, deviceManager } = createProvider([]);
             provider['visible'] = true;
 
-            deviceManager.submitBroadcast('stale');
-            deviceManager.submitReconcile('stale');
+            deviceManager.submitOrders([{ type: 'broadcast', reason: 'stale' }]);
+            deviceManager.submitOrders([{ type: 'reconcile', reason: 'stale' }]);
 
             expect(deviceManager.broadcast.called).to.be.false;
             expect(deviceManager.reconcile.called).to.be.false;
@@ -579,8 +577,8 @@ describe('DevicesViewProvider', () => {
         it('leaves live orders pending while hidden', () => {
             const { deviceManager } = createProvider([]);
 
-            deviceManager.submitBroadcast('sleep');
-            deviceManager.submitReconcile('sleep');
+            deviceManager.submitOrders([{ type: 'broadcast', reason: 'sleep' }]);
+            deviceManager.submitOrders([{ type: 'reconcile', reason: 'sleep' }]);
 
             expect(deviceManager.broadcast.called).to.be.false;
             expect(deviceManager.reconcile.called).to.be.false;
@@ -623,8 +621,8 @@ describe('DevicesViewProvider', () => {
             const { treeView, setVisible } = createTreeView(false);
             provider.setTreeView(treeView);
 
-            deviceManager.submitBroadcast('network');
-            deviceManager.submitReconcile('refresh-clicked');
+            deviceManager.submitOrders([{ type: 'broadcast', reason: 'network' }]);
+            deviceManager.submitOrders([{ type: 'reconcile', reason: 'refresh-clicked' }]);
 
             setVisible(true);
 
@@ -637,8 +635,8 @@ describe('DevicesViewProvider', () => {
         it('consumes queued startup orders when the panel is already open at activation', () => {
             const { provider, deviceManager } = createProvider([]);
 
-            deviceManager.submitBroadcast('startup');
-            deviceManager.submitReconcile('startup');
+            deviceManager.submitOrders([{ type: 'broadcast', reason: 'startup' }]);
+            deviceManager.submitOrders([{ type: 'reconcile', reason: 'startup' }]);
 
             //panel already visible when setTreeView runs — the startup sync path fulfills
             provider.setTreeView(createTreeView(true).treeView);
@@ -652,7 +650,7 @@ describe('DevicesViewProvider', () => {
             const { treeView, setVisible } = createTreeView(false);
             provider.setTreeView(treeView);
 
-            deviceManager.submitBroadcast('stale');
+            deviceManager.submitOrders([{ type: 'broadcast', reason: 'stale' }]);
 
             setVisible(true);
 
@@ -665,9 +663,9 @@ describe('DevicesViewProvider', () => {
             provider.setTreeView(treeView);
 
             //multiple triggers fire while no view is visible — each queues its own reason
-            deviceManager.submitBroadcast('stale');
-            deviceManager.submitBroadcast('sleep');
-            deviceManager.submitBroadcast('network');
+            deviceManager.submitOrders([{ type: 'broadcast', reason: 'stale' }]);
+            deviceManager.submitOrders([{ type: 'broadcast', reason: 'sleep' }]);
+            deviceManager.submitOrders([{ type: 'broadcast', reason: 'network' }]);
 
             setVisible(true);
 

--- a/src/viewProviders/DevicesViewProvider.spec.ts
+++ b/src/viewProviders/DevicesViewProvider.spec.ts
@@ -334,6 +334,8 @@ describe('DevicesViewProvider', () => {
             ];
             await vscodeContextManager.set('activeHost', '2.2.2.2');
             const { provider } = createProvider(devices);
+            //decorations are populated by the first visible render (no eager constructor read)
+            await provider.getChildren();
             const decorationProvider = provider['decorationProvider'];
 
             const activeDecoration = decorationProvider.provideFileDecoration({ scheme: 'roku-device', path: '/stb2' } as any);
@@ -351,6 +353,7 @@ describe('DevicesViewProvider', () => {
             const devices = [makeDevice({ key: 'stb1', ip: '1.1.1.1', deviceState: 'offline' })];
             await vscodeContextManager.set('activeHost', '1.1.1.1');
             const { provider } = createProvider(devices);
+            await provider.getChildren();
 
             const decoration = provider['decorationProvider'].provideFileDecoration({ scheme: 'roku-device', path: '/stb1' } as any);
             expect(decoration?.badge).to.equal('⭐');
@@ -364,6 +367,9 @@ describe('DevicesViewProvider', () => {
             ];
             await vscodeContextManager.set('activeHost', '1.1.1.1');
             const { provider } = createProvider(devices);
+            //live active-device moves only re-render while the panel is visible
+            provider['visible'] = true;
+            await provider.getChildren();
             const decorationProvider = provider['decorationProvider'];
 
             let treeChanges = 0;
@@ -599,6 +605,18 @@ describe('DevicesViewProvider', () => {
                 }
             };
         }
+
+        it('does not read the device list while hidden — marks it dirty for the next visible render', () => {
+            const { provider, deviceManager } = createProvider([]);
+            const readSpy = sinon.spy(deviceManager, 'getAllDevices');
+
+            //a devices-changed arrives while the panel is hidden: reading would trigger
+            //lazy hydration (network traffic) that nobody can see
+            provider['handleDevicesChanged']();
+
+            expect(readSpy.called).to.be.false;
+            expect(provider['devicesDirty']).to.be.true;
+        });
 
         it('fulfills orders queued while hidden when the panel becomes visible (ALL reasons)', () => {
             const { provider, deviceManager } = createProvider([]);

--- a/src/viewProviders/DevicesViewProvider.spec.ts
+++ b/src/viewProviders/DevicesViewProvider.spec.ts
@@ -111,26 +111,23 @@ describe('DevicesViewProvider', () => {
             getPendingBroadcastReasons: () => [...pendingBroadcastReasons],
             getPendingReconcileReasons: () => [...pendingReconcileReasons],
             fulfillOrders: (fulfillOptions: { types: string[]; except?: string[] }) => {
-                const types = fulfillOptions.types;
-                const result = { scanStarted: false, reconciled: false };
-                if (types.includes('broadcast')) {
-                    const triggers = [...pendingBroadcastReasons].filter(x => !fulfillOptions.except?.includes(x));
-                    if (triggers.length > 0) {
-                        const reasons = [...pendingBroadcastReasons];
-                        pendingBroadcastReasons.clear();
-                        result.scanStarted = deviceManager.broadcast(reasons);
+                const taken: Array<{ type: string; reasons: string[] }> = [];
+                for (const type of fulfillOptions.types) {
+                    const set = type === 'broadcast' ? pendingBroadcastReasons : pendingReconcileReasons;
+                    const triggers = [...set].filter(x => !fulfillOptions.except?.includes(x));
+                    if (triggers.length === 0) {
+                        continue;
                     }
-                }
-                if (types.includes('reconcile')) {
-                    const triggers = [...pendingReconcileReasons].filter(x => !fulfillOptions.except?.includes(x));
-                    if (triggers.length > 0) {
-                        const reasons = [...pendingReconcileReasons];
-                        pendingReconcileReasons.clear();
+                    const reasons = [...set];
+                    set.clear();
+                    taken.push({ type: type, reasons: reasons });
+                    if (type === 'broadcast') {
+                        deviceManager.broadcast(reasons);
+                    } else {
                         deviceManager.reconcile(reasons);
-                        result.reconciled = true;
                     }
                 }
-                return result;
+                return taken;
             }
         };
         const credentialStore: any = {

--- a/src/viewProviders/DevicesViewProvider.spec.ts
+++ b/src/viewProviders/DevicesViewProvider.spec.ts
@@ -88,10 +88,10 @@ describe('DevicesViewProvider', () => {
 
     function createProvider(devices: any[], options?: { storedPasswords?: Record<string, string> }) {
         const emitter = new EventEmitter();
-        //a real pending-slot implementation backs the fake so the take/fulfill semantics are
+        //a real pending-set implementation backs the fake so the take/fulfill semantics are
         //exercised for real; execution routes to the broadcast/reconcile stubs below
-        let pendingBroadcast: any = null;
-        let pendingReconcile: any = null;
+        const pendingBroadcastReasons = new Set<string>();
+        const pendingReconcileReasons = new Set<string>();
         const deviceManager: any = {
             on: (event: string, handler: any) => emitter.on(event, handler),
             getAllDevices: () => devices,
@@ -103,36 +103,34 @@ describe('DevicesViewProvider', () => {
             broadcast: sinon.stub().returns(true),
             reconcile: sinon.stub(),
             submitBroadcast: (reason: string) => {
-                const order = { reason: reason, timestamp: Date.now() };
-                if (!(pendingBroadcast && pendingBroadcast.reason !== 'stale' && reason === 'stale')) {
-                    pendingBroadcast = order;
-                }
-                emitter.emit('broadcast-ordered', order);
+                pendingBroadcastReasons.add(reason);
+                emitter.emit('broadcast-ordered', { reason: reason, timestamp: Date.now() });
             },
             submitReconcile: (reason: string) => {
-                const order = { reason: reason, timestamp: Date.now() };
-                if (!(pendingReconcile && pendingReconcile.reason !== 'stale' && reason === 'stale')) {
-                    pendingReconcile = order;
-                }
-                emitter.emit('reconcile-ordered', order);
+                pendingReconcileReasons.add(reason);
+                emitter.emit('reconcile-ordered', { reason: reason, timestamp: Date.now() });
             },
-            getPendingBroadcast: () => pendingBroadcast,
-            getPendingReconcile: () => pendingReconcile,
+            getPendingBroadcastReasons: () => [...pendingBroadcastReasons],
+            getPendingReconcileReasons: () => [...pendingReconcileReasons],
             fulfillPendingBroadcast: (fulfillOptions?: { except?: string[] }) => {
-                if (!pendingBroadcast || fulfillOptions?.except?.includes(pendingBroadcast.reason)) {
+                const reasons = [...pendingBroadcastReasons].filter(x => !fulfillOptions?.except?.includes(x));
+                if (reasons.length === 0) {
                     return false;
                 }
-                const order = pendingBroadcast;
-                pendingBroadcast = null;
-                return deviceManager.broadcast(order.reason);
+                for (const reason of reasons) {
+                    pendingBroadcastReasons.delete(reason);
+                }
+                return deviceManager.broadcast(reasons);
             },
             fulfillPendingReconcile: (fulfillOptions?: { except?: string[] }) => {
-                if (!pendingReconcile || fulfillOptions?.except?.includes(pendingReconcile.reason)) {
+                const reasons = [...pendingReconcileReasons].filter(x => !fulfillOptions?.except?.includes(x));
+                if (reasons.length === 0) {
                     return false;
                 }
-                const order = pendingReconcile;
-                pendingReconcile = null;
-                deviceManager.reconcile(order.reason);
+                for (const reason of reasons) {
+                    pendingReconcileReasons.delete(reason);
+                }
+                deviceManager.reconcile(reasons);
                 return true;
             }
         };
@@ -539,20 +537,20 @@ describe('DevicesViewProvider', () => {
 
             deviceManager.submitBroadcast('network');
 
-            expect(deviceManager.broadcast.calledOnceWith('network')).to.be.true;
-            expect(deviceManager.getPendingBroadcast()).to.be.null;
+            expect(deviceManager.broadcast.calledOnceWith(['network'])).to.be.true;
+            expect(deviceManager.getPendingBroadcastReasons()).to.be.empty;
         });
 
-        it('fulfills live reconcile orders, passing the reason through', () => {
+        it('fulfills live reconcile orders, passing the reasons through', () => {
             const { provider, deviceManager } = createProvider([]);
             provider['visible'] = true;
 
             deviceManager.submitReconcile('config-changed');
-            expect(deviceManager.reconcile.calledOnceWith('config-changed')).to.be.true;
+            expect(deviceManager.reconcile.calledOnceWith(['config-changed'])).to.be.true;
 
             deviceManager.reconcile.resetHistory();
             deviceManager.submitReconcile('refresh-clicked');
-            expect(deviceManager.reconcile.calledOnceWith('refresh-clicked')).to.be.true;
+            expect(deviceManager.reconcile.calledOnceWith(['refresh-clicked'])).to.be.true;
         });
 
         it('ignores live stale orders while visible, leaving them pending', () => {
@@ -564,8 +562,8 @@ describe('DevicesViewProvider', () => {
 
             expect(deviceManager.broadcast.called).to.be.false;
             expect(deviceManager.reconcile.called).to.be.false;
-            expect(deviceManager.getPendingBroadcast()).to.include({ reason: 'stale' });
-            expect(deviceManager.getPendingReconcile()).to.include({ reason: 'stale' });
+            expect(deviceManager.getPendingBroadcastReasons()).to.include('stale');
+            expect(deviceManager.getPendingReconcileReasons()).to.include('stale');
         });
 
         it('leaves live orders pending while hidden', () => {
@@ -576,8 +574,8 @@ describe('DevicesViewProvider', () => {
 
             expect(deviceManager.broadcast.called).to.be.false;
             expect(deviceManager.reconcile.called).to.be.false;
-            expect(deviceManager.getPendingBroadcast()).to.include({ reason: 'sleep' });
-            expect(deviceManager.getPendingReconcile()).to.include({ reason: 'sleep' });
+            expect(deviceManager.getPendingBroadcastReasons()).to.include('sleep');
+            expect(deviceManager.getPendingReconcileReasons()).to.include('sleep');
         });
 
         it('fulfills orders queued while hidden when the panel becomes visible (ALL reasons)', () => {
@@ -589,10 +587,10 @@ describe('DevicesViewProvider', () => {
             provider['visible'] = true;
             provider['fulfillPendingOrders']();
 
-            expect(deviceManager.broadcast.calledOnceWith('network')).to.be.true;
-            expect(deviceManager.reconcile.calledOnceWith('refresh-clicked')).to.be.true;
-            expect(deviceManager.getPendingBroadcast()).to.be.null;
-            expect(deviceManager.getPendingReconcile()).to.be.null;
+            expect(deviceManager.broadcast.calledOnceWith(['network'])).to.be.true;
+            expect(deviceManager.reconcile.calledOnceWith(['refresh-clicked'])).to.be.true;
+            expect(deviceManager.getPendingBroadcastReasons()).to.be.empty;
+            expect(deviceManager.getPendingReconcileReasons()).to.be.empty;
         });
 
         it('fulfills a queued stale broadcast on open with its reason intact (staleness-gated inside)', () => {
@@ -603,7 +601,24 @@ describe('DevicesViewProvider', () => {
             provider['visible'] = true;
             provider['fulfillPendingOrders']();
 
-            expect(deviceManager.broadcast.calledOnceWith('stale')).to.be.true;
+            expect(deviceManager.broadcast.calledOnceWith(['stale'])).to.be.true;
+        });
+
+        it('accumulated reasons are fulfilled together in one execution', () => {
+            const { provider, deviceManager } = createProvider([]);
+
+            //multiple triggers fire while no view is visible — each queues its own reason
+            deviceManager.submitBroadcast('stale');
+            deviceManager.submitBroadcast('sleep');
+            deviceManager.submitBroadcast('network');
+
+            provider['visible'] = true;
+            provider['fulfillPendingOrders']();
+
+            //one scan satisfies all of them
+            expect(deviceManager.broadcast.calledOnce).to.be.true;
+            expect(deviceManager.broadcast.firstCall.args[0]).to.have.members(['stale', 'sleep', 'network']);
+            expect(deviceManager.getPendingBroadcastReasons()).to.be.empty;
         });
     });
 });

--- a/src/viewProviders/DevicesViewProvider.spec.ts
+++ b/src/viewProviders/DevicesViewProvider.spec.ts
@@ -124,7 +124,7 @@ describe('DevicesViewProvider', () => {
                 }
                 const order = pendingBroadcast;
                 pendingBroadcast = null;
-                return deviceManager.broadcast(order.reason !== 'stale');
+                return deviceManager.broadcast(order.reason);
             },
             fulfillPendingReconcile: (fulfillOptions?: { except?: string[] }) => {
                 if (!pendingReconcile || fulfillOptions?.except?.includes(pendingReconcile.reason)) {
@@ -132,7 +132,7 @@ describe('DevicesViewProvider', () => {
                 }
                 const order = pendingReconcile;
                 pendingReconcile = null;
-                deviceManager.reconcile(order.reason === 'refresh-clicked');
+                deviceManager.reconcile(order.reason);
                 return true;
             }
         };
@@ -533,26 +533,26 @@ describe('DevicesViewProvider', () => {
     });
 
     describe('order fulfillment (spec: tree-view table)', () => {
-        it('fulfills a live non-stale broadcast order while visible (forced)', () => {
+        it('fulfills a live non-stale broadcast order while visible', () => {
             const { provider, deviceManager } = createProvider([]);
             provider['visible'] = true;
 
             deviceManager.submitBroadcast('network');
 
-            expect(deviceManager.broadcast.calledOnceWith(true)).to.be.true;
+            expect(deviceManager.broadcast.calledOnceWith('network')).to.be.true;
             expect(deviceManager.getPendingBroadcast()).to.be.null;
         });
 
-        it('fulfills a live reconcile order with force only for refresh-clicked', () => {
+        it('fulfills live reconcile orders, passing the reason through', () => {
             const { provider, deviceManager } = createProvider([]);
             provider['visible'] = true;
 
             deviceManager.submitReconcile('config-changed');
-            expect(deviceManager.reconcile.calledOnceWith(false)).to.be.true;
+            expect(deviceManager.reconcile.calledOnceWith('config-changed')).to.be.true;
 
             deviceManager.reconcile.resetHistory();
             deviceManager.submitReconcile('refresh-clicked');
-            expect(deviceManager.reconcile.calledOnceWith(true)).to.be.true;
+            expect(deviceManager.reconcile.calledOnceWith('refresh-clicked')).to.be.true;
         });
 
         it('ignores live stale orders while visible, leaving them pending', () => {
@@ -589,13 +589,13 @@ describe('DevicesViewProvider', () => {
             provider['visible'] = true;
             provider['fulfillPendingOrders']();
 
-            expect(deviceManager.broadcast.calledOnceWith(true)).to.be.true;
-            expect(deviceManager.reconcile.calledOnceWith(true)).to.be.true;
+            expect(deviceManager.broadcast.calledOnceWith('network')).to.be.true;
+            expect(deviceManager.reconcile.calledOnceWith('refresh-clicked')).to.be.true;
             expect(deviceManager.getPendingBroadcast()).to.be.null;
             expect(deviceManager.getPendingReconcile()).to.be.null;
         });
 
-        it('fulfills a queued stale broadcast on open without forcing (staleness-gated)', () => {
+        it('fulfills a queued stale broadcast on open with its reason intact (staleness-gated inside)', () => {
             const { provider, deviceManager } = createProvider([]);
 
             deviceManager.submitBroadcast('stale');
@@ -603,7 +603,7 @@ describe('DevicesViewProvider', () => {
             provider['visible'] = true;
             provider['fulfillPendingOrders']();
 
-            expect(deviceManager.broadcast.calledOnceWith(false)).to.be.true;
+            expect(deviceManager.broadcast.calledOnceWith('stale')).to.be.true;
         });
     });
 });

--- a/src/viewProviders/DevicesViewProvider.spec.ts
+++ b/src/viewProviders/DevicesViewProvider.spec.ts
@@ -99,7 +99,7 @@ describe('DevicesViewProvider', () => {
             getDeviceDisplayName: (device: any) => device.key,
             getIconPath: () => undefined,
             hasDeviceCache: () => false,
-            getDeviceInfo: () => Promise.resolve({}),
+            healthCheckDevice: () => Promise.resolve(true),
             broadcast: sinon.stub().returns(true),
             reconcile: sinon.stub(),
             submitOrders: (orders: Array<{ type: string; reason: string }>) => {

--- a/src/viewProviders/DevicesViewProvider.spec.ts
+++ b/src/viewProviders/DevicesViewProvider.spec.ts
@@ -99,7 +99,7 @@ describe('DevicesViewProvider', () => {
             getDeviceDisplayName: (device: any) => device.key,
             getIconPath: () => undefined,
             hasDeviceCache: () => false,
-            healthCheckDevice: () => Promise.resolve(),
+            deviceEngaged: () => Promise.resolve(true),
             broadcast: sinon.stub().returns(true),
             reconcile: sinon.stub(),
             submitBroadcast: (reason: string) => {
@@ -130,6 +130,12 @@ describe('DevicesViewProvider', () => {
                 pendingReconcileReasons.clear();
                 deviceManager.reconcile(reasons);
                 return true;
+            },
+            fulfillPendingOrders: (fulfillOptions?: { except?: string[] }) => {
+                return {
+                    scanStarted: deviceManager.fulfillPendingBroadcast(fulfillOptions),
+                    reconciled: deviceManager.fulfillPendingReconcile(fulfillOptions)
+                };
             }
         };
         const credentialStore: any = {

--- a/src/viewProviders/DevicesViewProvider.spec.ts
+++ b/src/viewProviders/DevicesViewProvider.spec.ts
@@ -603,7 +603,7 @@ describe('DevicesViewProvider', () => {
             const readSpy = sinon.spy(deviceManager, 'getAllDevices');
 
             //a devices-changed arrives while the panel is hidden: reading would trigger
-            //lazy hydration (network traffic) that nobody can see
+            //background refreshes (network traffic) that nobody can see
             provider['handleDevicesChanged']();
 
             expect(readSpy.called).to.be.false;

--- a/src/viewProviders/DevicesViewProvider.spec.ts
+++ b/src/viewProviders/DevicesViewProvider.spec.ts
@@ -113,23 +113,21 @@ describe('DevicesViewProvider', () => {
             getPendingBroadcastReasons: () => [...pendingBroadcastReasons],
             getPendingReconcileReasons: () => [...pendingReconcileReasons],
             fulfillPendingBroadcast: (fulfillOptions?: { except?: string[] }) => {
-                const reasons = [...pendingBroadcastReasons].filter(x => !fulfillOptions?.except?.includes(x));
-                if (reasons.length === 0) {
+                const triggers = [...pendingBroadcastReasons].filter(x => !fulfillOptions?.except?.includes(x));
+                if (triggers.length === 0) {
                     return false;
                 }
-                for (const reason of reasons) {
-                    pendingBroadcastReasons.delete(reason);
-                }
+                const reasons = [...pendingBroadcastReasons];
+                pendingBroadcastReasons.clear();
                 return deviceManager.broadcast(reasons);
             },
             fulfillPendingReconcile: (fulfillOptions?: { except?: string[] }) => {
-                const reasons = [...pendingReconcileReasons].filter(x => !fulfillOptions?.except?.includes(x));
-                if (reasons.length === 0) {
+                const triggers = [...pendingReconcileReasons].filter(x => !fulfillOptions?.except?.includes(x));
+                if (triggers.length === 0) {
                     return false;
                 }
-                for (const reason of reasons) {
-                    pendingReconcileReasons.delete(reason);
-                }
+                const reasons = [...pendingReconcileReasons];
+                pendingReconcileReasons.clear();
                 deviceManager.reconcile(reasons);
                 return true;
             }

--- a/src/viewProviders/DevicesViewProvider.spec.ts
+++ b/src/viewProviders/DevicesViewProvider.spec.ts
@@ -105,35 +105,32 @@ describe('DevicesViewProvider', () => {
             submitOrders: (orders: Array<{ type: string; reason: string }>) => {
                 for (const order of orders) {
                     (order.type === 'broadcast' ? pendingBroadcastReasons : pendingReconcileReasons).add(order.reason);
-                    emitter.emit(`${order.type}-ordered`, { reason: order.reason, timestamp: Date.now() });
+                    emitter.emit('order-submitted', { ...order, timestamp: Date.now() });
                 }
             },
             getPendingBroadcastReasons: () => [...pendingBroadcastReasons],
             getPendingReconcileReasons: () => [...pendingReconcileReasons],
-            fulfillPendingBroadcast: (fulfillOptions?: { except?: string[] }) => {
-                const triggers = [...pendingBroadcastReasons].filter(x => !fulfillOptions?.except?.includes(x));
-                if (triggers.length === 0) {
-                    return false;
+            fulfillOrders: (fulfillOptions?: { types?: string[]; except?: string[] }) => {
+                const types = fulfillOptions?.types ?? ['broadcast', 'reconcile'];
+                const result = { scanStarted: false, reconciled: false };
+                if (types.includes('broadcast')) {
+                    const triggers = [...pendingBroadcastReasons].filter(x => !fulfillOptions?.except?.includes(x));
+                    if (triggers.length > 0) {
+                        const reasons = [...pendingBroadcastReasons];
+                        pendingBroadcastReasons.clear();
+                        result.scanStarted = deviceManager.broadcast(reasons);
+                    }
                 }
-                const reasons = [...pendingBroadcastReasons];
-                pendingBroadcastReasons.clear();
-                return deviceManager.broadcast(reasons);
-            },
-            fulfillPendingReconcile: (fulfillOptions?: { except?: string[] }) => {
-                const triggers = [...pendingReconcileReasons].filter(x => !fulfillOptions?.except?.includes(x));
-                if (triggers.length === 0) {
-                    return false;
+                if (types.includes('reconcile')) {
+                    const triggers = [...pendingReconcileReasons].filter(x => !fulfillOptions?.except?.includes(x));
+                    if (triggers.length > 0) {
+                        const reasons = [...pendingReconcileReasons];
+                        pendingReconcileReasons.clear();
+                        deviceManager.reconcile(reasons);
+                        result.reconciled = true;
+                    }
                 }
-                const reasons = [...pendingReconcileReasons];
-                pendingReconcileReasons.clear();
-                deviceManager.reconcile(reasons);
-                return true;
-            },
-            fulfillPendingOrders: (fulfillOptions?: { except?: string[] }) => {
-                return {
-                    scanStarted: deviceManager.fulfillPendingBroadcast(fulfillOptions),
-                    reconciled: deviceManager.fulfillPendingReconcile(fulfillOptions)
-                };
+                return result;
             }
         };
         const credentialStore: any = {

--- a/src/viewProviders/DevicesViewProvider.ts
+++ b/src/viewProviders/DevicesViewProvider.ts
@@ -55,7 +55,7 @@ export class DevicesViewProvider implements vscode.TreeDataProvider<vscode.TreeI
         this.decorationProvider = new DeviceDecorationProvider();
         vscode.window.registerFileDecorationProvider(this.decorationProvider);
 
-        //no device-list read here: reads trigger lazy hydration (network traffic), which must
+        //no device-list read here: reads trigger background refreshes (network traffic), which must
         //wait until this view is actually visible
         this.deviceManager.on('devices-changed', () => {
             this.handleDevicesChanged();
@@ -158,7 +158,7 @@ export class DevicesViewProvider implements vscode.TreeDataProvider<vscode.TreeI
     }
 
     private handleDevicesChanged(): void {
-        //while hidden, only mark the list dirty - reading it would trigger lazy hydration
+        //while hidden, only mark the list dirty - reading it would trigger background refreshes
         //(network traffic) for a panel nobody can see
         if (!this.visible) {
             this.devicesDirty = true;

--- a/src/viewProviders/DevicesViewProvider.ts
+++ b/src/viewProviders/DevicesViewProvider.ts
@@ -118,13 +118,14 @@ export class DevicesViewProvider implements vscode.TreeDataProvider<vscode.TreeI
             this.fulfillPendingOrders();
         }
 
-        // Health check device when expanded (not on every getChildren/devices-changed)
+        // Expanding a device is explicit engagement with it — the manager freshens it
+        // (not on every getChildren/devices-changed)
         treeView.onDidExpandElement(e => {
             const element = e.element;
             if (element instanceof DeviceTreeItem && element.key) {
                 const device = this.deviceManager.getDevice(element.key);
                 if (device) {
-                    this.deviceManager.healthCheckDevice(device).catch(() => { });
+                    this.deviceManager.deviceEngaged(device).catch(() => { });
                 }
             }
         });
@@ -139,14 +140,13 @@ export class DevicesViewProvider implements vscode.TreeDataProvider<vscode.TreeI
     }
 
     /**
-     * When the panel becomes visible, fulfill any broadcast/reconcile orders that were queued
-     * while it was hidden. On-open fulfills every reason (spec's tree-view table: "fulfills
-     * pending broadcast AND reconcile orders for any reason") — a queued `stale` broadcast is
-     * still staleness-gated inside the DeviceManager, so this never over-scans.
+     * When the panel becomes visible, fulfill any orders that were queued while it was hidden.
+     * On-open fulfills every reason (spec's tree-view table: "fulfills pending broadcast AND
+     * reconcile orders for any reason") — a queued `stale` broadcast is still staleness-gated
+     * inside the DeviceManager, so this never over-scans.
      */
     private fulfillPendingOrders() {
-        this.deviceManager.fulfillPendingBroadcast();
-        this.deviceManager.fulfillPendingReconcile();
+        this.deviceManager.fulfillPendingOrders();
     }
 
     private showScanProgress() {

--- a/src/viewProviders/DevicesViewProvider.ts
+++ b/src/viewProviders/DevicesViewProvider.ts
@@ -119,16 +119,15 @@ export class DevicesViewProvider implements vscode.TreeDataProvider<vscode.TreeI
             this.deviceManager.fulfillOrders({ types: ['broadcast', 'reconcile'] });
         }
 
-        // Expanding a device reveals its Device Info section — fetch it fresh. The result
-        // itself isn't needed here: the fetch updates the manager's cache and fires
-        // devices-changed, and the re-render reads it back. (Not on every
-        // getChildren/devices-changed.)
+        // Expanding a device reveals its Device Info section - refresh it. The health check
+        // updates the manager's cache and fires devices-changed; the re-render reads it back.
+        // (Not on every getChildren/devices-changed.)
         treeView.onDidExpandElement(e => {
             const element = e.element;
             if (element instanceof DeviceTreeItem && element.key) {
                 const device = this.deviceManager.getDevice(element.key);
                 if (device) {
-                    this.deviceManager.getDeviceInfo(device).catch(() => { });
+                    this.deviceManager.healthCheckDevice(device).catch(() => { });
                 }
             }
         });

--- a/src/viewProviders/DevicesViewProvider.ts
+++ b/src/viewProviders/DevicesViewProvider.ts
@@ -71,11 +71,21 @@ export class DevicesViewProvider implements vscode.TreeDataProvider<vscode.TreeI
         });
         this.context.subscriptions.push({ dispose: unsubscribeContextChange });
 
-        this.deviceManager.on('scanNeeded-changed', () => {
+        // While the panel is visible, fulfill live broadcast/reconcile orders as they arrive,
+        // except timer-driven `stale` ones (avoid surprise scans while the user is looking).
+        // Fulfillment is atomic — if another visible consumer (e.g. the device picker) already
+        // fulfilled this order, the slot is empty and the call is a no-op.
+        this.deviceManager.on('broadcast-ordered', () => {
             if (!this.visible) {
                 return;
             }
-            this.deviceManager.refresh();
+            this.deviceManager.fulfillPendingBroadcast({ except: ['stale'] });
+        });
+        this.deviceManager.on('reconcile-ordered', () => {
+            if (!this.visible) {
+                return;
+            }
+            this.deviceManager.fulfillPendingReconcile({ except: ['stale'] });
         });
 
         // Re-render when a device's stored password changes so the Clear item appears/disappears
@@ -98,8 +108,15 @@ export class DevicesViewProvider implements vscode.TreeDataProvider<vscode.TreeI
             if (!this.visible) {
                 return;
             }
-            this.deviceManager.refresh();
+            this.fulfillPendingOrders();
         });
+
+        // onDidChangeVisibility only fires on *changes* — if the panel is already open when the
+        // extension activates, sync the flag now and consume any queued (startup) orders
+        this.visible = treeView.visible;
+        if (this.visible) {
+            this.fulfillPendingOrders();
+        }
 
         // Health check device when expanded (not on every getChildren/devices-changed)
         treeView.onDidExpandElement(e => {
@@ -119,6 +136,17 @@ export class DevicesViewProvider implements vscode.TreeDataProvider<vscode.TreeI
         this.deviceManager.on('scan-ended', () => {
             this.endScanProgress();
         });
+    }
+
+    /**
+     * When the panel becomes visible, fulfill any broadcast/reconcile orders that were queued
+     * while it was hidden. On-open fulfills every reason (spec's tree-view table: "fulfills
+     * pending broadcast AND reconcile orders for any reason") — a queued `stale` broadcast is
+     * still staleness-gated inside the DeviceManager, so this never over-scans.
+     */
+    private fulfillPendingOrders() {
+        this.deviceManager.fulfillPendingBroadcast();
+        this.deviceManager.fulfillPendingReconcile();
     }
 
     private showScanProgress() {

--- a/src/viewProviders/DevicesViewProvider.ts
+++ b/src/viewProviders/DevicesViewProvider.ts
@@ -103,19 +103,22 @@ export class DevicesViewProvider implements vscode.TreeDataProvider<vscode.TreeI
     private scanProgressResolver: (() => void) | null = null;
 
     public setTreeView(treeView: vscode.TreeView<vscode.TreeItem>) {
+        // On open, fulfill orders queued while hidden — every reason (spec's tree-view table:
+        // "fulfills pending broadcast AND reconcile orders for any reason"); a queued `stale`
+        // broadcast is still staleness-gated inside the DeviceManager, so this never over-scans.
         treeView.onDidChangeVisibility(e => {
             this.visible = e.visible;
             if (!this.visible) {
                 return;
             }
-            this.fulfillPendingOrders();
+            this.deviceManager.fulfillPendingOrders();
         });
 
         // onDidChangeVisibility only fires on *changes* — if the panel is already open when the
         // extension activates, sync the flag now and consume any queued (startup) orders
         this.visible = treeView.visible;
         if (this.visible) {
-            this.fulfillPendingOrders();
+            this.deviceManager.fulfillPendingOrders();
         }
 
         // Expanding a device is explicit engagement with it — the manager freshens it
@@ -137,16 +140,6 @@ export class DevicesViewProvider implements vscode.TreeDataProvider<vscode.TreeI
         this.deviceManager.on('scan-ended', () => {
             this.endScanProgress();
         });
-    }
-
-    /**
-     * When the panel becomes visible, fulfill any orders that were queued while it was hidden.
-     * On-open fulfills every reason (spec's tree-view table: "fulfills pending broadcast AND
-     * reconcile orders for any reason") — a queued `stale` broadcast is still staleness-gated
-     * inside the DeviceManager, so this never over-scans.
-     */
-    private fulfillPendingOrders() {
-        this.deviceManager.fulfillPendingOrders();
     }
 
     private showScanProgress() {

--- a/src/viewProviders/DevicesViewProvider.ts
+++ b/src/viewProviders/DevicesViewProvider.ts
@@ -55,10 +55,8 @@ export class DevicesViewProvider implements vscode.TreeDataProvider<vscode.TreeI
         this.decorationProvider = new DeviceDecorationProvider();
         vscode.window.registerFileDecorationProvider(this.decorationProvider);
 
-        // No device-list read here: reads trigger lazy hydration (network traffic), and the
-        // spec says nothing hits the network until a view is actually visible. The first
-        // visible render reads via the dirty flag.
-
+        //no device-list read here: reads trigger lazy hydration (network traffic), which must
+        //wait until this view is actually visible
         this.deviceManager.on('devices-changed', () => {
             this.handleDevicesChanged();
         });
@@ -71,10 +69,7 @@ export class DevicesViewProvider implements vscode.TreeDataProvider<vscode.TreeI
         });
         this.context.subscriptions.push({ dispose: unsubscribeContextChange });
 
-        // While the panel is visible, fulfill live orders as they arrive, except timer-driven
-        // `stale` ones (avoid surprise scans while the user is looking). Fulfillment is
-        // atomic — if another visible consumer (e.g. the device picker) already fulfilled this
-        // order, the pending set is empty and the call is a no-op.
+        //while visible, fulfill live orders as they arrive (except timer-driven `stale` ones)
         this.deviceManager.on('order-submitted', (order) => {
             if (!this.visible) {
                 return;
@@ -97,31 +92,27 @@ export class DevicesViewProvider implements vscode.TreeDataProvider<vscode.TreeI
     private scanProgressResolver: (() => void) | null = null;
 
     public setTreeView(treeView: vscode.TreeView<vscode.TreeItem>) {
-        // On open, fulfill orders queued while hidden — every reason (spec's tree-view table:
-        // "fulfills pending broadcast AND reconcile orders for any reason"); a queued `stale`
-        // broadcast is still staleness-gated inside the DeviceManager, so this never over-scans.
+        //on open, fulfill orders queued while hidden (every reason)
         treeView.onDidChangeVisibility(e => {
             this.visible = e.visible;
             if (!this.visible) {
                 return;
             }
             this.deviceManager.fulfillOrders({ types: ['broadcast', 'reconcile'] });
-            // Re-render if the device list changed while hidden (getChildren consumes the flag)
+            //re-render if the device list changed while hidden
             if (this.devicesDirty) {
                 this._onDidChangeTreeData.fire(null);
             }
         });
 
-        // onDidChangeVisibility only fires on *changes* — if the panel is already open when the
-        // extension activates, sync the flag now and consume any queued (startup) orders
+        //onDidChangeVisibility only fires on changes - if the panel is already open at
+        //activation, sync now and consume any queued startup orders
         this.visible = treeView.visible;
         if (this.visible) {
             this.deviceManager.fulfillOrders({ types: ['broadcast', 'reconcile'] });
         }
 
-        // Expanding a device reveals its Device Info section - refresh it. The health check
-        // updates the manager's cache and fires devices-changed; the re-render reads it back.
-        // (Not on every getChildren/devices-changed.)
+        //expanding a device reveals its Device Info section - refresh it
         treeView.onDidExpandElement(e => {
             const element = e.element;
             if (element instanceof DeviceTreeItem && element.key) {
@@ -166,12 +157,9 @@ export class DevicesViewProvider implements vscode.TreeDataProvider<vscode.TreeI
         }
     }
 
-    /**
-     * The device list changed (or the active device moved). While hidden, only mark the list
-     * dirty — reading it would trigger lazy hydration (network traffic) for a panel nobody can
-     * see. The dirty flag is consumed on the next visible render.
-     */
     private handleDevicesChanged(): void {
+        //while hidden, only mark the list dirty - reading it would trigger lazy hydration
+        //(network traffic) for a panel nobody can see
         if (!this.visible) {
             this.devicesDirty = true;
             return;
@@ -215,8 +203,7 @@ export class DevicesViewProvider implements vscode.TreeDataProvider<vscode.TreeI
 
     async getChildren(element?: vscode.TreeItem): Promise<vscode.TreeItem[]> {
         if (!element) {
-            // Re-read on first render and after hidden-time changes (getChildren only runs
-            // when VS Code is actually rendering the tree, so a read here is a visible read)
+            //re-read on first render and after hidden-time changes
             if (this.devicesDirty || this.devices.length === 0) {
                 this.devicesDirty = false;
                 this.devices = this.deviceManager.getAllDevices();

--- a/src/viewProviders/DevicesViewProvider.ts
+++ b/src/viewProviders/DevicesViewProvider.ts
@@ -71,21 +71,15 @@ export class DevicesViewProvider implements vscode.TreeDataProvider<vscode.TreeI
         });
         this.context.subscriptions.push({ dispose: unsubscribeContextChange });
 
-        // While the panel is visible, fulfill live broadcast/reconcile orders as they arrive,
-        // except timer-driven `stale` ones (avoid surprise scans while the user is looking).
-        // Fulfillment is atomic — if another visible consumer (e.g. the device picker) already
-        // fulfilled this order, the pending set is empty and the call is a no-op.
-        this.deviceManager.on('broadcast-ordered', () => {
+        // While the panel is visible, fulfill live orders as they arrive, except timer-driven
+        // `stale` ones (avoid surprise scans while the user is looking). Fulfillment is
+        // atomic — if another visible consumer (e.g. the device picker) already fulfilled this
+        // order, the pending set is empty and the call is a no-op.
+        this.deviceManager.on('order-submitted', (order) => {
             if (!this.visible) {
                 return;
             }
-            this.deviceManager.fulfillPendingBroadcast({ except: ['stale'] });
-        });
-        this.deviceManager.on('reconcile-ordered', () => {
-            if (!this.visible) {
-                return;
-            }
-            this.deviceManager.fulfillPendingReconcile({ except: ['stale'] });
+            this.deviceManager.fulfillOrders({ types: [order.type], except: ['stale'] });
         });
 
         // Re-render when a device's stored password changes so the Clear item appears/disappears
@@ -111,7 +105,7 @@ export class DevicesViewProvider implements vscode.TreeDataProvider<vscode.TreeI
             if (!this.visible) {
                 return;
             }
-            this.deviceManager.fulfillPendingOrders();
+            this.deviceManager.fulfillOrders();
             // Re-render if the device list changed while hidden (getChildren consumes the flag)
             if (this.devicesDirty) {
                 this._onDidChangeTreeData.fire(null);
@@ -122,7 +116,7 @@ export class DevicesViewProvider implements vscode.TreeDataProvider<vscode.TreeI
         // extension activates, sync the flag now and consume any queued (startup) orders
         this.visible = treeView.visible;
         if (this.visible) {
-            this.deviceManager.fulfillPendingOrders();
+            this.deviceManager.fulfillOrders();
         }
 
         // Expanding a device reveals its Device Info section — fetch it fresh. The result

--- a/src/viewProviders/DevicesViewProvider.ts
+++ b/src/viewProviders/DevicesViewProvider.ts
@@ -55,9 +55,9 @@ export class DevicesViewProvider implements vscode.TreeDataProvider<vscode.TreeI
         this.decorationProvider = new DeviceDecorationProvider();
         vscode.window.registerFileDecorationProvider(this.decorationProvider);
 
-        // Pre-populate devices and decorations so they're ready before first render
-        this.devices = this.deviceManager.getAllDevices();
-        this.decorationProvider.updateDevices(this.devices, this.getActiveDeviceKey());
+        // No device-list read here: reads trigger lazy hydration (network traffic), and the
+        // spec says nothing hits the network until a view is actually visible. The first
+        // visible render reads via the dirty flag.
 
         this.deviceManager.on('devices-changed', () => {
             this.handleDevicesChanged();
@@ -74,7 +74,7 @@ export class DevicesViewProvider implements vscode.TreeDataProvider<vscode.TreeI
         // While the panel is visible, fulfill live broadcast/reconcile orders as they arrive,
         // except timer-driven `stale` ones (avoid surprise scans while the user is looking).
         // Fulfillment is atomic — if another visible consumer (e.g. the device picker) already
-        // fulfilled this order, the slot is empty and the call is a no-op.
+        // fulfilled this order, the pending set is empty and the call is a no-op.
         this.deviceManager.on('broadcast-ordered', () => {
             if (!this.visible) {
                 return;
@@ -112,6 +112,10 @@ export class DevicesViewProvider implements vscode.TreeDataProvider<vscode.TreeI
                 return;
             }
             this.deviceManager.fulfillPendingOrders();
+            // Re-render if the device list changed while hidden (getChildren consumes the flag)
+            if (this.devicesDirty) {
+                this._onDidChangeTreeData.fire(null);
+            }
         });
 
         // onDidChangeVisibility only fires on *changes* — if the panel is already open when the
@@ -167,7 +171,16 @@ export class DevicesViewProvider implements vscode.TreeDataProvider<vscode.TreeI
         }
     }
 
+    /**
+     * The device list changed (or the active device moved). While hidden, only mark the list
+     * dirty — reading it would trigger lazy hydration (network traffic) for a panel nobody can
+     * see. The dirty flag is consumed on the next visible render.
+     */
     private handleDevicesChanged(): void {
+        if (!this.visible) {
+            this.devicesDirty = true;
+            return;
+        }
         this.devices = this.deviceManager.getAllDevices();
         this.decorationProvider.updateDevices(this.devices, this.getActiveDeviceKey());
         this._onDidChangeTreeData.fire(null);
@@ -197,12 +210,20 @@ export class DevicesViewProvider implements vscode.TreeDataProvider<vscode.TreeI
         return util.getConfiguration('brightscript.deviceDiscovery').get('concealDeviceInfo') === true;
     }
 
-    private devices: Array<RokuDevice>;
+    private devices: Array<RokuDevice> = [];
+
+    /**
+     * Set when the device list changed while the panel was hidden; the next visible render
+     * re-reads. Starts true so the first render populates the list.
+     */
+    private devicesDirty = true;
 
     async getChildren(element?: vscode.TreeItem): Promise<vscode.TreeItem[]> {
         if (!element) {
-            // Fetch directly if devices haven't been populated yet (avoids debounce delay on initial load)
-            if (this.devices.length === 0) {
+            // Re-read on first render and after hidden-time changes (getChildren only runs
+            // when VS Code is actually rendering the tree, so a read here is a visible read)
+            if (this.devicesDirty || this.devices.length === 0) {
+                this.devicesDirty = false;
                 this.devices = this.deviceManager.getAllDevices();
                 this.decorationProvider.updateDevices(this.devices, this.getActiveDeviceKey());
             }

--- a/src/viewProviders/DevicesViewProvider.ts
+++ b/src/viewProviders/DevicesViewProvider.ts
@@ -125,14 +125,16 @@ export class DevicesViewProvider implements vscode.TreeDataProvider<vscode.TreeI
             this.deviceManager.fulfillPendingOrders();
         }
 
-        // Expanding a device is explicit engagement with it — the manager freshens it
-        // (not on every getChildren/devices-changed)
+        // Expanding a device reveals its Device Info section — fetch it fresh. The result
+        // itself isn't needed here: the fetch updates the manager's cache and fires
+        // devices-changed, and the re-render reads it back. (Not on every
+        // getChildren/devices-changed.)
         treeView.onDidExpandElement(e => {
             const element = e.element;
             if (element instanceof DeviceTreeItem && element.key) {
                 const device = this.deviceManager.getDevice(element.key);
                 if (device) {
-                    this.deviceManager.deviceEngaged(device).catch(() => { });
+                    this.deviceManager.getDeviceInfo(device).catch(() => { });
                 }
             }
         });

--- a/src/viewProviders/DevicesViewProvider.ts
+++ b/src/viewProviders/DevicesViewProvider.ts
@@ -105,7 +105,7 @@ export class DevicesViewProvider implements vscode.TreeDataProvider<vscode.TreeI
             if (!this.visible) {
                 return;
             }
-            this.deviceManager.fulfillOrders();
+            this.deviceManager.fulfillOrders({ types: ['broadcast', 'reconcile'] });
             // Re-render if the device list changed while hidden (getChildren consumes the flag)
             if (this.devicesDirty) {
                 this._onDidChangeTreeData.fire(null);
@@ -116,7 +116,7 @@ export class DevicesViewProvider implements vscode.TreeDataProvider<vscode.TreeI
         // extension activates, sync the flag now and consume any queued (startup) orders
         this.visible = treeView.visible;
         if (this.visible) {
-            this.deviceManager.fulfillOrders();
+            this.deviceManager.fulfillOrders({ types: ['broadcast', 'reconcile'] });
         }
 
         // Expanding a device reveals its Device Info section — fetch it fresh. The result


### PR DESCRIPTION
## Summary

Implements the behavior described in [`docs/device-discovery.md`](docs/device-discovery.md): the `scanNeeded` flag and direct `refresh()`/`scan()` calls are replaced by an **orders** system where triggers submit work and visible views fulfill it. No new files — this is a behavior change in the existing ones.

> **Note:** the doc will be updated separately to match a few places where the implementation evolved past its wording (called out below).

## How it works now

**Triggers submit orders; views fulfill them.**

```
trigger (startup / network / sleep / config change / refresh click / stale timer)
   └─ submitOrder(reason)          ── one funnel; the reason decides which order
        ├─ broadcast order            types it implies (most imply both;
        └─ reconcile order            config-changed → reconcile only,
                                      unhealthy-device → broadcast only)
                │
                ├─ emits *-ordered  → a VISIBLE view fulfills live
                └─ pending sets     → a hidden view fulfills on open
                        │
                        └─ fulfillment coalesces: ALL pending broadcast
                           reasons → one SSDP M-SEARCH scan; ALL pending
                           reconcile reasons → one health-check sweep
```

- **Pending orders are a set of reasons per order type** — different reasons accumulate (`stale` + `sleep` can both be pending), the same reason never queues twice, and one execution satisfies everything taken. When a real reason triggers fulfillment, the whole set clears (the scan satisfies the stale want too).
- **Reasons carry the policy.** A stale-only broadcast is gated (discovery enabled + last scan older than 30 min); any real reason scans now. A reconcile bypasses each device's cache trust window only when `refresh-clicked` is among its reasons.
- **Views are the gate.** If no UI is visible, no network traffic happens — orders queue until a view opens. The tree view fulfills everything on open (including a panel already open at activation) and live orders except `stale`; the quick pick fulfills except `stale` on open/live, with a 7s fallback that fulfills whatever is pending (staleness-gated inside, so it never over-scans).

**Lazy hydration on read.** Reads return immediately; devices that are `unknown` with no cache, or whose cache is older than 8h, get a background resolve (with convergence guards: pending skip, in-flight set, 5-min per-IP retry cooldown). This is what makes `ssdp:alive` "just work", and it replaces the deleted eager paths (`resolveUncachedDiscoveredDevices`, the post-scan `healthCheckStaleDevices` sweep). Because reads now cost network, the tree view no longer reads while hidden — changes set a dirty flag consumed on the next visible render.

**The de-dupe rule.** Concurrent device-info requests for the same `ip:port` share one in-flight HTTP request; a sequence counter ensures a stale slow response can't overwrite a newer result (regression test included).

**Views speak interactions, not mechanisms.** The full view-facing surface of `DeviceManager`:

| Call | Meaning |
|---|---|
| `submitOrder('refresh-clicked')` | "the user clicked refresh/scan" |
| `fulfillPendingOrders({except})` | "I'm visible — run what's queued" |
| `fulfillPendingBroadcast/Reconcile` | per-order-type view policy (picker's 7s fallback) |
| `deviceEngaged(keyOrDevice)` | "the user engaged this device" — freshens it, reports health |

Everything else (order types, executors, gates, stale timers, the cache-bypass mechanics) is private. The old `force` flag is gone — `resolveDevice` takes `{ bypassCache, syntheticDelay }` and the reason→policy mapping lives inside the manager.

## Deliberate deviations from the doc (to be folded into its next revision)

- **7s picker fallback *fulfills* rather than *submits*** a stale order — per the doc's own view rules, nobody would fulfill a submitted stale order, so it would sit forever.
- **Pending orders are a set of reasons, not a single slot** — a stale order can no longer downgrade (or be lost behind) a queued real trigger.
- **`unhealthy-device` broadcasts are rate-limited** (suppressed when discovery is off or a scan ran within 60s) — terminates the scan → fail → scan loop the reason list would otherwise allow.
- **The discovery-enabled toggle submits `startup` orders** — the doc models no toggle reason.

## Bug fixes along the way

- `randomDelay(min, max)` produced 0–max instead of min–max
- `refreshDevice` passed the encoded tree key as a serial number — silent no-op
- The quick pick's scan-fallback timer leaked when the picker closed early
- The tree view missed queued startup orders when the panel was already open at activation