### PR TITLE
chore: Simplify create-vsix inputs and improve branch resolution

### DIFF
--- a/.github/workflows/create-vsix.yml
+++ b/.github/workflows/create-vsix.yml
@@ -4,15 +4,9 @@ on:
     types: [labeled, unlabeled, synchronize]
   workflow_dispatch:
     inputs:
-      branch:
-        description: "The branch name which should be used to build the vsix. Optional when pr is provided (defaults to the PR's branch)"
-        required: false
       pr:
-        description: "Optional PR that requested this build (PR number or full PR URL). When provided, a comment with the .vsix download links will be posted on that PR"
-        required: false
-      repo:
-        description: "Optional owner/repo that the PR number belongs to (defaults to this repo). Ignored when pr is a full URL"
-        required: false
+        description: "What to build: a PR number (for this repo), a full PR URL (for any repo), or a branch name"
+        required: true
 jobs:
   create-vsix:
     runs-on: ubuntu-latest
@@ -30,46 +24,51 @@ jobs:
         id: info
         with:
           script: |
-            let branch, prInput, repoInput;
+            let input;
             if (context.eventName === 'pull_request') {
-              branch = context.payload.pull_request.head.ref;
-              prInput = context.payload.pull_request.html_url;
-              repoInput = `${context.repo.owner}/${context.repo.repo}`;
+              input = context.payload.pull_request.html_url;
             } else {
-              branch = `${{ github.event.inputs.branch }}`.trim();
-              prInput = `${{ github.event.inputs.pr }}`.trim();
-              repoInput = `${{ github.event.inputs.repo }}`.trim();
+              input = `${{ github.event.inputs.pr }}`.trim();
             }
