### PR TITLE
chore: Only clone create-vsix dependencies that have a matching branch

### DIFF
--- a/.github/workflows/create-vsix.yml
+++ b/.github/workflows/create-vsix.yml
@@ -143,19 +143,19 @@ jobs:
             body += '### 📦 [Download the .vsix](' + prod.url + ')\n';
             body += 'See the [install instructions](https://rokucommunity.github.io/vscode-brightscript-language/prerelease-versions.html) if you need them. This replaces your marketplace version of the extension until you reinstall it.\n\n';
 
+            body += '<sub>_Prefer to keep the marketplace version installed? There\'s also a [side-by-side build](' + temp.url + ') that installs as a separate extension. Be sure to disable the marketplace version while testing it, otherwise the two will conflict._</sub>\n\n';
+
             //include the per-project sources so testers can see exactly what went into this build
             try {
               const buildInfo = JSON.parse(require('fs').readFileSync('.vsix-building/build-info.json', 'utf8'));
-              body += 'Built from:\n';
+              body += '| package | source |\n';
+              body += '| :--- | :--- |\n';
               for (const project of buildInfo) {
-                body += '- ' + project.name + ': ' + project.source + '\n';
+                body += '| `' + project.name + '` | ' + project.source + ' |\n';
               }
-              body += '\n';
             } catch (e) {
               console.log('Could not read build-info.json:', e.message);
             }
