### PR TITLE
fix: Prevent stale keep-alive sockets from failing create-vsix

### DIFF
--- a/scripts/create-vsix.ts
+++ b/scripts/create-vsix.ts
@@ -138,7 +138,10 @@ async function findOpenPr(repoName: string, owner: string, branch: string) {
     if (process.env.GITHUB_TOKEN) {
         headers.authorization = `Bearer ${process.env.GITHUB_TOKEN}`;
     }
-    const response = await fetch(url, { headers });
+    //minutes of npm installs/builds pass between calls, and GitHub closes idle keep-alive sockets
+    //long before then. `connection: close` avoids undici reusing a socket the server already dropped
+    //(which surfaces as `TypeError: fetch failed` / UND_ERR_SOCKET "other side closed")
+    const response = await fetch(url, { headers: { ...headers, connection: 'close' } });
     if (!response.ok) {
         log(`Warning: could not look up open PRs for ${owner}:${branch} on ${repoName} (HTTP ${response.status})`);
         return undefined;


### PR DESCRIPTION
`create-vsix` has been failing on most runs since #867, with:

```
TypeError: fetch failed
    at async findOpenPr (scripts/create-vsix.ts:141:22)
  [cause]: SocketError: other side closed
    code: 'UND_ERR_SOCKET',
```

## Cause

`findOpenPr` runs once per project, and consecutive calls are separated by multi-minute `npm i && npm run build && npm pack` runs. GitHub closes idle keep-alive sockets long before the next call, but undici still takes the dead socket from its connection pool, so the request fails before it ever leaves the machine.

The socket dump confirms it — `bytesWritten`/`bytesRead` are non-zero, so the connection had already completed one request/response cycle before being reused.

Because `main()` is `async` with `.catch(… process.exit(1))`, a single failed lookup aborts the entire build after several projects have already been built.

## Fix

Send `connection: close` on the lookup requests so each gets a fresh socket.

## Verification

Ran the full script locally exactly as CI does:

- **Before:** failed at `roku-debug` (the 3rd lookup)
- **After:** all five projects resolve, and the final lookup correctly finds open PR #855

Also ruled out the other candidate explanations:

- **Not auth** — reproduced locally with no `GITHUB_TOKEN` set, so no `authorization` header was sent at all. Auth failures would also return HTTP 401/403 and hit the existing `!response.ok` branch rather than throwing.
- **Not a malformed URL** — the first two lookups succeed using identical URL-construction code, and hitting the exact encoded URL directly returns HTTP 200.
- **Not general network flakiness** — reproduced on the first attempt on a different machine, network, GitHub IP, and Node/undici version.

## Note

This removes the cause, but a transient network blip could still abort a build, since the throw bypasses the graceful `!response.ok` handling immediately below it. These lookups only *improve* ref resolution — priorities 3 and 4 (`git ls-remote`, then `master`) still produce a valid vsix. Wrapping the fetch in a try/catch that returns `undefined` would make failures degrade instead of abort. Left out here to keep the fix focused; happy to add it if wanted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