-            if (prInput) {
-              //`pr` can be a full PR URL or a plain PR number (paired with the `repo` input)
-              let prOwner, prRepo, prNumber;
-              const urlMatch = /github\.com\/([^/]+)\/([^/]+)\/pull\/(\d+)/.exec(prInput);
-              if (urlMatch) {
-                [, prOwner, prRepo, prNumber] = urlMatch;
-              } else if (/^\d+$/.test(prInput)) {
-                [prOwner, prRepo] = (repoInput || `${context.repo.owner}/${context.repo.repo}`).split('/');
-                prNumber = prInput;
-              } else {
-                core.setFailed(`Could not parse a PR number or URL from "${prInput}"`);
-                return;
-              }
+            if (!input) {
+              core.setFailed('You must provide a PR number, PR URL, or branch name');
+              return;
+            }
+            //`pr` can be a full PR URL (any repo), a plain PR number (this repo), or a branch name
+            let prOwner, prRepo, prNumber;
+            const urlMatch = /github\.com\/([^/]+)\/([^/]+)\/pull\/(\d+)/.exec(input);
+            if (urlMatch) {
+              [, prOwner, prRepo, prNumber] = urlMatch;
+            } else if (/^\d+$/.test(input)) {
+              prOwner = context.repo.owner;
+              prRepo = context.repo.repo;
+              prNumber = input;
+            }
+            let branch;
+            let forkOwner = '';
+            if (prNumber) {
               const { data: pr } = await github.rest.pulls.get({
                 owner: prOwner,
                 repo: prRepo,
                 pull_number: Number(prNumber)
               });
+              branch = pr.head.ref;
+              //when the PR comes from a fork, remember the fork owner so the build can also consider
+              //that owner's same-named branches (when attached to open PRs) on the other projects
+              if (pr.head.repo.owner.login !== prOwner) {
+                forkOwner = pr.head.repo.owner.login;
+              }
               core.setOutput('prOwner', prOwner);
               core.setOutput('prRepo', prRepo);
               core.setOutput('prNumber', prNumber);
               core.setOutput('prSha', pr.head.sha);
-              branch = branch || pr.head.ref;
-              console.log(`PR: ${prOwner}/${prRepo}#${prNumber} @ ${pr.head.sha}`);
-            }
-            if (!branch) {
-              core.setFailed('You must provide either a branch or a pr');
-              return;
+              console.log(`PR: ${prOwner}/${prRepo}#${prNumber} @ ${pr.head.sha}${forkOwner ? ` (fork owner: ${forkOwner})` : ''}`);
+            } else {
+              //not a PR number or URL, so treat the input as a branch name
+              branch = input.replace(/^refs\/heads\//, '');
             }
             core.setOutput('branch', branch);
+            core.setOutput('forkOwner', forkOwner);
             console.log(`branch: "${branch}"`);
       # GitHub withholds repository secrets from fork-triggered runs, so fail fast with a clear message
       - name: Reject fork PRs
@@ -78,7 +77,9 @@ jobs:
           echo "::error::Could not build a .vsix because fork PRs can't access the required secrets. Ask a maintainer to dispatch it manually for PR #${{ github.event.pull_request.number }}: https://github.com/${{ github.repository }}/actions/workflows/create-vsix.yml"
           exit 1
       - run: npm ci
-      - run: npx ts-node scripts/create-vsix.ts ${{ steps.info.outputs.branch }}
+      - run: npx ts-node scripts/create-vsix.ts "${{ steps.info.outputs.branch }}" --fork-owner "${{ steps.info.outputs.forkOwner }}"
+        env:
+          GITHUB_TOKEN: ${{ github.token }}
       # upload the production .vsix (archive: false only supports a single file, so
       # upload each .vsix as its own artifact: upload, delete, repackage, upload again)
       - uses: actions/upload-artifact@v7
@@ -141,6 +142,19 @@ jobs:
             let body = 'Hey there! I just built a new version of the vscode extension based on [' + sha.substring(0, 7) + '](https://github.com/' + '${{ steps.info.outputs.prOwner }}' + '/' + '${{ steps.info.outputs.prRepo }}' + '/commit/' + sha + ').\n\n';
             body += '### 📦 [Download the .vsix](' + prod.url + ')\n';
             body += 'See the [install instructions](https://rokucommunity.github.io/vscode-brightscript-language/prerelease-versions.html) if you need them. This replaces your marketplace version of the extension until you reinstall it.\n\n';
+
+            //include the per-project sources so testers can see exactly what went into this build
+            try {
+              const buildInfo = JSON.parse(require('fs').readFileSync('.vsix-building/build-info.json', 'utf8'));
+              body += 'Built from:\n';
+              for (const project of buildInfo) {
+                body += '- ' + project.name + ': ' + project.source + '\n';
+              }
+              body += '\n';
+            } catch (e) {
+              console.log('Could not read build-info.json:', e.message);
+            }
+
             body += '<sub>_Prefer to keep the marketplace version installed? There\'s also a [side-by-side build](' + temp.url + ') that installs as a separate extension. Be sure to disable the marketplace version while testing it, otherwise the two will conflict._</sub>';
 
             await github.rest.issues.createComment({

--- a/scripts/create-vsix.ts
+++ b/scripts/create-vsix.ts
@@ -5,7 +5,8 @@ import * as chalk from 'chalk';
 
 const silent = process.argv.includes('--silent');
 const tempDir = s`${__dirname}/../.vsix-building`;
-const baseUrl = 'https://github.com/rokucommunity';
+const orgName = 'rokucommunity';
+const baseUrl = `https://github.com/${orgName}`;
 const projects = [{
     name: 'roku-deploy',
     dependencies: []
@@ -23,34 +24,55 @@ const projects = [{
     dependencies: ['brighterscript', 'roku-debug', 'brighterscript-formatter', 'roku-deploy']
 }] as Project[];
 
-function main() {
+async function main() {
     //create a temp directory for this process
     log(`Creating and cleaning ${tempDir}`);
     fsExtra.emptyDirSync(tempDir);
     process.chdir(tempDir);
 
-    const branch = process.argv[2].replace(/^refs\/heads\//, '');
+    const args = process.argv.slice(2);
+    //when set, the originating PR came from this owner's fork, so also consider that owner's
+    //same-named branches (when attached to open PRs) on the other projects
+    let forkOwner = '';
+    const forkOwnerIndex = args.indexOf('--fork-owner');
+    if (forkOwnerIndex > -1) {
+        forkOwner = (args[forkOwnerIndex + 1] ?? '').trim();
+        args.splice(forkOwnerIndex, 2);
+    }
+    if (forkOwner === orgName) {
+        forkOwner = '';
+    }
+    const branch = (args.find(x => !x.startsWith('--')) ?? '').replace(/^refs\/heads\//, '');
+    if (!branch) {
+        throw new Error('You must provide a branch name');
+    }
 
     //build and link all the projects
     for (const project of projects) {
-        processProject(project, branch);
+        await processProject(project, branch, forkOwner);
     }
+
+    //write a summary of what was built (the workflow includes this in the PR comment)
+    const buildInfo = projects.map(x => ({ name: x.name, source: x.source }));
+    fsExtra.writeJsonSync(`${tempDir}/build-info.json`, buildInfo, { spaces: 4 });
+    log('Build summary:\n' + buildInfo.map(x => `  ${x.name}: ${x.source}`).join('\n'));
 
     log('Building and packaging the extension');
     execSync('npm run package', { cwd: 'vscode-brightscript-language' });
 }
 
-function processProject(project: Project, branch: string) {
+async function processProject(project: Project, branch: string, forkOwner: string) {
     //if this project has already been processed, skip
     if (project.processed) {
         log(`${project.name}: already processed`);
         return;
     }
     log(`${project.name}: processing`);
-    const projectBranch = hasBranch(project, branch) ? branch : 'master';
-    const buildVersion = `9001.0.0-${projectBranch.replace(/[^a-zA-Z0-9]/g, '-')}.${Date.now()}`;
+    const ref = await resolveRef(project, branch, forkOwner);
+    log(`${project.name}: building from ${ref.source}`);
+    const buildVersion = `9001.0.0-${ref.ref.replace(/[^a-zA-Z0-9]/g, '-')}.${Date.now()}`;
 
-    clone(project, projectBranch);
+    clone(project, ref);
     changeVersion(project, buildVersion);
     execSync(`npm i`, {
         cwd: project.name
@@ -58,7 +80,7 @@ function processProject(project: Project, branch: string) {
     for (const dependencyName of project.dependencies) {
         log(`${project.name}: Processing dependency '${dependencyName}'`);
         const dependency = projects.find(x => x.name === dependencyName)!;
-        processProject(dependency, branch);
+        await processProject(dependency, branch, forkOwner);
         //install the dependency into this project
         execSync(`npm i ${dependency.packagePath}`, { cwd: project.name });
     }
@@ -67,15 +89,76 @@ function processProject(project: Project, branch: string) {
     });
 
     project.packagePath = `file:/${tempDir}/${project.name}/${project.name}-${buildVersion}.tgz`;
+    project.source = ref.source;
     project.processed = true;
     log(`${project.name}: done`);
+}
+
+/**
+ * Figure out where to build this project from. Priority:
+ *   1. the org's branch, when attached to an open PR
+ *   2. the fork owner's same-named branch, when attached to an open PR
+ *   3. the org's branch, even without a PR
+ *   4. master
+ */
+async function resolveRef(project: Project, branch: string, forkOwner: string): Promise<Ref> {
+    const orgCloneUrl = `${baseUrl}/${project.name}`;
+    if (branch && branch !== 'master') {
+        //1. the org has this branch and it's attached to an open PR
+        let pr = await findOpenPr(project.name, orgName, branch);
+        if (pr) {
+            return { cloneUrl: orgCloneUrl, ref: branch, source: `${orgName} branch '${branch}' (open PR ${pr.html_url})` };
+        }
+        //2. the fork owner has this branch attached to an open PR on this project
+        if (forkOwner) {
+            pr = await findOpenPr(project.name, forkOwner, branch);
+            if (pr) {
+                return { cloneUrl: pr.head.repo.clone_url, ref: branch, source: `${forkOwner} fork branch '${branch}' (open PR ${pr.html_url})` };
+            }
+        }
+        //3. the org has this branch (no PR)
+        if (hasBranch(project, branch)) {
+            return { cloneUrl: orgCloneUrl, ref: branch, source: `${orgName} branch '${branch}'` };
+        }
+    }
+    //4. fall back to master
+    return { cloneUrl: orgCloneUrl, ref: 'master', source: `${orgName} branch 'master'` };
+}
+
+/**
+ * Find an open PR on the org's repo whose head is `<owner>:<branch>` (returns undefined when there isn't one)
+ */
+async function findOpenPr(repoName: string, owner: string, branch: string) {
+    const url = `https://api.github.com/repos/${orgName}/${repoName}/pulls?state=open&head=${encodeURIComponent(`${owner}:${branch}`)}`;
+    const headers: Record<string, string> = {
+        'accept': 'application/vnd.github+json',
+        'user-agent': `${orgName}-create-vsix`
+    };
+    //use the token when available (CI) to avoid the low unauthenticated rate limit
+    if (process.env.GITHUB_TOKEN) {
+        headers.authorization = `Bearer ${process.env.GITHUB_TOKEN}`;
+    }
+    const response = await fetch(url, { headers });
+    if (!response.ok) {
+        log(`Warning: could not look up open PRs for ${owner}:${branch} on ${repoName} (HTTP ${response.status})`);
+        return undefined;
+    }
+    const prs = await response.json() as any[];
+    return prs[0];
 }
 
 interface Project {
     name: string;
     dependencies: string[];
     packagePath?: string;
+    source?: string;
     processed: boolean;
+}
+
+interface Ref {
+    cloneUrl: string;
+    ref: string;
+    source: string;
 }
 
 /**
@@ -91,11 +174,10 @@ function escapeRegExp(string: string) {
     return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); // $& means the whole matched string
 }
 
-function clone(project: Project, branch: string) {
-    const url = `${baseUrl}/${project.name}`;
-    log(`Cloning ${url}`);
-    execSync(`git clone ${url} ${project.name}`);
-    execSync(`git checkout ${branch}`, {
+function clone(project: Project, ref: Ref) {
+    log(`Cloning ${ref.cloneUrl}`);
+    execSync(`git clone ${ref.cloneUrl} ${project.name}`);
+    execSync(`git checkout ${ref.ref}`, {
         cwd: project.name
     });
 }
@@ -136,4 +218,7 @@ export function s(stringParts, ...expressions: any[]) {
     ).replace(/[\/\\]+/g, '/');
 }
 
-main();
+main().catch(e => {
+    console.error(e);
+    process.exit(1);
+});


### PR DESCRIPTION
## What
- The `workflow_dispatch` now takes a **single `pr` input**: a PR number (for this repo), a full PR URL (for any repo), or a branch name — replacing the separate `branch`/`pr`/`repo` inputs.
- `scripts/create-vsix.ts` now resolves each project's build source with this priority:
  1. rokucommunity branch attached to an open PR
  2. the originating fork owner's same-named branch attached to an open PR (clones the fork)
  3. rokucommunity branch without a PR
  4. master
- The PR comment now includes a **Built from:** section listing exactly which source each of the 5 projects was built from.

## Why
- Fork PRs previously built silently from master (the fork's branch never exists on the rokucommunity clone), producing a vsix with none of the PR's changes. Now the fork branch is used — but only when it belongs to the same owner as the originating PR and is attached to an open PR, so an unrelated fork's `patch-1` can never leak into a build.
- Upstream repos no longer need to pass `branch`/`repo` — just the PR URL.

## Rollout
⚠️ Must merge together with the matching PRs on the dispatcher repos (brighterscript, roku-debug, roku-deploy, brighterscript-formatter, logger, roku-test-automation) — `workflow_dispatch` rejects unknown inputs, so the old `branch`/`repo` payloads fail once this merges.

🤖 Generated with [Claude Code](https://claude.com/claude-code)