### PR TITLE
DeviceManager: order-based discovery (extracted from #865)

### DIFF
--- a/src/BrightScriptCommands.spec.ts
+++ b/src/BrightScriptCommands.spec.ts
@@ -97,6 +97,43 @@ describe('BrightScriptFileUtils ', () => {
         });
     });
 
+    describe('refreshDeviceList / rescanDevices', () => {
+        let capturedCommands: Record<string, (...args: any[]) => any>;
+        let deviceManager: any;
+
+        beforeEach(() => {
+            deviceManager = {
+                submitOrders: sinon.stub(),
+                broadcast: sinon.stub(),
+                reconcile: sinon.stub()
+            };
+            const localCommands = new BrightScriptCommands({} as any, {} as any, vscode.context, deviceManager, {} as any, {} as any, {} as any, {} as any);
+            capturedCommands = {};
+            sinon.stub(vscode.commands as any, 'registerCommand').callsFake((name: any, cb: any) => {
+                capturedCommands[name] = cb;
+            });
+            localCommands.registerCommands();
+        });
+
+        afterEach(() => {
+            (vscode.commands.registerCommand as any).restore();
+        });
+
+        it('refreshDeviceList submits refresh orders instead of scanning directly', () => {
+            capturedCommands['extension.brightscript.refreshDeviceList']();
+            assert.isTrue(deviceManager.submitOrders.calledOnceWith([{ type: 'broadcast', reason: 'refresh-clicked' }, { type: 'reconcile', reason: 'refresh-clicked' }]));
+            assert.isTrue(deviceManager.broadcast.notCalled);
+            assert.isTrue(deviceManager.reconcile.notCalled);
+        });
+
+        it('rescanDevices submits refresh orders instead of scanning directly', () => {
+            capturedCommands['extension.brightscript.rescanDevices']();
+            assert.isTrue(deviceManager.submitOrders.calledOnceWith([{ type: 'broadcast', reason: 'refresh-clicked' }, { type: 'reconcile', reason: 'refresh-clicked' }]));
+            assert.isTrue(deviceManager.broadcast.notCalled);
+            assert.isTrue(deviceManager.reconcile.notCalled);
+        });
+    });
+
     describe('setDefaultDevicePassword', () => {
         let localCommands: BrightScriptCommands;
         let capturedCommands: Record<string, (...args: any[]) => any>;

--- a/src/BrightScriptCommands.ts
+++ b/src/BrightScriptCommands.ts
@@ -59,11 +59,17 @@ export class BrightScriptCommands {
 
         //the "Refresh" button in the Devices list
         this.registerCommand('refreshDeviceList', (key: string) => {
-            this.deviceManager.refresh(true);
+            this.deviceManager.submitOrders([
+                { type: 'broadcast', reason: 'refresh-clicked' },
+                { type: 'reconcile', reason: 'refresh-clicked' }
+            ]);
         });
 
         this.registerCommand('rescanDevices', () => {
-            this.deviceManager.refresh(true);
+            this.deviceManager.submitOrders([
+                { type: 'broadcast', reason: 'refresh-clicked' },
+                { type: 'reconcile', reason: 'refresh-clicked' }
+            ]);
         });
 
         // Refresh a single device (inline button on hover in devices panel)
@@ -349,7 +355,7 @@ export class BrightScriptCommands {
 
         this.registerCommand('clearCurrentDeviceList', async () => {
             const toatsPromise = util.showTimedNotification('Clearing device list');
-            await this.deviceManager.clearCurrentDeviceList();
+            this.deviceManager.clearCurrentDeviceList();
             await toatsPromise;
         });
 

--- a/src/deviceDiscovery/DeviceManager.spec.ts
+++ b/src/deviceDiscovery/DeviceManager.spec.ts
@@ -166,30 +166,253 @@ describe('DeviceManager', () => {
         sinon.restore();
     });
 
-    describe('setScanNeeded', () => {
-        it('emits event when scanNeeded is false', () => {
+    describe('orders (submit + pending sets)', () => {
+        it('a broadcast order lands in the pending set and emits order-submitted with type + reason', () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
             const eventSpy = sinon.spy();
-            manager.on('scanNeeded-changed', eventSpy);
+            manager.on('order-submitted', eventSpy);
 
-            manager['setScanNeeded']();
+            manager.submitOrders([{ type: 'broadcast', reason: 'network' }]);
 
             expect(eventSpy.calledOnce).to.be.true;
+            expect(eventSpy.firstCall.args[0].reason).to.equal('network');
+            expect(manager.getPendingBroadcastReasons()).to.include('network');
         });
 
-        it('does not emit event when scanNeeded is already true', () => {
+        it('a reconcile order lands in the pending set and emits order-submitted with type + reason', () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
-            manager['setScanNeeded'](); // Set to true first
 
             const eventSpy = sinon.spy();
-            manager.on('scanNeeded-changed', eventSpy);
+            manager.on('order-submitted', eventSpy);
 
-            manager['setScanNeeded'](); // Set to true again
+            manager.submitOrders([{ type: 'reconcile', reason: 'config-changed' }]);
 
-            expect(eventSpy.called).to.be.false;
+            expect(eventSpy.calledOnce).to.be.true;
+            expect(eventSpy.firstCall.args[0].reason).to.equal('config-changed');
+            expect(manager.getPendingReconcileReasons()).to.include('config-changed');
         });
 
+        it('different reasons accumulate instead of replacing each other', () => {
+            manager = new DeviceManager(vscode.context, mockGlobalStateManager);
+
+            manager.submitOrders([{ type: 'broadcast', reason: 'sleep' }]);
+            manager.submitOrders([{ type: 'broadcast', reason: 'network' }]);
+            manager.submitOrders([{ type: 'broadcast', reason: 'stale' }]);
+
+            expect(manager.getPendingBroadcastReasons()).to.have.members(['sleep', 'network', 'stale']);
+        });
+
+        it('the same reason never queues twice', () => {
+            manager = new DeviceManager(vscode.context, mockGlobalStateManager);
+
+            manager.submitOrders([{ type: 'broadcast', reason: 'stale' }]);
+            manager.submitOrders([{ type: 'broadcast', reason: 'stale' }]);
+            manager.submitOrders([{ type: 'broadcast', reason: 'stale' }]);
+
+            expect(manager.getPendingBroadcastReasons()).to.eql(['stale']);
+        });
+
+        it('broadcast and reconcile pending sets are independent', () => {
+            manager = new DeviceManager(vscode.context, mockGlobalStateManager);
+
+            manager.submitOrders([{ type: 'broadcast', reason: 'network' }]);
+            manager.submitOrders([{ type: 'reconcile', reason: 'config-changed' }]);
+
+            expect(manager.getPendingBroadcastReasons()).to.include('network');
+            expect(manager.getPendingReconcileReasons()).to.include('config-changed');
+        });
+
+        it('submitOrders accepts multiple orders at once', () => {
+            manager = new DeviceManager(vscode.context, mockGlobalStateManager);
+
+            manager.submitOrders([{ type: 'broadcast', reason: 'refresh-clicked' }, { type: 'reconcile', reason: 'refresh-clicked' }]);
+
+            expect(manager.getPendingBroadcastReasons()).to.eql(['refresh-clicked']);
+            expect(manager.getPendingReconcileReasons()).to.eql(['refresh-clicked']);
+        });
+
+        it('a reconcile-only submission leaves the broadcast set untouched', () => {
+            manager = new DeviceManager(vscode.context, mockGlobalStateManager);
+
+            manager.submitOrders([{ type: 'reconcile', reason: 'config-changed' }]);
+
+            expect(manager.getPendingBroadcastReasons()).to.be.empty;
+            expect(manager.getPendingReconcileReasons()).to.eql(['config-changed']);
+        });
+
+        it('a broadcast-only submission leaves the reconcile set untouched', () => {
+            manager = new DeviceManager(vscode.context, mockGlobalStateManager);
+
+            manager.submitOrders([{ type: 'broadcast', reason: 'unhealthy-device' }]);
+
+            expect(manager.getPendingBroadcastReasons()).to.eql(['unhealthy-device']);
+            expect(manager.getPendingReconcileReasons()).to.be.empty;
+        });
+    });
+
+    describe('fulfillOrders', () => {
+        beforeEach(() => {
+            manager = new DeviceManager(vscode.context, mockGlobalStateManager);
+        });
+
+        it('consumes and executes a pending broadcast, passing its reason through', () => {
+            const broadcastStub = sinon.stub(manager as any, 'broadcast').returns(true);
+            manager.submitOrders([{ type: 'broadcast', reason: 'network' }]);
+
+            const result = manager.fulfillOrders({ types: ['broadcast'] }).length > 0;
+
+            expect(result).to.be.true;
+            expect(broadcastStub.calledOnceWith(['network'])).to.be.true;
+            expect(manager.getPendingBroadcastReasons()).to.be.empty;
+        });
+
+        it('consumes all accumulated reasons in a single execution', () => {
+            const broadcastStub = sinon.stub(manager as any, 'broadcast').returns(true);
+            manager.submitOrders([{ type: 'broadcast', reason: 'sleep' }]);
+            manager.submitOrders([{ type: 'broadcast', reason: 'network' }]);
+
+            const result = manager.fulfillOrders({ types: ['broadcast'] }).length > 0;
+
+            expect(result).to.be.true;
+            expect(broadcastStub.calledOnce).to.be.true;
+            expect(broadcastStub.firstCall.args[0]).to.have.members(['sleep', 'network']);
+            expect(manager.getPendingBroadcastReasons()).to.be.empty;
+        });
+
+        it('passes a stale reason through (broadcast applies the staleness gate itself)', () => {
+            const broadcastStub = sinon.stub(manager as any, 'broadcast').returns(false);
+            manager.submitOrders([{ type: 'broadcast', reason: 'stale' }]);
+
+            manager.fulfillOrders({ types: ['broadcast'] });
+
+            expect(broadcastStub.calledOnceWith(['stale'])).to.be.true;
+        });
+
+        it('leaves except-listed reasons QUEUED instead of consuming them', () => {
+            const broadcastStub = sinon.stub(manager as any, 'broadcast').returns(true);
+            manager.submitOrders([{ type: 'broadcast', reason: 'stale' }]);
+
+            const result = manager.fulfillOrders({ types: ['broadcast'], except: ['stale'] }).length > 0;
+
+            expect(result).to.be.false;
+            expect(broadcastStub.called).to.be.false;
+            expect(manager.getPendingBroadcastReasons()).to.include('stale');
+        });
+
+        it('when a real reason triggers execution, the whole set is cleared — excepted reasons included', () => {
+            const broadcastStub = sinon.stub(manager as any, 'broadcast').returns(true);
+            manager.submitOrders([{ type: 'broadcast', reason: 'stale' }]);
+            manager.submitOrders([{ type: 'broadcast', reason: 'network' }]);
+
+            const result = manager.fulfillOrders({ types: ['broadcast'], except: ['stale'] }).length > 0;
+
+            //the scan satisfies the stale want too, so it rides along instead of staying queued
+            expect(result).to.be.true;
+            expect(broadcastStub.calledOnce).to.be.true;
+            expect(broadcastStub.firstCall.args[0]).to.have.members(['stale', 'network']);
+            expect(manager.getPendingBroadcastReasons()).to.be.empty;
+        });
+
+        it('returns false and does nothing when no order is pending', () => {
+            const broadcastStub = sinon.stub(manager as any, 'broadcast').returns(true);
+
+            expect(manager.fulfillOrders({ types: ['broadcast'] })).to.be.empty;
+            expect(broadcastStub.called).to.be.false;
+        });
+
+        it('is atomic: a second fulfillment finds the set empty', () => {
+            const broadcastStub = sinon.stub(manager as any, 'broadcast').returns(true);
+            manager.submitOrders([{ type: 'broadcast', reason: 'network' }]);
+
+            expect(manager.fulfillOrders({ types: ['broadcast'] })).to.not.be.empty;
+            expect(manager.fulfillOrders({ types: ['broadcast'] })).to.be.empty;
+            expect(broadcastStub.calledOnce).to.be.true;
+        });
+
+        it('passes the reconcile reason through (reconcile decides cache bypass itself)', () => {
+            const reconcileStub = sinon.stub(manager as any, 'reconcile');
+
+            manager.submitOrders([{ type: 'reconcile', reason: 'config-changed' }]);
+            expect(manager.fulfillOrders({ types: ['reconcile'] })).to.not.be.empty;
+            expect(reconcileStub.calledOnceWith(['config-changed'])).to.be.true;
+
+            reconcileStub.resetHistory();
+            manager.submitOrders([{ type: 'reconcile', reason: 'refresh-clicked' }]);
+            expect(manager.fulfillOrders({ types: ['reconcile'] })).to.not.be.empty;
+            expect(reconcileStub.calledOnceWith(['refresh-clicked'])).to.be.true;
+        });
+
+        it('leaves an except-listed reconcile queued', () => {
+            const reconcileStub = sinon.stub(manager as any, 'reconcile');
+            manager.submitOrders([{ type: 'reconcile', reason: 'stale' }]);
+
+            expect(manager.fulfillOrders({ types: ['reconcile'], except: ['stale'] })).to.be.empty;
+            expect(reconcileStub.called).to.be.false;
+            expect(manager.getPendingReconcileReasons()).to.include('stale');
+        });
+
+        it('fulfills both order types in one call, returning what was taken', () => {
+            const broadcastStub = sinon.stub(manager as any, 'broadcast').returns(true);
+            const reconcileStub = sinon.stub(manager as any, 'reconcile');
+            manager.submitOrders([{ type: 'broadcast', reason: 'refresh-clicked' }, { type: 'reconcile', reason: 'refresh-clicked' }]);
+
+            const result = manager.fulfillOrders({ types: ['broadcast', 'reconcile'] });
+
+            expect(result).to.eql([
+                { type: 'broadcast', reasons: ['refresh-clicked'] },
+                { type: 'reconcile', reasons: ['refresh-clicked'] }
+            ]);
+            expect(broadcastStub.calledOnceWith(['refresh-clicked'])).to.be.true;
+            expect(reconcileStub.calledOnceWith(['refresh-clicked'])).to.be.true;
+            expect(manager.getPendingBroadcastReasons()).to.be.empty;
+            expect(manager.getPendingReconcileReasons()).to.be.empty;
+        });
+
+        it('passes the except list to both order types', () => {
+            const broadcastStub = sinon.stub(manager as any, 'broadcast').returns(true);
+            const reconcileStub = sinon.stub(manager as any, 'reconcile');
+            manager.submitOrders([{ type: 'broadcast', reason: 'stale' }]);
+            manager.submitOrders([{ type: 'reconcile', reason: 'stale' }]);
+
+            const result = manager.fulfillOrders({ types: ['broadcast', 'reconcile'], except: ['stale'] });
+
+            expect(result).to.be.empty;
+            expect(broadcastStub.called).to.be.false;
+            expect(reconcileStub.called).to.be.false;
+            expect(manager.getPendingBroadcastReasons()).to.include('stale');
+            expect(manager.getPendingReconcileReasons()).to.include('stale');
+        });
+    });
+
+    describe('stale timers', () => {
+        it('activateMonitoring starts the stale order timers, deactivateMonitoring stops them', async () => {
+            const clock = sinon.useFakeTimers();
+            try {
+                manager = new DeviceManager(vscode.context, mockGlobalStateManager);
+                sinon.stub(manager['finder'], 'start').resolves();
+                sinon.stub(manager['networkChangeMonitor'], 'start');
+                sinon.stub(manager['networkChangeMonitor'], 'stop');
+
+                await manager['activateMonitoring']();
+
+                clock.tick(manager['STALE_RECONCILE_INTERVAL_MS']);
+                expect(manager.getPendingReconcileReasons()).to.include('stale');
+
+                clock.tick(manager['STALE_SCAN_THRESHOLD_MS']);
+                expect(manager.getPendingBroadcastReasons()).to.include('stale');
+
+                //consume the pending orders, stop monitoring, and verify no new stale orders arrive
+                manager['orders'].take({ types: ['broadcast', 'reconcile'] });
+                manager['deactivateMonitoring']();
+
+                clock.tick(manager['STALE_SCAN_THRESHOLD_MS'] * 2);
+                expect(manager.getPendingBroadcastReasons()).to.be.empty;
+                expect(manager.getPendingReconcileReasons()).to.be.empty;
+            } finally {
+                clock.restore();
+            }
+        });
     });
 
     describe('timeSinceLastScan', () => {
@@ -198,12 +421,12 @@ describe('DeviceManager', () => {
             expect(manager['timeSinceLastScan']).to.equal(Infinity);
         });
 
-        it('returns elapsed time after refresh', () => {
+        it('returns elapsed time after a broadcast', () => {
             const clock = sinon.useFakeTimers();
             try {
                 manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
-                manager.refresh(true);
+                manager['broadcast'](['refresh-clicked']);
 
                 clock.tick(5_000);
 
@@ -399,16 +622,14 @@ describe('DeviceManager', () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
             const handler = sinon.spy();
-            const unsubscribe = manager.on('scanNeeded-changed', handler);
+            const unsubscribe = manager.on('order-submitted', handler);
 
-            manager['setScanNeeded']();
+            manager.submitOrders([{ type: 'broadcast', reason: 'network' }]);
             expect(handler.calledOnce).to.be.true;
 
             unsubscribe();
 
-            // Reset via refresh and try again
-            manager.refresh(true);
-            manager['setScanNeeded']();
+            manager.submitOrders([{ type: 'broadcast', reason: 'network' }]);
             expect(handler.calledOnce).to.be.true; // Still just one call (unsubscribed)
         });
 
@@ -416,7 +637,7 @@ describe('DeviceManager', () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
             const disposables: any[] = [];
-            manager.on('scanNeeded-changed', () => { }, disposables);
+            manager.on('order-submitted', () => { }, disposables);
 
             expect(disposables.length).to.equal(1);
             expect(disposables[0]).to.have.property('dispose');
@@ -491,88 +712,97 @@ describe('DeviceManager', () => {
         });
     });
 
-    describe('refresh', () => {
-        it('resets scanNeeded flag (allows event to fire again)', () => {
-            manager = new DeviceManager(vscode.context, mockGlobalStateManager);
-
-            const eventSpy = sinon.spy();
-            manager.on('scanNeeded-changed', eventSpy);
-
-            manager['setScanNeeded']();
-            expect(eventSpy.calledOnce).to.be.true;
-
-            // Before refresh, calling setScanNeeded again should not emit
-            manager['setScanNeeded']();
-            expect(eventSpy.calledOnce).to.be.true;
-
-            // After refresh, the flag is reset so event should fire again
-            manager.refresh(true);
-            manager['setScanNeeded']();
-            expect(eventSpy.calledTwice).to.be.true;
-        });
-
-        it('sets lastScanDate', () => {
+    describe('reconcile', () => {
+        it('sets lastScanDate via broadcast', () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
             expect(manager['timeSinceLastScan']).to.equal(Infinity);
 
-            manager.refresh(true);
+            manager['broadcast'](['refresh-clicked']);
 
-            // After refresh, timeSinceLastScan should be very small (just happened)
+            // After a broadcast, timeSinceLastScan should be very small (just happened)
             expect(manager['timeSinceLastScan']).to.be.lessThan(100);
         });
 
-        it('calls healthCheckAllDevices with force flag', () => {
+        it('bypasses the device-info cache (force) only for refresh-clicked', () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
             const healthCheckAllDevicesSpy = sinon.stub(manager as any, 'healthCheckAllDevices').resolves();
 
-            manager.refresh(true);
+            manager['reconcile'](['refresh-clicked']);
             expect(healthCheckAllDevicesSpy.calledWith(true)).to.be.true;
 
-            manager.refresh(false);
+            manager['reconcile'](['config-changed']);
             expect(healthCheckAllDevicesSpy.calledWith(false)).to.be.true;
 
-            manager.refresh(); // defaults to false
-            expect(healthCheckAllDevicesSpy.calledWith(false)).to.be.true;
+            manager['reconcile'](['network']);
+            expect(healthCheckAllDevicesSpy.lastCall.args[0]).to.equal(false);
         });
     });
 
-    describe('scan', () => {
+    describe('broadcast', () => {
         it('triggers discovery without health checking', () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
 
-            const discoverAllSpy = sinon.spy(manager as any, 'discoverAll');
+            const finderScanSpy = sinon.stub(manager['finder'], 'scan');
             const healthCheckAllDevicesSpy = sinon.spy(manager as any, 'healthCheckAllDevices');
 
-            manager.scan(true);
+            manager['broadcast'](['refresh-clicked']);
 
-            expect(discoverAllSpy.calledOnce).to.be.true;
+            expect(finderScanSpy.calledOnce).to.be.true;
             expect(healthCheckAllDevicesSpy.called).to.be.false;
         });
 
-        it('respects deviceDiscoveryEnabled when force=false', () => {
+        it('a stale reason does not scan while device discovery is disabled', () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
             sinon.stub(manager as any, 'deviceDiscoveryEnabled').get(() => false);
 
-            const discoverAllSpy = sinon.spy(manager as any, 'discoverAll');
+            const finderScanSpy = sinon.stub(manager['finder'], 'scan');
 
-            const result = manager.scan(false);
+            const result = manager['broadcast'](['stale']);
 
             expect(result).to.be.false;
-            expect(discoverAllSpy.called).to.be.false;
+            expect(finderScanSpy.called).to.be.false;
         });
 
-        it('ignores deviceDiscoveryEnabled when force=true', () => {
+        it('a real reason scans even while device discovery is disabled (explicit user intent)', () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
             sinon.stub(manager as any, 'deviceDiscoveryEnabled').get(() => false);
 
-            const discoverAllSpy = sinon.spy(manager as any, 'discoverAll');
+            const finderScanSpy = sinon.stub(manager['finder'], 'scan');
 
-            const result = manager.scan(true);
+            const result = manager['broadcast'](['refresh-clicked']);
 
             expect(result).to.be.true;
-            expect(discoverAllSpy.calledOnce).to.be.true;
+            expect(finderScanSpy.calledOnce).to.be.true;
+        });
+
+        it('a stale reason is staleness-gated: no scan when the last scan is recent', () => {
+            manager = new DeviceManager(vscode.context, mockGlobalStateManager);
+            sinon.stub(manager['finder'], 'scan');
+
+            expect(manager['broadcast'](['refresh-clicked'])).to.be.true; //sets lastScanDate
+            expect(manager['broadcast'](['stale'])).to.be.false; //fresh — gate closed
+        });
+
+        it('the gate only applies when stale is the ONLY reason: stale + a real reason scans', () => {
+            manager = new DeviceManager(vscode.context, mockGlobalStateManager);
+            sinon.stub(manager['finder'], 'scan');
+
+            expect(manager['broadcast'](['refresh-clicked'])).to.be.true; //sets lastScanDate
+            expect(manager['broadcast'](['stale', 'network'])).to.be.true; //the real reason wins
+        });
+
+        it('a stale reason scans when the last scan is older than the threshold', () => {
+            manager = new DeviceManager(vscode.context, mockGlobalStateManager);
+            //the suite-wide config stub disables discovery; this test is about the staleness half of the gate
+            sinon.stub(manager as any, 'deviceDiscoveryEnabled').get(() => true);
+            sinon.stub(manager['finder'], 'scan');
+
+            //backdate the last scan past the staleness threshold
+            manager['lastScanDate'] = new Date(Date.now() - manager['STALE_SCAN_THRESHOLD_MS'] - 1);
+
+            expect(manager['broadcast'](['stale'])).to.be.true;
         });
 
         it('emits scan-started event', () => {
@@ -583,7 +813,7 @@ describe('DeviceManager', () => {
                 const scanStartedSpy = sinon.spy();
                 manager.on('scan-started', scanStartedSpy);
 
-                manager.scan(true);
+                manager['broadcast'](['refresh-clicked']);
 
                 expect(scanStartedSpy.calledOnce).to.be.true;
             } finally {
@@ -760,7 +990,7 @@ describe('DeviceManager', () => {
                 const scanStartedSpy = sinon.spy();
                 manager.on('scan-started', scanStartedSpy);
 
-                manager.refresh(true);
+                manager['broadcast'](['refresh-clicked']);
 
                 expect(scanStartedSpy.calledOnce).to.be.true;
             } finally {
@@ -776,7 +1006,7 @@ describe('DeviceManager', () => {
                 const scanEndedSpy = sinon.spy();
                 manager.on('scan-ended', scanEndedSpy);
 
-                manager.refresh(true);
+                manager['broadcast'](['refresh-clicked']);
 
                 // Not ended yet - neither timer has fired
                 expect(scanEndedSpy.called).to.be.false;
@@ -801,11 +1031,11 @@ describe('DeviceManager', () => {
                 const scanStartedSpy = sinon.spy();
                 manager.on('scan-started', scanStartedSpy);
 
-                manager.refresh(true);
+                manager['broadcast'](['refresh-clicked']);
                 expect(scanStartedSpy.calledOnce).to.be.true;
 
                 // Try to start another scan while one is in progress
-                manager.refresh(true);
+                manager['broadcast'](['refresh-clicked']);
                 expect(scanStartedSpy.calledOnce).to.be.true; // Still just one call
             } finally {
                 clock.restore();
@@ -822,7 +1052,7 @@ describe('DeviceManager', () => {
                 manager.on('scan-started', scanStartedSpy);
                 manager.on('scan-ended', scanEndedSpy);
 
-                manager.refresh(true);
+                manager['broadcast'](['refresh-clicked']);
                 expect(scanStartedSpy.calledOnce).to.be.true;
 
                 // Complete the scan
@@ -830,7 +1060,7 @@ describe('DeviceManager', () => {
                 expect(scanEndedSpy.calledOnce).to.be.true;
 
                 // Now can start a new scan
-                manager.refresh(true);
+                manager['broadcast'](['refresh-clicked']);
                 expect(scanStartedSpy.calledTwice).to.be.true;
             } finally {
                 clock.restore();
@@ -1019,8 +1249,8 @@ describe('DeviceManager', () => {
             const device = createMockDevice({ serialNumber: 'device-123' });
             addDevice(device);
 
-            // Stub refresh to prevent cascade of health checks
-            sinon.stub(manager, 'refresh');
+            // Stub the unhealthy-device order path to prevent cascade of health checks
+            sinon.stub(manager as any, 'submitUnhealthyDeviceBroadcast');
 
             // Create two controllable promises for the health checks
             let rejectSlowCheck: (err: Error) => void;
@@ -1072,8 +1302,8 @@ describe('DeviceManager', () => {
             addDevice(device1);
             addDevice(device2);
 
-            // Stub refresh to prevent cascade of health checks
-            sinon.stub(manager, 'refresh');
+            // Stub the unhealthy-device order path to prevent cascade of health checks
+            sinon.stub(manager as any, 'submitUnhealthyDeviceBroadcast');
 
             let resolveDevice1: (value: any) => void;
             let resolveDevice2: (value: any) => void;
@@ -2343,10 +2573,8 @@ describe('DeviceManager', () => {
             expect(manager['discoveredDevices'].length).to.equal(0);
         });
 
-        it('calls setScanNeeded when network changes', () => {
+        it('submits broadcast + reconcile orders when the network changes', () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
-
-            const setScanNeededSpy = sinon.spy(manager as any, 'setScanNeeded');
 
             // Change the network hash
             (NetworkChangeMonitorModule.getNetworkHash as sinon.SinonStub).returns('new-network-hash');
@@ -2354,7 +2582,8 @@ describe('DeviceManager', () => {
             // Trigger the network change callback directly
             manager['networkChangeMonitor']['onNetworkChanged']();
 
-            expect(setScanNeededSpy.calledOnce).to.be.true;
+            expect(manager.getPendingBroadcastReasons()).to.include('network');
+            expect(manager.getPendingReconcileReasons()).to.include('network');
         });
 
         it('clears discovered devices when network changes', () => {
@@ -2526,7 +2755,7 @@ describe('DeviceManager', () => {
             it('marks configured device as offline when health check fails and cache exists', async () => {
                 manager = new DeviceManager(vscode.context, mockGlobalStateManager);
                 sinon.stub(manager as any, 'randomDelay').resolves();
-                sinon.stub(manager as any, 'refresh').resolves();
+                sinon.stub(manager as any, 'submitUnhealthyDeviceBroadcast');
 
                 const device = createMockDevice({
                     serialNumber: 'device-123',
@@ -2554,7 +2783,7 @@ describe('DeviceManager', () => {
             it('marks configured device as offline when health check fails and no cache exists', async () => {
                 manager = new DeviceManager(vscode.context, mockGlobalStateManager);
                 sinon.stub(manager as any, 'randomDelay').resolves();
-                sinon.stub(manager as any, 'refresh').resolves();
+                sinon.stub(manager as any, 'submitUnhealthyDeviceBroadcast');
 
                 const device = createMockDevice({
                     serialNumber: 'device-123',
@@ -2581,7 +2810,7 @@ describe('DeviceManager', () => {
             it('removes discovered-only device when health check fails', async () => {
                 manager = new DeviceManager(vscode.context, mockGlobalStateManager);
                 sinon.stub(manager as any, 'randomDelay').resolves();
-                sinon.stub(manager as any, 'refresh').resolves();
+                sinon.stub(manager as any, 'submitUnhealthyDeviceBroadcast');
 
                 const device = createMockDevice({
                     serialNumber: 'device-123',
@@ -2613,7 +2842,7 @@ describe('DeviceManager', () => {
             it('sets isDiscovered false when health check fails on configured device', async () => {
                 manager = new DeviceManager(vscode.context, mockGlobalStateManager);
                 sinon.stub(manager as any, 'randomDelay').resolves();
-                sinon.stub(manager as any, 'refresh').resolves();
+                sinon.stub(manager as any, 'submitUnhealthyDeviceBroadcast');
 
                 const device = createMockDevice({
                     ip: '192.168.1.100',
@@ -2636,7 +2865,7 @@ describe('DeviceManager', () => {
             it('removes discovered-only device when health check fails', async () => {
                 manager = new DeviceManager(vscode.context, mockGlobalStateManager);
                 sinon.stub(manager as any, 'randomDelay').resolves();
-                sinon.stub(manager as any, 'refresh').resolves();
+                sinon.stub(manager as any, 'submitUnhealthyDeviceBroadcast');
 
                 const device = createMockDevice({
                     ip: '192.168.1.100',
@@ -3046,20 +3275,21 @@ describe('DeviceManager', () => {
                     const clock = sinon.useFakeTimers();
                     try {
                         manager = new DeviceManager(vscode.context, mockGlobalStateManager);
+                        sinon.stub(manager as any, 'deviceDiscoveryEnabled').get(() => true);
 
                         // Simulate recent scan
                         manager['lastScanDate'] = new Date();
                         sinon.stub(manager['finder'], 'scan');
 
-                        // discoverAll should return false (scan not needed)
-                        let scanStarted = manager['discoverAll'](false);
+                        // a stale-only broadcast is gated off while the last scan is recent
+                        let scanStarted = manager['broadcast'](['stale']);
                         expect(scanStarted).to.be.false;
 
                         // Clear cache
                         manager.clearAllCache();
 
                         // Now scan should be allowed (lastScanDate is null, timeSinceLastScan is Infinity)
-                        scanStarted = manager['discoverAll'](false);
+                        scanStarted = manager['broadcast'](['stale']);
                         expect(scanStarted).to.be.true;
                     } finally {
                         clock.restore();
@@ -3606,7 +3836,7 @@ describe('DeviceManager', () => {
             it('shows online when configured at wrong IP and discovered at correct IP resolve concurrently', async () => {
                 manager = new DeviceManager(vscode.context, mockGlobalStateManager);
                 sinon.stub(manager as any, 'randomDelay').resolves();
-                sinon.stub(manager as any, 'refresh').resolves();
+                sinon.stub(manager as any, 'submitUnhealthyDeviceBroadcast');
 
                 // Configured device XYZ at wrong IP (192.168.1.100)
                 const configuredDevice = createMockDevice({
@@ -3654,7 +3884,7 @@ describe('DeviceManager', () => {
             it('shows online regardless of which concurrent health check completes first', async () => {
                 manager = new DeviceManager(vscode.context, mockGlobalStateManager);
                 sinon.stub(manager as any, 'randomDelay').resolves();
-                sinon.stub(manager as any, 'refresh').resolves();
+                sinon.stub(manager as any, 'submitUnhealthyDeviceBroadcast');
 
                 // Same setup: configured at wrong IP, discovered at correct IP
                 addDevice(createMockDevice({

--- a/src/deviceDiscovery/DeviceManager.ts
+++ b/src/deviceDiscovery/DeviceManager.ts
@@ -7,6 +7,8 @@ import type { RceFinder } from './RceFinder';
 import { util as rokuDebugUtil } from 'roku-debug/dist/util';
 import type { GlobalStateManager } from '../GlobalStateManager';
 import { RokuFinder } from './RokuFinder';
+import { Orders } from './Orders';
+import type { Order, OrderType, SubmittedOrder, TakenOrders, BroadcastReason, ReconcileReason } from './Orders';
 import { NetworkChangeMonitor, getNetworkHash } from './NetworkChangeMonitor';
 import { SystemSleepMonitor } from './SystemSleepMonitor';
 import { util } from '../util';
@@ -124,8 +126,10 @@ export class DeviceManager {
             //if the `deviceDiscovery.enabled` setting was changed, start or stop monitoring
             if (event?.affectsConfiguration('brightscript.deviceDiscovery.enabled')) {
                 if (this.deviceDiscoveryEnabled) {
-                    //emit that we need a scan (will trigger UI to refresh and show devices as needed when enabled)
-                    this.setScanNeeded(true);
+                    this.submitOrders([
+                        { type: 'broadcast', reason: 'startup' },
+                        { type: 'reconcile', reason: 'startup' }
+                    ]);
                     this.systemSleepMonitor.start();
                     void this.activateMonitoring();
                 } else {
@@ -139,11 +143,11 @@ export class DeviceManager {
                 this.emitDevicesChanged();
             }
 
-            //if the `devices` setting was changed, re-apply configured devices and health check them
+            //if the `devices` setting was changed, re-apply configured devices immediately (cheap,
+            //local) and order a health check for the views to fulfill when one is visible
             if (event?.affectsConfiguration('brightscript.devices')) {
-                this.loadConfiguredDevices().then(() => {
-                    return this.healthCheckAllDevices(false, true);
-                }).catch(() => { });
+                this.loadConfiguredDevices().catch(() => { });
+                this.submitOrders([{ type: 'reconcile', reason: 'config-changed' }]);
             }
 
             //if the `defaultDevicePassword` setting was changed, refresh any device views that rely on it
@@ -171,7 +175,10 @@ export class DeviceManager {
 
     private setupMonitors() {
         this.systemSleepMonitor = new SystemSleepMonitor(() => {
-            this.setScanNeeded();
+            this.submitOrders([
+                { type: 'broadcast', reason: 'sleep' },
+                { type: 'reconcile', reason: 'sleep' }
+            ]);
         });
         this.networkChangeMonitor = new NetworkChangeMonitor(() => {
             this.networkId = getNetworkHash();
@@ -189,8 +196,10 @@ export class DeviceManager {
 
             this.restartRokuFinder();
 
-            //this is important for telling the devices view to refresh and health check its devices
-            this.setScanNeeded();
+            this.submitOrders([
+                { type: 'broadcast', reason: 'network' },
+                { type: 'reconcile', reason: 'network' }
+            ]);
         });
     }
 
@@ -209,14 +218,13 @@ export class DeviceManager {
             // Sleep monitor runs all the time when enabled (ignores focus state)
             this.systemSleepMonitor.start();
 
-            this.activateMonitoring().then(() => {
-                const lastSeenDeviceIds = this.globalStateManager.getLastSeenDevices(this.networkId);
-                if (lastSeenDeviceIds.length === 0) {
-                    this.refresh();
-                } else {
-                    this.setScanNeeded();
-                }
-            }).catch((e) => {
+            //no proactive scan here, even on a cold cache - orders queue until a view is visible
+            this.submitOrders([
+                { type: 'broadcast', reason: 'startup' },
+                { type: 'reconcile', reason: 'startup' }
+            ]);
+
+            this.activateMonitoring().catch((e) => {
                 console.error(e);
             });
         }
@@ -227,9 +235,15 @@ export class DeviceManager {
     private configuredDevices: ConfiguredDeviceEntry[] = [];
     private discoveredDevices: DiscoveredDeviceEntry[] = [];
     private rceDevices: RceDeviceEntry[] = [];
-    private scanNeeded = false;
     private lastUsedDeviceKey: string | undefined = undefined;
     private networkId: string;
+
+    // Orders (see docs/device-discovery.md "Orders")
+    private orders = new Orders((order, timestamp) => {
+        this.emitter.emit('order-submitted', { ...order, timestamp: timestamp });
+    });
+    private broadcastStaleTimer: ReturnType<typeof setInterval> | undefined;
+    private reconcileStaleTimer: ReturnType<typeof setInterval> | undefined;
 
     private emitter = new EventEmitter();
     private systemSleepMonitor: SystemSleepMonitor;
@@ -250,14 +264,17 @@ export class DeviceManager {
     private readonly DEVICES_CHANGED_DEBOUNCE_MS = 50;
     private deviceOnlineNotifiers = new Map<string, ReturnType<typeof debounce>>();
 
-    // Scan state management
+    // Scan state management. STALE_SCAN_THRESHOLD_MS is both the stale-only broadcast gate
+    // and the stale broadcast timer interval
     private readonly STALE_SCAN_THRESHOLD_MS = 30 * 60 * 1_000; // 30 minutes
+    private readonly STALE_RECONCILE_INTERVAL_MS = 5 * 60 * 1_000; // 5 minutes
+    private readonly UNHEALTHY_BROADCAST_MIN_INTERVAL_MS = 60_000; // 1 minute - suppress unhealthy-device orders this soon after a scan
     private lastScanDate: Date | null = null;
 
     public on(eventName: 'devices-changed', handler: () => void, disposables?: Disposable[]): () => void;
     public on(eventName: 'scan-started', handler: () => void, disposables?: Disposable[]): () => void;
     public on(eventName: 'scan-ended', handler: () => void, disposables?: Disposable[]): () => void;
-    public on(eventName: 'scanNeeded-changed', handler: () => void, disposables?: Disposable[]): () => void;
+    public on(eventName: 'order-submitted', handler: (order: SubmittedOrder) => void, disposables?: Disposable[]): () => void;
     public on(eventName: string, handler: (payload: any) => void, disposables?: Disposable[]): () => void {
         this.emitter.on(eventName, handler);
         const unsubscribe = () => {
@@ -652,36 +669,90 @@ export class DeviceManager {
         return !!this.globalStateManager.getCachedDevice(serialNumber);
     }
 
+    // #region Orders (docs/device-discovery.md "Orders" / "When are orders submitted?")
     /**
-     * Re-scan the network for devices and health-check existing ones
+     * Submit orders. Emits `order-submitted` so a visible view can fulfill immediately;
+     * hidden views drain the pending sets when they open.
      */
-    public refresh(force = false, doSyntheticDelay = true): boolean {
-        this.healthCheckAllDevices(force, doSyntheticDelay).catch(() => { });
-        // Block automatic scans when device discovery is disabled
-        if (!force && !this.deviceDiscoveryEnabled) {
-            return false;
-        }
-        return this.discoverAll(force);
+    public submitOrders(orders: Order[]): void {
+        this.orders.submit(orders);
+    }
+
+    public getPendingBroadcastReasons(): BroadcastReason[] {
+        return this.orders.getPending('broadcast');
+    }
+
+    public getPendingReconcileReasons(): ReconcileReason[] {
+        return this.orders.getPending('reconcile');
     }
 
     /**
-     * Trigger a network scan for devices without health checking existing devices.
-     * Use this when you just want to discover new devices without verifying existing ones.
-     * @param force - If true, scan even if deviceDiscovery is disabled
-     * @returns true if a scan was started, false otherwise
+     * Atomically consume and execute pending orders (see {@link Orders.take} for the
+     * types/except semantics). Returns what was taken and executed.
      */
-    public scan(force = false): boolean {
-        if (!force && !this.deviceDiscoveryEnabled) {
-            return false;
+    public fulfillOrders(options: { types: OrderType[]; except?: Array<BroadcastReason | ReconcileReason> }): TakenOrders[] {
+        const taken = this.orders.take(options);
+        for (const orders of taken) {
+            if (orders.type === 'broadcast') {
+                this.broadcast(orders.reasons);
+            } else {
+                this.reconcile(orders.reasons);
+            }
         }
-        return this.discoverAll(force);
+        return taken;
     }
+
+    /**
+     * Broadcast an SSDP M-SEARCH to discover devices on the network.
+     * @returns true if a scan was started
+     */
+    private broadcast(reasons: BroadcastReason[]): boolean {
+        //a stale-only fulfillment is just a freshness hint - skip unless discovery is enabled
+        //and the last scan is old
+        const staleOnly = reasons.every(x => x === 'stale');
+        if (staleOnly) {
+            if (!this.deviceDiscoveryEnabled || this.timeSinceLastScan <= this.STALE_SCAN_THRESHOLD_MS) {
+                return false;
+            }
+        }
+        this.lastScanDate = new Date();
+        this.finder.scan();
+        void this.rceFinder?.scan();
+        return true;
+    }
+
+    /**
+     * Health-check every known device (configured + discovered), marking them online/offline.
+     * Only an explicit user refresh bypasses each device's cache trust window.
+     */
+    private reconcile(reasons: ReconcileReason[]): void {
+        //an explicit user refresh demands fresh data (force bypasses the device-info cache)
+        const force = reasons.includes('refresh-clicked');
+        this.healthCheckAllDevices(force).catch((e) => {
+            console.error('[DeviceManager] reconcile health check failed', e);
+        });
+    }
+
+    /**
+     * Submit an `unhealthy-device` broadcast order. Rate-limited - this is the terminating
+     * guard for the scan → health-check → fail → scan feedback loop.
+     */
+    private submitUnhealthyDeviceBroadcast(): void {
+        if (!this.deviceDiscoveryEnabled) {
+            return;
+        }
+        if (this.timeSinceLastScan < this.UNHEALTHY_BROADCAST_MIN_INTERVAL_MS) {
+            return;
+        }
+        this.submitOrders([{ type: 'broadcast', reason: 'unhealthy-device' }]);
+    }
+    // #endregion
 
     /**
      * Clear discovered devices from the device list, keeping configured devices.
      * Useful for refreshing the network scan without losing user-configured devices.
      */
-    public async clearCurrentDeviceList() {
+    public clearCurrentDeviceList(): void {
         // Clear discovered devices (ephemeral)
         this.discoveredDevices = [];
 
@@ -695,9 +766,8 @@ export class DeviceManager {
         //clear the cache for the current list of devices
         this.globalStateManager.setLastSeenDevices(this.networkId, []);
 
-        await this.healthCheckAllDevices(false, false).catch(() => { });
+        this.submitOrders([{ type: 'reconcile', reason: 'refresh-clicked' }]);
         this.emitDevicesChanged();
-
     }
 
     public clearAllCache() {
@@ -721,7 +791,7 @@ export class DeviceManager {
         }
 
         // Clear discovered devices (state goes with them)
-        this.clearCurrentDeviceList().catch(() => { });
+        this.clearCurrentDeviceList();
     }
 
     public async healthCheckDevice(deviceOrLookup: RokuDevice | { ip?: string; serialNumber?: string }, force = false, doSyntheticDelay = true): Promise<boolean> {
@@ -745,8 +815,8 @@ export class DeviceManager {
         // Cooldown is handled by fetchDeviceInfo cache; force bypasses it
         const isHealthy = await this.resolveDevice(device, doSyntheticDelay, force);
         if (!isHealthy && device.isDiscovered) {
-            // force a scan if passive scan is permitted
-            this.refresh(this.deviceDiscoveryEnabled);
+            //a discovered device went dark - order a rescan for the views to fulfill
+            this.submitUnhealthyDeviceBroadcast();
         }
         return isHealthy;
     }
@@ -1150,7 +1220,8 @@ export class DeviceManager {
         await rceScan;
 
         if (needsScan) {
-            this.discoverAll(this.deviceDiscoveryEnabled);
+            //a discovered device went dark - order a rescan for the views to fulfill
+            this.submitUnhealthyDeviceBroadcast();
         }
     }
 
@@ -1220,21 +1291,6 @@ export class DeviceManager {
             return undefined;
         }
     }
-
-    /**
-     * Discover all Roku devices on the network and watch for new ones that connect
-     */
-    private discoverAll(force: boolean): boolean {
-        if (force || this.scanNeeded || this.timeSinceLastScan > this.STALE_SCAN_THRESHOLD_MS) {
-            this.scanNeeded = false;
-            this.lastScanDate = new Date();
-            this.finder.scan();
-            void this.rceFinder?.scan();
-            return true;
-        }
-        return false;
-    }
-
 
     /**
      * Add or update a device in the discoveredDevices array.
@@ -1534,13 +1590,37 @@ export class DeviceManager {
     private async activateMonitoring() {
         this.networkChangeMonitor.start();
         this.rceFinder?.start();
+
+        //periodically submit `stale` orders so long-lived sessions eventually refresh
+        this.stopStaleTimers();
+        this.broadcastStaleTimer = setInterval(() => {
+            this.submitOrders([{ type: 'broadcast', reason: 'stale' }]);
+        }, this.STALE_SCAN_THRESHOLD_MS);
+        this.reconcileStaleTimer = setInterval(() => {
+            this.submitOrders([{ type: 'reconcile', reason: 'stale' }]);
+        }, this.STALE_RECONCILE_INTERVAL_MS);
+        this.broadcastStaleTimer?.unref?.();
+        this.reconcileStaleTimer?.unref?.();
+
         await this.startRokuFinder();
     }
 
     private deactivateMonitoring() {
         this.networkChangeMonitor.stop();
         this.rceFinder?.stop();
+        this.stopStaleTimers();
         this.stopRokuFinder();
+    }
+
+    private stopStaleTimers() {
+        if (this.broadcastStaleTimer) {
+            clearInterval(this.broadcastStaleTimer);
+            this.broadcastStaleTimer = undefined;
+        }
+        if (this.reconcileStaleTimer) {
+            clearInterval(this.reconcileStaleTimer);
+            this.reconcileStaleTimer = undefined;
+        }
     }
 
     /**
@@ -1643,17 +1723,6 @@ export class DeviceManager {
         this.networkChangeMonitor.stop();
     }
 
-    /**
-     * Set the flag indicating a scan is needed. Emits 'scanNeeded-changed' event
-     * when the flag flips from false to true.
-     */
-    private setScanNeeded(force = false): void {
-        if (!this.scanNeeded || force) {
-            this.scanNeeded = true;
-            this.emitter.emit('scanNeeded-changed');
-        }
-    }
-
     private emitDevicesChanged = throttleBounce(() => {
         this.emitter.emit('devices-changed');
     }, this.DEVICES_CHANGED_DEBOUNCE_MS);
@@ -1665,6 +1734,9 @@ export class DeviceManager {
 }
 
 export type DeviceState = 'offline' | 'unknown' | 'pending' | 'online';
+
+//order types live with the Orders class; re-exported here so consumers keep one import site
+export type { Order, OrderType, SubmittedOrder, TakenOrders, BroadcastReason, ReconcileReason } from './Orders';
 
 export type PasswordValidationResult = 'ok' | 'bad-password' | 'unreachable';
 

--- a/src/deviceDiscovery/Orders.spec.ts
+++ b/src/deviceDiscovery/Orders.spec.ts
@@ -1,0 +1,97 @@
+import { expect } from 'chai';
+import { createSandbox } from 'sinon';
+import { Orders } from './Orders';
+import type { Order } from './Orders';
+
+const sinon = createSandbox();
+
+describe('Orders', () => {
+    afterEach(() => {
+        sinon.restore();
+    });
+
+    it('submit lands each order in its type\'s pending set and announces it', () => {
+        const onSubmit = sinon.spy();
+        const orders = new Orders(onSubmit);
+
+        orders.submit([
+            { type: 'broadcast', reason: 'network' },
+            { type: 'reconcile', reason: 'config-changed' }
+        ]);
+
+        expect(orders.getPending('broadcast')).to.eql(['network']);
+        expect(orders.getPending('reconcile')).to.eql(['config-changed']);
+        expect(onSubmit.callCount).to.equal(2);
+        expect(onSubmit.firstCall.args[0]).to.eql({ type: 'broadcast', reason: 'network' });
+        expect(onSubmit.firstCall.args[1]).to.be.a('number');
+    });
+
+    it('the same reason never queues twice; different reasons accumulate', () => {
+        const orders = new Orders(() => { });
+
+        orders.submit([
+            { type: 'broadcast', reason: 'stale' },
+            { type: 'broadcast', reason: 'stale' },
+            { type: 'broadcast', reason: 'sleep' }
+        ]);
+
+        expect(orders.getPending('broadcast')).to.have.members(['stale', 'sleep']);
+    });
+
+    it('take drains the whole set and returns one entry with every reason', () => {
+        const orders = new Orders(() => { });
+        orders.submit([
+            { type: 'broadcast', reason: 'sleep' },
+            { type: 'broadcast', reason: 'network' }
+        ]);
+
+        const taken = orders.take({ types: ['broadcast'] });
+
+        expect(taken).to.have.length(1);
+        expect(taken[0].type).to.equal('broadcast');
+        expect(taken[0].reasons).to.have.members(['sleep', 'network']);
+        expect(orders.getPending('broadcast')).to.be.empty;
+    });
+
+    it('take returns nothing and keeps the set when only excepted reasons are pending', () => {
+        const orders = new Orders(() => { });
+        orders.submit([{ type: 'broadcast', reason: 'stale' }]);
+
+        expect(orders.take({ types: ['broadcast'], except: ['stale'] })).to.be.empty;
+        expect(orders.getPending('broadcast')).to.eql(['stale']);
+    });
+
+    it('an excepted reason rides along when a non-excepted reason triggers the take', () => {
+        const orders = new Orders(() => { });
+        orders.submit([
+            { type: 'broadcast', reason: 'stale' },
+            { type: 'broadcast', reason: 'network' }
+        ]);
+
+        const taken = orders.take({ types: ['broadcast'], except: ['stale'] });
+
+        expect(taken).to.have.length(1);
+        expect(taken[0].reasons).to.have.members(['stale', 'network']);
+        expect(orders.getPending('broadcast')).to.be.empty;
+    });
+
+    it('take is atomic per type: a second take finds nothing', () => {
+        const orders = new Orders(() => { });
+        orders.submit([{ type: 'reconcile', reason: 'network' }]);
+
+        expect(orders.take({ types: ['reconcile'] })).to.eql([{ type: 'reconcile', reasons: ['network'] }]);
+        expect(orders.take({ types: ['reconcile'] })).to.be.empty;
+    });
+
+    it('the two order types are independent', () => {
+        const orders = new Orders(() => { });
+        const submitted: Order[] = [
+            { type: 'broadcast', reason: 'network' },
+            { type: 'reconcile', reason: 'network' }
+        ];
+        orders.submit(submitted);
+
+        expect(orders.take({ types: ['broadcast'] })).to.eql([{ type: 'broadcast', reasons: ['network'] }]);
+        expect(orders.getPending('reconcile')).to.eql(['network']);
+    });
+});

--- a/src/deviceDiscovery/Orders.ts
+++ b/src/deviceDiscovery/Orders.ts
@@ -1,0 +1,97 @@
+/**
+ * Why a broadcast (SSDP scan) was ordered
+ */
+export type BroadcastReason =
+    | 'startup'
+    | 'network'
+    | 'sleep'
+    | 'refresh-clicked'
+    | 'unhealthy-device'
+    | 'stale';
+
+/**
+ * Why a reconcile (health-check-all) was ordered
+ */
+export type ReconcileReason =
+    | 'startup'
+    | 'network'
+    | 'sleep'
+    | 'refresh-clicked'
+    | 'config-changed'
+    | 'stale';
+
+export type OrderType = 'broadcast' | 'reconcile';
+
+/**
+ * A unit of deferred work: submitted by triggers, fulfilled by visible views
+ */
+export type Order =
+    | { type: 'broadcast'; reason: BroadcastReason }
+    | { type: 'reconcile'; reason: ReconcileReason };
+
+/**
+ * Payload of the `order-submitted` event
+ */
+export type SubmittedOrder = Order & { timestamp: number };
+
+/**
+ * Everything a take drained for one order type; a single execution satisfies all of it
+ */
+export type TakenOrders =
+    | { type: 'broadcast'; reasons: BroadcastReason[] }
+    | { type: 'reconcile'; reasons: ReconcileReason[] };
+
+/**
+ * The pending-orders store (docs/device-discovery.md "Orders"): one set of reasons per order
+ * type. Reasons accumulate (the same reason never queues twice) and a take drains everything
+ * at once for a single execution.
+ */
+export class Orders {
+    public constructor(
+        /**
+         * Called once per submitted order
+         */
+        private onSubmit: (order: Order, timestamp: number) => void
+    ) { }
+
+    private pending = {
+        broadcast: new Set<BroadcastReason>(),
+        reconcile: new Set<ReconcileReason>()
+    };
+
+    public submit(orders: Order[]): void {
+        for (const order of orders) {
+            (this.pending[order.type] as Set<string>).add(order.reason);
+            this.onSubmit(order, Date.now());
+        }
+    }
+
+    public getPending(type: 'broadcast'): BroadcastReason[];
+    public getPending(type: 'reconcile'): ReconcileReason[];
+    public getPending(type: OrderType): string[] {
+        return [...this.pending[type]];
+    }
+
+    /**
+     * Atomically take the pending reasons for the requested order types, one entry per type
+     * that had something to take. `except` reasons can't trigger a take on their own, but when
+     * another reason triggers one, the type's WHOLE set is drained (the single execution that
+     * follows satisfies excepted reasons too). Atomic per type: concurrent takers can't drain
+     * the same set twice.
+     */
+    public take(options: { types: OrderType[]; except?: Array<BroadcastReason | ReconcileReason> }): TakenOrders[] {
+        const except = options.except as string[] | undefined;
+        const taken: TakenOrders[] = [];
+        for (const type of options.types) {
+            const set = this.pending[type] as Set<string>;
+            const triggers = [...set].filter(x => !except?.includes(x));
+            if (triggers.length === 0) {
+                continue;
+            }
+            const reasons = [...set];
+            set.clear();
+            taken.push({ type: type, reasons: reasons } as TakenOrders);
+        }
+        return taken;
+    }
+}

--- a/src/managers/UserInputManager.spec.ts
+++ b/src/managers/UserInputManager.spec.ts
@@ -269,9 +269,9 @@ describe('UserInputManager', () => {
     });
 
     describe('promptForHost', () => {
-        it('calls scan() instead of refresh() when picker opens', async () => {
-            const scanSpy = sinon.spy(deviceManager, 'scan');
-            const refreshSpy = sinon.spy(deviceManager, 'refresh');
+        it('does not scan or reconcile on open when no orders are pending', async () => {
+            const broadcastSpy = sinon.spy(deviceManager as any, 'broadcast');
+            const reconcileSpy = sinon.spy(deviceManager as any, 'reconcile');
 
             // Capture the quickPick instance when created
             let quickPick: any;
@@ -289,11 +289,174 @@ describe('UserInputManager', () => {
                 setTimeout(resolve, 10);
             });
 
-            // Verify scan was called, not refresh
-            expect(scanSpy.called).to.be.true;
-            expect(refreshSpy.called).to.be.false;
+            // Opening the picker is not itself a reason to hit the network
+            expect(broadcastSpy.called).to.be.false;
+            expect(reconcileSpy.called).to.be.false;
 
             // Clean up by hiding the quickpick (triggers rejection)
+            quickPick?.hide();
+            await promptPromise.catch(() => { });
+        });
+
+        it('fulfills a queued non-stale broadcast order when the picker opens', async () => {
+            //stub (not spy) so no real RokuFinder scan with real timers starts
+            const broadcastStub = sinon.stub(deviceManager as any, 'broadcast').returns(true);
+
+            let quickPick: any;
+            const originalCreateQuickPick = vscode.window.createQuickPick;
+            sinon.stub(vscode.window, 'createQuickPick').callsFake(() => {
+                quickPick = originalCreateQuickPick();
+                return quickPick;
+            });
+
+            //queue a broadcast order as if the network changed while no view was visible
+            deviceManager.submitOrders([{ type: 'broadcast', reason: 'network' }]);
+
+            const promptPromise = userInputManager.promptForHost();
+            await new Promise<void>(resolve => {
+                setTimeout(resolve, 10);
+            });
+
+            expect(broadcastStub.calledOnceWith(['network'])).to.be.true;
+            expect(deviceManager.getPendingBroadcastReasons()).to.be.empty;
+
+            quickPick?.hide();
+            await promptPromise.catch(() => { });
+        });
+
+        it('leaves a queued stale broadcast untouched on open, then the 7s fallback fulfills it (staleness-gated)', async () => {
+            //stub (not spy): this test is about order consumption, not the scan machinery —
+            //don't start a real RokuFinder scan with real timers
+            const broadcastStub = sinon.stub(deviceManager as any, 'broadcast').returns(false);
+            //shrink the 7s fallback so the test can wait it out with real timers
+            userInputManager['scanTimeoutMs'] = 20;
+
+            let quickPick: any;
+            const originalCreateQuickPick = vscode.window.createQuickPick;
+            sinon.stub(vscode.window, 'createQuickPick').callsFake(() => {
+                quickPick = originalCreateQuickPick();
+                return quickPick;
+            });
+
+            //the 30-minute timer queued a routine freshness order while no view was visible
+            deviceManager.submitOrders([{ type: 'broadcast', reason: 'stale' }]);
+
+            const promptPromise = userInputManager.promptForHost();
+
+            //opening the picker does NOT consume the stale order — routine freshness is
+            //the fallback's job, so a fresh open causes no immediate network activity
+            expect(deviceManager.getPendingBroadcastReasons()).to.include('stale');
+            expect(broadcastStub.called).to.be.false;
+
+            //once the picker has been open past the fallback window with no broadcast, the
+            //fallback fulfills everything pending — the queued stale order reaches broadcast
+            //with its reason, so the staleness gate decides whether a scan actually happens
+            await new Promise<void>(resolve => {
+                setTimeout(resolve, 50);
+            });
+            expect(deviceManager.getPendingBroadcastReasons()).to.be.empty;
+            expect(broadcastStub.calledOnceWith(['stale'])).to.be.true;
+
+            quickPick?.hide();
+            await promptPromise.catch(() => { });
+        });
+
+        it('7s fallback does nothing when no orders are pending', async () => {
+            const broadcastStub = sinon.stub(deviceManager as any, 'broadcast').returns(false);
+            userInputManager['scanTimeoutMs'] = 20;
+
+            let quickPick: any;
+            const originalCreateQuickPick = vscode.window.createQuickPick;
+            sinon.stub(vscode.window, 'createQuickPick').callsFake(() => {
+                quickPick = originalCreateQuickPick();
+                return quickPick;
+            });
+
+            const promptPromise = userInputManager.promptForHost();
+            expect(broadcastStub.called).to.be.false;
+
+            //nothing queued → nothing to fulfill → no network activity
+            await new Promise<void>(resolve => {
+                setTimeout(resolve, 50);
+            });
+            expect(broadcastStub.called).to.be.false;
+
+            quickPick?.hide();
+            await promptPromise.catch(() => { });
+        });
+
+        it('fulfills a queued non-stale reconcile order when the picker opens', async () => {
+            const reconcileSpy = sinon.spy(deviceManager as any, 'reconcile');
+
+            let quickPick: any;
+            const originalCreateQuickPick = vscode.window.createQuickPick;
+            sinon.stub(vscode.window, 'createQuickPick').callsFake(() => {
+                quickPick = originalCreateQuickPick();
+                return quickPick;
+            });
+
+            //queue a reconcile order as if the network changed while no view was visible
+            deviceManager.submitOrders([{ type: 'reconcile', reason: 'network' }]);
+
+            const promptPromise = userInputManager.promptForHost();
+            await new Promise<void>(resolve => {
+                setTimeout(resolve, 10);
+            });
+
+            expect(reconcileSpy.calledOnce).to.be.true;
+            expect(reconcileSpy.firstCall.args[0]).to.eql(['network']);
+            expect(deviceManager.getPendingReconcileReasons()).to.be.empty;
+
+            quickPick?.hide();
+            await promptPromise.catch(() => { });
+        });
+
+        it('leaves a queued stale reconcile order untouched when the picker opens', async () => {
+            const reconcileSpy = sinon.spy(deviceManager as any, 'reconcile');
+
+            let quickPick: any;
+            const originalCreateQuickPick = vscode.window.createQuickPick;
+            sinon.stub(vscode.window, 'createQuickPick').callsFake(() => {
+                quickPick = originalCreateQuickPick();
+                return quickPick;
+            });
+
+            deviceManager.submitOrders([{ type: 'reconcile', reason: 'stale' }]);
+
+            const promptPromise = userInputManager.promptForHost();
+            await new Promise<void>(resolve => {
+                setTimeout(resolve, 10);
+            });
+
+            expect(reconcileSpy.called).to.be.false;
+            expect(deviceManager.getPendingReconcileReasons()).to.include('stale');
+
+            quickPick?.hide();
+            await promptPromise.catch(() => { });
+        });
+
+        it('fulfills a live non-stale reconcile order while the picker is open', async () => {
+            const reconcileSpy = sinon.spy(deviceManager as any, 'reconcile');
+
+            let quickPick: any;
+            const originalCreateQuickPick = vscode.window.createQuickPick;
+            sinon.stub(vscode.window, 'createQuickPick').callsFake(() => {
+                quickPick = originalCreateQuickPick();
+                return quickPick;
+            });
+
+            const promptPromise = userInputManager.promptForHost();
+            await new Promise<void>(resolve => {
+                setTimeout(resolve, 10);
+            });
+            expect(reconcileSpy.called).to.be.false;
+
+            //a trigger fires while the picker is open
+            deviceManager.submitOrders([{ type: 'reconcile', reason: 'sleep' }]);
+
+            expect(reconcileSpy.calledOnce).to.be.true;
+            expect(deviceManager.getPendingReconcileReasons()).to.be.empty;
+
             quickPick?.hide();
             await promptPromise.catch(() => { });
         });

--- a/src/managers/UserInputManager.ts
+++ b/src/managers/UserInputManager.ts
@@ -48,6 +48,12 @@ export class UserInputManager {
         private credentialStore: CredentialStore
     ) { }
 
+    /**
+     * How long the picker waits after open with no broadcast before fulfilling any pending
+     * order (including `stale`) as a routine freshness fallback. Overridable for tests.
+     */
+    private scanTimeoutMs = 7_000;
+
     public async promptForHostManual(): Promise<HostWithDeviceInfo | undefined> {
         while (true) {
             const value = await vscode.window.showInputBox({
@@ -234,25 +240,40 @@ export class UserInputManager {
             setBusy(false);
         }, disposables);
 
-        const scanTimeoutMs = 7_000;
         let scanTimeoutId: NodeJS.Timeout | null = null;
-        let hasScanned = this.deviceManager.scan();
-        this.deviceManager.on('scanNeeded-changed', () => {
-            hasScanned = true;
-            if (scanTimeoutId) {
-                clearTimeout(scanTimeoutId);
-                scanTimeoutId = null;
+
+        //on open: fulfill queued real orders. `stale` is left alone - routine freshness is the
+        //fallback's job (below), so opening the picker never scans the network by itself
+        let hasScanned = this.deviceManager.fulfillOrders({ types: ['broadcast', 'reconcile'], except: ['stale'] })
+            .some(taken => taken.type === 'broadcast');
+
+        this.deviceManager.on('order-submitted', (order) => {
+            //a real broadcast means a scan is happening - the fallback isn't needed
+            if (order.type === 'broadcast' && order.reason !== 'stale') {
+                hasScanned = true;
+                if (scanTimeoutId) {
+                    clearTimeout(scanTimeoutId);
+                    scanTimeoutId = null;
+                }
             }
-            this.deviceManager.scan();
+            this.deviceManager.fulfillOrders({ types: [order.type], except: ['stale'] });
         }, disposables);
+
         scanTimeoutId = setTimeout(() => {
             if (hasScanned) {
                 return;
             }
-            this.deviceManager.scan();
-        }, scanTimeoutMs);
+            //nothing scanned since the picker opened - fulfill any pending broadcast, `stale`
+            //included (its fulfillment is staleness-gated, so this never over-scans)
+            this.deviceManager.fulfillOrders({ types: ['broadcast'] });
+        }, this.scanTimeoutMs);
 
         function dispose() {
+            //the fallback timer must not outlive the picker
+            if (scanTimeoutId) {
+                clearTimeout(scanTimeoutId);
+                scanTimeoutId = null;
+            }
             for (const disposable of disposables) {
                 disposable.dispose();
             }
@@ -266,7 +287,10 @@ export class UserInputManager {
                     if (selectedDevice.label === manualLabel) {
                         deferred.resolve({ manual: true });
                     } else if (selectedDevice.label === scanForDevicesLabel) {
-                        this.deviceManager.refresh(true);
+                        this.deviceManager.submitOrders([
+                            { type: 'broadcast', reason: 'refresh-clicked' },
+                            { type: 'reconcile', reason: 'refresh-clicked' }
+                        ]);
                         return;
                     } else {
                         const device = (selectedDevice as any).device as RokuDevice;
@@ -430,9 +454,12 @@ export class UserInputManager {
 
         quickPick.onDidTriggerButton(button => {
             if (button.tooltip === SCAN_FOR_DEVICES) {
-                this.deviceManager.refresh(true);
+                this.deviceManager.submitOrders([
+                    { type: 'broadcast', reason: 'refresh-clicked' },
+                    { type: 'reconcile', reason: 'refresh-clicked' }
+                ]);
             } else if (button.tooltip === CLEAR_DEVICE_LIST) {
-                this.deviceManager.clearCurrentDeviceList().catch(() => { });
+                this.deviceManager.clearCurrentDeviceList();
                 void util.showTimedNotification('Clearing device list');
             } else if (button.tooltip === ENABLE_DEVICE_DISCOVERY) {
                 void util.setConfigurationValueAtUserOrClosestScope('brightscript.deviceDiscovery.enabled', true);

--- a/src/viewProviders/DevicesViewProvider.spec.ts
+++ b/src/viewProviders/DevicesViewProvider.spec.ts
@@ -89,6 +89,10 @@ describe('DevicesViewProvider', () => {
 
     function createProvider(devices: any[], options?: { storedPasswords?: Record<string, string> }) {
         const emitter = new EventEmitter();
+        //a real pending-set implementation backs the fake so the take/fulfill semantics are
+        //exercised for real; execution routes to the broadcast/reconcile stubs below
+        const pendingBroadcastReasons = new Set<string>();
+        const pendingReconcileReasons = new Set<string>();
         const deviceManager: any = {
             on: (event: string, handler: any) => emitter.on(event, handler),
             getAllDevices: () => devices,
@@ -98,8 +102,36 @@ describe('DevicesViewProvider', () => {
             getWebPortalUrl: (device: any) => (device.rce ? `https://developer.roku.com/cloud-emulator-bff/devices/${device.rce.id}/sideload/` : `http://${device.ip}`),
             getIconPath: () => undefined,
             hasDeviceCache: () => false,
-            refresh: () => undefined,
-            healthCheckDevice: () => Promise.resolve()
+            healthCheckDevice: () => Promise.resolve(true),
+            broadcast: sinon.stub().returns(true),
+            reconcile: sinon.stub(),
+            submitOrders: (orders: Array<{ type: string; reason: string }>) => {
+                for (const order of orders) {
+                    (order.type === 'broadcast' ? pendingBroadcastReasons : pendingReconcileReasons).add(order.reason);
+                    emitter.emit('order-submitted', { ...order, timestamp: Date.now() });
+                }
+            },
+            getPendingBroadcastReasons: () => [...pendingBroadcastReasons],
+            getPendingReconcileReasons: () => [...pendingReconcileReasons],
+            fulfillOrders: (fulfillOptions: { types: string[]; except?: string[] }) => {
+                const taken: Array<{ type: string; reasons: string[] }> = [];
+                for (const type of fulfillOptions.types) {
+                    const set = type === 'broadcast' ? pendingBroadcastReasons : pendingReconcileReasons;
+                    const triggers = [...set].filter(x => !fulfillOptions.except?.includes(x));
+                    if (triggers.length === 0) {
+                        continue;
+                    }
+                    const reasons = [...set];
+                    set.clear();
+                    taken.push({ type: type, reasons: reasons });
+                    if (type === 'broadcast') {
+                        deviceManager.broadcast(reasons);
+                    } else {
+                        deviceManager.reconcile(reasons);
+                    }
+                }
+                return taken;
+            }
         };
         const credentialStore: any = {
             on: () => undefined,
@@ -531,6 +563,132 @@ describe('DevicesViewProvider', () => {
             });
 
             expect(treeChanged.called).to.be.false;
+        });
+    });
+
+    describe('order fulfillment', () => {
+        it('fulfills a live non-stale broadcast order while visible', () => {
+            const { provider, deviceManager } = createProvider([]);
+            provider['visible'] = true;
+
+            deviceManager.submitOrders([{ type: 'broadcast', reason: 'network' }]);
+
+            expect(deviceManager.broadcast.calledOnceWith(['network'])).to.be.true;
+            expect(deviceManager.getPendingBroadcastReasons()).to.be.empty;
+        });
+
+        it('fulfills live reconcile orders, passing the reasons through', () => {
+            const { provider, deviceManager } = createProvider([]);
+            provider['visible'] = true;
+
+            deviceManager.submitOrders([{ type: 'reconcile', reason: 'config-changed' }]);
+            expect(deviceManager.reconcile.calledOnceWith(['config-changed'])).to.be.true;
+
+            deviceManager.reconcile.resetHistory();
+            deviceManager.submitOrders([{ type: 'reconcile', reason: 'refresh-clicked' }]);
+            expect(deviceManager.reconcile.calledOnceWith(['refresh-clicked'])).to.be.true;
+        });
+
+        it('ignores live stale orders while visible, leaving them pending', () => {
+            const { provider, deviceManager } = createProvider([]);
+            provider['visible'] = true;
+
+            deviceManager.submitOrders([{ type: 'broadcast', reason: 'stale' }]);
+            deviceManager.submitOrders([{ type: 'reconcile', reason: 'stale' }]);
+
+            expect(deviceManager.broadcast.called).to.be.false;
+            expect(deviceManager.reconcile.called).to.be.false;
+            expect(deviceManager.getPendingBroadcastReasons()).to.include('stale');
+            expect(deviceManager.getPendingReconcileReasons()).to.include('stale');
+        });
+
+        it('leaves live orders pending while hidden', () => {
+            const { deviceManager } = createProvider([]);
+
+            deviceManager.submitOrders([{ type: 'broadcast', reason: 'sleep' }]);
+            deviceManager.submitOrders([{ type: 'reconcile', reason: 'sleep' }]);
+
+            expect(deviceManager.broadcast.called).to.be.false;
+            expect(deviceManager.reconcile.called).to.be.false;
+            expect(deviceManager.getPendingBroadcastReasons()).to.include('sleep');
+            expect(deviceManager.getPendingReconcileReasons()).to.include('sleep');
+        });
+
+        //a minimal TreeView fake: enough for setTreeView to register handlers and for tests to
+        //toggle visibility through the real onDidChangeVisibility path
+        function createTreeView(visible: boolean) {
+            const emitter = new EventEmitter();
+            const treeView = {
+                visible: visible,
+                onDidChangeVisibility: (cb: (e: { visible: boolean }) => void) => emitter.on('visibility', cb),
+                onDidExpandElement: () => undefined
+            } as any;
+            return {
+                treeView: treeView,
+                setVisible: (value: boolean) => {
+                    treeView.visible = value;
+                    emitter.emit('visibility', { visible: value });
+                }
+            };
+        }
+
+        it('fulfills orders queued while hidden when the panel becomes visible (ALL reasons)', () => {
+            const { provider, deviceManager } = createProvider([]);
+            const { treeView, setVisible } = createTreeView(false);
+            provider.setTreeView(treeView);
+
+            deviceManager.submitOrders([{ type: 'broadcast', reason: 'network' }]);
+            deviceManager.submitOrders([{ type: 'reconcile', reason: 'refresh-clicked' }]);
+
+            setVisible(true);
+
+            expect(deviceManager.broadcast.calledOnceWith(['network'])).to.be.true;
+            expect(deviceManager.reconcile.calledOnceWith(['refresh-clicked'])).to.be.true;
+            expect(deviceManager.getPendingBroadcastReasons()).to.be.empty;
+            expect(deviceManager.getPendingReconcileReasons()).to.be.empty;
+        });
+
+        it('consumes queued startup orders when the panel is already open at activation', () => {
+            const { provider, deviceManager } = createProvider([]);
+
+            deviceManager.submitOrders([{ type: 'broadcast', reason: 'startup' }]);
+            deviceManager.submitOrders([{ type: 'reconcile', reason: 'startup' }]);
+
+            //panel already visible when setTreeView runs — the startup sync path fulfills
+            provider.setTreeView(createTreeView(true).treeView);
+
+            expect(deviceManager.broadcast.calledOnceWith(['startup'])).to.be.true;
+            expect(deviceManager.reconcile.calledOnceWith(['startup'])).to.be.true;
+        });
+
+        it('fulfills a queued stale broadcast on open with its reason intact (staleness-gated inside)', () => {
+            const { provider, deviceManager } = createProvider([]);
+            const { treeView, setVisible } = createTreeView(false);
+            provider.setTreeView(treeView);
+
+            deviceManager.submitOrders([{ type: 'broadcast', reason: 'stale' }]);
+
+            setVisible(true);
+
+            expect(deviceManager.broadcast.calledOnceWith(['stale'])).to.be.true;
+        });
+
+        it('accumulated reasons are fulfilled together in one execution', () => {
+            const { provider, deviceManager } = createProvider([]);
+            const { treeView, setVisible } = createTreeView(false);
+            provider.setTreeView(treeView);
+
+            //multiple triggers fire while no view is visible — each queues its own reason
+            deviceManager.submitOrders([{ type: 'broadcast', reason: 'stale' }]);
+            deviceManager.submitOrders([{ type: 'broadcast', reason: 'sleep' }]);
+            deviceManager.submitOrders([{ type: 'broadcast', reason: 'network' }]);
+
+            setVisible(true);
+
+            //one scan satisfies all of them
+            expect(deviceManager.broadcast.calledOnce).to.be.true;
+            expect(deviceManager.broadcast.firstCall.args[0]).to.have.members(['stale', 'sleep', 'network']);
+            expect(deviceManager.getPendingBroadcastReasons()).to.be.empty;
         });
     });
 });

--- a/src/viewProviders/DevicesViewProvider.ts
+++ b/src/viewProviders/DevicesViewProvider.ts
@@ -74,11 +74,12 @@ export class DevicesViewProvider implements vscode.TreeDataProvider<vscode.TreeI
         // Seed the context from the persisted active device so the indicator survives a window reload
         void vscodeContextManager.set('activeDeviceKey', this.context.workspaceState.get('activeDeviceKey') ?? '');
 
-        this.deviceManager.on('scanNeeded-changed', () => {
+        //while visible, fulfill live orders as they arrive (except timer-driven `stale` ones)
+        this.deviceManager.on('order-submitted', (order) => {
             if (!this.visible) {
                 return;
             }
-            this.deviceManager.refresh();
+            this.deviceManager.fulfillOrders({ types: [order.type], except: ['stale'] });
         });
 
         // Re-render when a device's stored password changes so the Clear item appears/disappears
@@ -96,13 +97,21 @@ export class DevicesViewProvider implements vscode.TreeDataProvider<vscode.TreeI
     private scanProgressResolver: (() => void) | null = null;
 
     public setTreeView(treeView: vscode.TreeView<vscode.TreeItem>) {
+        //on open, fulfill orders queued while hidden (every reason)
         treeView.onDidChangeVisibility(e => {
             this.visible = e.visible;
             if (!this.visible) {
                 return;
             }
-            this.deviceManager.refresh();
+            this.deviceManager.fulfillOrders({ types: ['broadcast', 'reconcile'] });
         });
+
+        //onDidChangeVisibility only fires on changes - if the panel is already open at
+        //activation, sync now and consume any queued startup orders
+        this.visible = treeView.visible;
+        if (this.visible) {
+            this.deviceManager.fulfillOrders({ types: ['broadcast', 'reconcile'] });
+        }
 
         // Health check device when expanded (not on every getChildren/devices-changed)
         treeView.onDidExpandElement(e => {


### PR DESCRIPTION
## What

Extracts just the **orders system** from #865, re-grafted onto current master (which has since gained Roku Cloud Emulator support — the source of #865's conflicts).

Triggers no longer scan/health-check directly. Instead they **submit orders** into per-type pending sets, and **visible views fulfill them**:

- **Order types**: `broadcast` (SSDP scan) and `reconcile` (health-check all), each with a reason (`startup`, `network`, `sleep`, `refresh-clicked`, `config-changed`, `unhealthy-device`, `stale`).
- Reasons **accumulate and dedupe**; one fulfillment satisfies every queued reason; `take` is atomic per type.
- **Nothing hits the network while no view is visible** — orders queue until the Devices panel or device picker opens (or is already open).
- Live orders are fulfilled immediately by visible views via the new `order-submitted` event (replacing `scanNeeded-changed`); timer-driven `stale` orders are excluded from live fulfillment and are staleness-gated inside `broadcast()`.
- The `unhealthy-device` rescan is now a rate-limited order (1/min), terminating the old scan → fail → scan feedback loop.
- Removed: `scanNeeded` flag, `setScanNeeded`, `refresh()`, `scan()`, `discoverAll()`.

## What this deliberately does NOT include from #865

The freshness rewrite (`ensureDeviceFresh`, `peekDevice`, `lastCheckedByIp` trust windows, `getDeviceInfo` consolidation, hidden-view lazy reads). `reconcile()` drives the existing `healthCheckAllDevices(force)` machinery unchanged; `healthCheckDevice` keeps its current signature.

## Testing

- Ported the orders test suites from #865 (Orders unit tests, submit/fulfill/stale-timer/broadcast/reconcile, picker order flow, view-provider fulfillment) and adapted them to master's API.
- Full suite: 1308 passing / 1 failing — the failing `BaseWebviewViewProvider` timeout also fails on clean master (pre-existing, unrelated).

🤖 Generated with [Claude Code](https://claude.com/claude-code)