-
-            body += '<sub>_Prefer to keep the marketplace version installed? There\'s also a [side-by-side build](' + temp.url + ') that installs as a separate extension. Be sure to disable the marketplace version while testing it, otherwise the two will conflict._</sub>';
 
             await github.rest.issues.createComment({
               owner: '${{ steps.info.outputs.prOwner }}',

--- a/.github/workflows/create-vsix.yml
+++ b/.github/workflows/create-vsix.yml
@@ -143,7 +143,7 @@ jobs:
             body += '### 📦 [Download the .vsix](' + prod.url + ')\n';
             body += 'See the [install instructions](https://rokucommunity.github.io/vscode-brightscript-language/prerelease-versions.html) if you need them. This replaces your marketplace version of the extension until you reinstall it.\n\n';
 
-            body += '<sub>_Prefer to keep the marketplace version installed? There\'s also a [side-by-side build](' + temp.url + ') that installs as a separate extension. Be sure to disable the marketplace version while testing it, otherwise the two will conflict._</sub>\n\n';
+            body += '_Prefer to keep the marketplace version installed? There\'s also a [side-by-side build](' + temp.url + ') that installs as a separate extension. Be sure to disable the marketplace version while testing it, otherwise the two will conflict._\n\n';
 
             //include the per-project sources so testers can see exactly what went into this build
             try {

--- a/.github/workflows/create-vsix.yml
+++ b/.github/workflows/create-vsix.yml
@@ -148,11 +148,13 @@ jobs:
             //include the per-project sources so testers can see exactly what went into this build
             try {
               const buildInfo = JSON.parse(require('fs').readFileSync('.vsix-building/build-info.json', 'utf8'));
-              body += '| package | source |\n';
-              body += '| :--- | :--- |\n';
+              body += '<details><summary>Built from</summary>\n\n';
+              body += '| package | source | sha |\n';
+              body += '| :--- | :--- | :--- |\n';
               for (const project of buildInfo) {
-                body += '| `' + project.name + '` | ' + project.source + ' |\n';
+                body += '| `' + project.name + '` | ' + project.source + ' | ' + (project.sha ?? '') + ' |\n';
               }
+              body += '\n</details>';
             } catch (e) {
               console.log('Could not read build-info.json:', e.message);
             }

--- a/scripts/create-vsix.ts
+++ b/scripts/create-vsix.ts
@@ -52,6 +52,18 @@ async function main() {
         await processProject(project, branch, forkOwner);
     }
 
+    //for projects that weren't built locally, report the exact npm version the extension ended up with
+    for (const project of projects) {
+        if (!project.packagePath) {
+            try {
+                const version = fsExtra.readJsonSync(`${tempDir}/vscode-brightscript-language/node_modules/${project.name}/package.json`).version;
+                project.source = `[${project.name}@${version}](${baseUrl}/${project.name}/releases/tag/v${version})`;
+            } catch (e) {
+                log(`Warning: could not determine the installed npm version of ${project.name}`);
+            }
+        }
+    }
+
     //write a summary of what was built (the workflow includes this in the PR comment)
     const buildInfo = projects.map(x => ({ name: x.name, source: x.source }));
     fsExtra.writeJsonSync(`${tempDir}/build-info.json`, buildInfo, { spaces: 4 });
@@ -67,8 +79,26 @@ async function processProject(project: Project, branch: string, forkOwner: strin
         log(`${project.name}: already processed`);
         return;
     }
+    project.processed = true;
     log(`${project.name}: processing`);
-    const ref = await resolveRef(project, branch, forkOwner);
+    //the extension itself is always built (falling back to master); dependency projects are only
+    //built when they have a matching branch, otherwise the normal npm dependency flows through
+    const isRoot = project.name === 'vscode-brightscript-language';
+    let ref = await resolveRef(project, branch, forkOwner);
+    if (!ref && isRoot) {
+        const cloneUrl = `${baseUrl}/${project.name}`;
+        const masterSha = getBranchSha(cloneUrl, 'master');
+        ref = {
+            cloneUrl: cloneUrl,
+            ref: 'master',
+            source: masterSha ? commitLink(project, 'master', masterSha) : `${orgName} branch 'master'`
+        };
+    }
+    if (!ref) {
+        project.source = `npm registry (no '${branch}' branch)`;
+        log(`${project.name}: no matching branch, using the version from the npm registry`);
+        return;
+    }
     log(`${project.name}: building from ${ref.source}`);
     const buildVersion = `9001.0.0-${ref.ref.replace(/[^a-zA-Z0-9]/g, '-')}.${Date.now()}`;
 
@@ -81,8 +111,10 @@ async function processProject(project: Project, branch: string, forkOwner: strin
         log(`${project.name}: Processing dependency '${dependencyName}'`);
         const dependency = projects.find(x => x.name === dependencyName)!;
         await processProject(dependency, branch, forkOwner);
-        //install the dependency into this project
-        execSync(`npm i ${dependency.packagePath}`, { cwd: project.name });
+        //install the dependency's local build (when it wasn't built locally, keep the npm version)
+        if (dependency.packagePath) {
+            execSync(`npm i ${dependency.packagePath}`, { cwd: project.name });
+        }
     }
     execSync(`npm i && npm run build && npm pack`, {
         cwd: project.name
@@ -90,7 +122,6 @@ async function processProject(project: Project, branch: string, forkOwner: strin
 
     project.packagePath = `file:/${tempDir}/${project.name}/${project.name}-${buildVersion}.tgz`;
     project.source = ref.source;
-    project.processed = true;
     log(`${project.name}: done`);
 }
 
@@ -99,30 +130,38 @@ async function processProject(project: Project, branch: string, forkOwner: strin
  *   1. the org's branch, when attached to an open PR
  *   2. the fork owner's same-named branch, when attached to an open PR
  *   3. the org's branch, even without a PR
- *   4. master
+ * Returns undefined when the project has no matching branch (i.e. it shouldn't be built locally)
  */
-async function resolveRef(project: Project, branch: string, forkOwner: string): Promise<Ref> {
+async function resolveRef(project: Project, branch: string, forkOwner: string): Promise<Ref | undefined> {
     const orgCloneUrl = `${baseUrl}/${project.name}`;
     if (branch && branch !== 'master') {
         //1. the org has this branch and it's attached to an open PR
         let pr = await findOpenPr(project.name, orgName, branch);
         if (pr) {
-            return { cloneUrl: orgCloneUrl, ref: branch, source: `${orgName} branch '${branch}' (open PR ${pr.html_url})` };
+            return { cloneUrl: orgCloneUrl, ref: branch, source: prLink(pr) };
         }
         //2. the fork owner has this branch attached to an open PR on this project
         if (forkOwner) {
             pr = await findOpenPr(project.name, forkOwner, branch);
             if (pr) {
-                return { cloneUrl: pr.head.repo.clone_url, ref: branch, source: `${forkOwner} fork branch '${branch}' (open PR ${pr.html_url})` };
+                return { cloneUrl: pr.head.repo.clone_url, ref: branch, source: prLink(pr) };
             }
         }
         //3. the org has this branch (no PR)
-        if (hasBranch(project, branch)) {
-            return { cloneUrl: orgCloneUrl, ref: branch, source: `${orgName} branch '${branch}'` };
+        const sha = getBranchSha(orgCloneUrl, branch);
+        if (sha) {
+            return { cloneUrl: orgCloneUrl, ref: branch, source: commitLink(project, branch, sha) };
         }
     }
-    //4. fall back to master
-    return { cloneUrl: orgCloneUrl, ref: 'master', source: `${orgName} branch 'master'` };
+    //no matching branch anywhere
+    return undefined;
+}
+
+/**
+ * Render a PR as a markdown link, e.g. `[rokucommunity/roku-deploy/pull/123](https://github.com/rokucommunity/roku-deploy/pull/123)`
+ */
+function prLink(pr: { html_url: string }) {
+    return `[${pr.html_url.replace(/^https:\/\/github\.com\//, '')}](${pr.html_url})`;
 }
 
 /**
@@ -165,24 +204,25 @@ interface Ref {
 }
 
 /**
- * Determine if a repo has a branch with the given name
+ * Get the tip commit sha of a branch on a remote repo (returns undefined when the branch doesn't exist)
  */
-function hasBranch(project: Project, branch: string) {
-    const output = childProcess.execSync(`git ls-remote --heads ${baseUrl}/${project.name}`).toString();
-    const regexp = new RegExp(`refs/heads/${escapeRegExp(branch)}\\b`);
-    return !!regexp.exec(output);
+function getBranchSha(cloneUrl: string, branch: string) {
+    const output = childProcess.execSync(`git ls-remote --heads ${cloneUrl} "refs/heads/${branch}"`).toString();
+    return output.split(/\s+/)[0] || undefined;
 }
 
-function escapeRegExp(string: string) {
-    return string.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'); // $& means the whole matched string
+/**
+ * Render a branch build as a markdown link to its tip commit,
+ * e.g. `[rokucommunity/roku-deploy/commit/a1b2c3d](https://github.com/rokucommunity/roku-deploy/commit/a1b2c3d...) (branch 'alpha')`
+ */
+function commitLink(project: Project, branch: string, sha: string) {
+    return `[${orgName}/${project.name}/commit/${sha.slice(0, 7)}](${baseUrl}/${project.name}/commit/${sha}) (branch '${branch}')`;
 }
 
 function clone(project: Project, ref: Ref) {
-    log(`Cloning ${ref.cloneUrl}`);
-    execSync(`git clone ${ref.cloneUrl} ${project.name}`);
-    execSync(`git checkout ${ref.ref}`, {
-        cwd: project.name
-    });
+    log(`Cloning ${ref.cloneUrl} (branch '${ref.ref}', shallow)`);
+    //shallow single-branch clone: we only ever build the tip of one branch, so skip the full history
+    execSync(`git clone --depth 1 --single-branch --branch "${ref.ref}" ${ref.cloneUrl} ${project.name}`);
 }
 
 function changeVersion(project: Project, version: string) {

--- a/scripts/create-vsix.ts
+++ b/scripts/create-vsix.ts
@@ -57,7 +57,7 @@ async function main() {
         if (!project.packagePath) {
             try {
                 const version = fsExtra.readJsonSync(`${tempDir}/vscode-brightscript-language/node_modules/${project.name}/package.json`).version;
-                project.source = `[${project.name}@${version}](${baseUrl}/${project.name}/releases/tag/v${version})`;
+                project.source = `[v${version}](${baseUrl}/${project.name}/releases/tag/v${version})`;
             } catch (e) {
                 log(`Warning: could not determine the installed npm version of ${project.name}`);
             }
@@ -65,7 +65,7 @@ async function main() {
     }
 
     //write a summary of what was built (the workflow includes this in the PR comment)
-    const buildInfo = projects.map(x => ({ name: x.name, source: x.source }));
+    const buildInfo = projects.map(x => ({ name: x.name, source: x.source, sha: x.sha }));
     fsExtra.writeJsonSync(`${tempDir}/build-info.json`, buildInfo, { spaces: 4 });
     log('Build summary:\n' + buildInfo.map(x => `  ${x.name}: ${x.source}`).join('\n'));
 
@@ -91,7 +91,9 @@ async function processProject(project: Project, branch: string, forkOwner: strin
         ref = {
             cloneUrl: cloneUrl,
             ref: 'master',
-            source: masterSha ? commitLink(project, 'master', masterSha) : `${orgName} branch 'master'`
+            source: branchLink(project, 'master'),
+            sha: masterSha,
+            commitUrl: `${cloneUrl}/commit/${masterSha}`
         };
     }
     if (!ref) {
@@ -122,6 +124,9 @@ async function processProject(project: Project, branch: string, forkOwner: strin
 
     project.packagePath = `file:/${tempDir}/${project.name}/${project.name}-${buildVersion}.tgz`;
     project.source = ref.source;
+    if (ref.sha) {
+        project.sha = `[${ref.sha.slice(0, 7)}](${ref.commitUrl})`;
+    }
     log(`${project.name}: done`);
 }
 
@@ -138,19 +143,37 @@ async function resolveRef(project: Project, branch: string, forkOwner: string): 
         //1. the org has this branch and it's attached to an open PR
         let pr = await findOpenPr(project.name, orgName, branch);
         if (pr) {
-            return { cloneUrl: orgCloneUrl, ref: branch, source: prLink(pr) };
+            return {
+                cloneUrl: orgCloneUrl,
+                ref: branch,
+                source: prLink(pr),
+                sha: pr.head.sha,
+                commitUrl: `${pr.head.repo.html_url}/commit/${pr.head.sha}`
+            };
         }
         //2. the fork owner has this branch attached to an open PR on this project
         if (forkOwner) {
             pr = await findOpenPr(project.name, forkOwner, branch);
             if (pr) {
-                return { cloneUrl: pr.head.repo.clone_url, ref: branch, source: prLink(pr) };
+                return {
+                    cloneUrl: pr.head.repo.clone_url,
+                    ref: branch,
+                    source: prLink(pr),
+                    sha: pr.head.sha,
+                    commitUrl: `${pr.head.repo.html_url}/commit/${pr.head.sha}`
+                };
             }
         }
         //3. the org has this branch (no PR)
         const sha = getBranchSha(orgCloneUrl, branch);
         if (sha) {
-            return { cloneUrl: orgCloneUrl, ref: branch, source: commitLink(project, branch, sha) };
+            return {
+                cloneUrl: orgCloneUrl,
+                ref: branch,
+                source: branchLink(project, branch),
+                sha: sha,
+                commitUrl: `${orgCloneUrl}/commit/${sha}`
+            };
         }
     }
     //no matching branch anywhere
@@ -158,10 +181,10 @@ async function resolveRef(project: Project, branch: string, forkOwner: string): 
 }
 
 /**
- * Render a PR as a markdown link, e.g. `[rokucommunity/roku-deploy/pull/123](https://github.com/rokucommunity/roku-deploy/pull/123)`
+ * Render a PR as a markdown link, e.g. `pr: [rokucommunity/roku-deploy#123](https://github.com/rokucommunity/roku-deploy/pull/123)`
  */
-function prLink(pr: { html_url: string }) {
-    return `[${pr.html_url.replace(/^https:\/\/github\.com\//, '')}](${pr.html_url})`;
+function prLink(pr: { html_url: string; number: number; base: { repo: { full_name: string } } }) {
+    return `pr: [${pr.base.repo.full_name}#${pr.number}](${pr.html_url})`;
 }
 
 /**
@@ -194,6 +217,10 @@ interface Project {
     dependencies: string[];
     packagePath?: string;
     source?: string;
+    /**
+     * Markdown link to the exact commit that was built (only set for locally-built projects)
+     */
+    sha?: string;
     processed: boolean;
 }
 
@@ -201,6 +228,8 @@ interface Ref {
     cloneUrl: string;
     ref: string;
     source: string;
+    sha?: string;
+    commitUrl?: string;
 }
 
 /**
@@ -212,11 +241,11 @@ function getBranchSha(cloneUrl: string, branch: string) {
 }
 
 /**
- * Render a branch build as a markdown link to its tip commit,
- * e.g. `[rokucommunity/roku-deploy/commit/a1b2c3d](https://github.com/rokucommunity/roku-deploy/commit/a1b2c3d...) (branch 'alpha')`
+ * Render a branch build as a markdown link to the branch,
+ * e.g. `branch: [alpha](https://github.com/rokucommunity/roku-deploy/tree/alpha)`
  */
-function commitLink(project: Project, branch: string, sha: string) {
-    return `[${orgName}/${project.name}/commit/${sha.slice(0, 7)}](${baseUrl}/${project.name}/commit/${sha}) (branch '${branch}')`;
+function branchLink(project: Project, branch: string) {
+    return `branch: [${branch}](${baseUrl}/${project.name}/tree/${branch})`;
 }
 
 function clone(project: Project, ref: Ref) {


### PR DESCRIPTION
create-vsix currently clones and builds all five projects from master even when only one has the target branch — slow, and it silently builds master for projects that should just use their published npm versions.

- Dependencies without a matching branch are no longer cloned; the normal npm dependency flows through instead (only `vscode-brightscript-language` itself always builds, falling back to master)
- Locally-built tgz installs are skipped for deps that stayed on npm
- Clones are now shallow single-branch (`--depth 1`)
- Every "Built from" entry in the bot comment is now a link: PR, branch tip commit, or the npm version's release tag

Verified via tsc; the create-vsix label on this PR will exercise the new flow for real.

🤖 Generated with [Claude Code](https://claude.com/claude-code)