### PR TITLE
Fixed: Carry the picked device config through the rekey and package flows

### DIFF
--- a/src/DebugConfigurationProvider.ts
+++ b/src/DebugConfigurationProvider.ts
@@ -516,26 +516,13 @@ export class BrightScriptDebugConfigurationProvider implements DebugConfiguratio
     }
 
     /**
-     * Describe a device config (a local `{host}` config, or a Roku Cloud Emulator config addressed
-     * by esn/id/instanceUrl) by whichever address field it has, for error messages.
+     * Describe a device config by whichever address field it has, for error messages.
      * `processHostParameter` always normalizes `config.device`, so once it has run this is the
      * authoritative way to name the target device - unlike the top-level `host`, which non-local
      * sessions leave unset or unresolved.
      */
     private describeDevice(device: DeviceConfig | undefined): string {
-        if (device && isLocalDeviceConfig(device)) {
-            return device.host;
-        }
-        if (device && 'instanceUrl' in device) {
-            return device.instanceUrl;
-        }
-        if (device && 'id' in device) {
-            return String(device.id);
-        }
-        if (device && 'esn' in device) {
-            return device.esn;
-        }
-        return 'the target device';
+        return util.describeDevice(device, 'the target device');
     }
 
     /**

--- a/src/commands/RekeyAndPackageCommand.spec.ts
+++ b/src/commands/RekeyAndPackageCommand.spec.ts
@@ -1,0 +1,114 @@
+import { vscode } from '../mockVscode.spec';
+import type { SinonStub } from 'sinon';
+import { createSandbox } from 'sinon';
+import { RekeyAndPackageCommand } from './RekeyAndPackageCommand';
+import { rokuDeploy } from 'roku-deploy';
+import { expect } from 'chai';
+
+const sinon = createSandbox();
+
+describe('RekeyAndPackageCommand', () => {
+    let command: RekeyAndPackageCommand;
+    let userInputManager: any;
+
+    beforeEach(() => {
+        command = new RekeyAndPackageCommand();
+        userInputManager = {
+            promptForHost: sinon.stub()
+        };
+        command.register(vscode.context as any, {} as any, userInputManager);
+    });
+
+    afterEach(() => {
+        sinon.restore();
+    });
+
+    /**
+     * Stub every dialog the manual rekey flow walks through: the config-source quick pick,
+     * the password/signingPassword input boxes, and the signed-package + confirmation modals
+     */
+    function stubRekeyDialogs() {
+        sinon.stub(vscode.window, 'showQuickPick').resolves('Enter manually' as any);
+        const inputBox = sinon.stub(vscode.window, 'showInputBox');
+        inputBox.onFirstCall().resolves('devPassword');
+        inputBox.onSecondCall().resolves('signingPassword');
+        const infoMessage = sinon.stub(vscode.window, 'showInformationMessage') as SinonStub;
+        //signed-package modal, then the confirmation modal, then the success toast
+        infoMessage.onFirstCall().resolves('Open file picker');
+        infoMessage.onSecondCall().resolves('Rekey');
+        sinon.stub(vscode.window, 'showOpenDialog').resolves([{ fsPath: '/path/to/signed.pkg' } as any]);
+        return { infoMessage: infoMessage };
+    }
+
+    describe('rekeyDevice', () => {
+        it('passes the picked LAN device config through to rokuDeploy.rekeyDevice', async () => {
+            stubRekeyDialogs();
+            userInputManager.promptForHost.resolves({ host: '1.1.1.1', deviceInfo: {}, device: { host: '1.1.1.1' } });
+            const rekeyStub = sinon.stub(rokuDeploy, 'rekeyDevice').resolves();
+
+            await command['rekeyDevice']();
+
+            expect(rekeyStub.getCall(0).args[0]).to.eql({
+                device: { host: '1.1.1.1' },
+                password: 'devPassword',
+                signingPassword: 'signingPassword',
+                pkg: '/path/to/signed.pkg'
+            });
+        });
+
+        it('passes a cloud emulator device config through to rokuDeploy.rekeyDevice', async () => {
+            const cloudDevice = { instanceUrl: 'https://rce.example.com/instance', rceToken: 'token' };
+            const { infoMessage } = stubRekeyDialogs();
+            userInputManager.promptForHost.resolves({ host: undefined, deviceInfo: {}, device: cloudDevice, rce: { status: 'running' } });
+            const rekeyStub = sinon.stub(rokuDeploy, 'rekeyDevice').resolves();
+
+            await command['rekeyDevice']();
+
+            expect(rekeyStub.getCall(0).args[0]).to.eql({
+                device: cloudDevice,
+                password: 'devPassword',
+                signingPassword: 'signingPassword',
+                pkg: '/path/to/signed.pkg'
+            });
+            //the confirmation dialog names the device by its instance url instead of "host: undefined"
+            const confirmDetail = infoMessage.getCall(1).args[1];
+            expect(confirmDetail.detail).to.include('device: https://rce.example.com/instance');
+        });
+
+        it('rejects a cloud emulator device that is not running', async () => {
+            stubRekeyDialogs();
+            userInputManager.promptForHost.resolves({ host: undefined, deviceInfo: {}, device: { id: 83, rceToken: 'token' }, rce: { status: 'stopped' } });
+            const rekeyStub = sinon.stub(rokuDeploy, 'rekeyDevice').resolves();
+
+            let error: Error | undefined;
+            try {
+                await command['rekeyDevice']();
+            } catch (e) {
+                error = e as Error;
+            }
+
+            expect(error?.message).to.include('not running');
+            expect(rekeyStub.called).to.be.false;
+        });
+    });
+
+    describe('resolveDeviceConfig', () => {
+        it('returns undefined when the picker was dismissed', () => {
+            expect(command['resolveDeviceConfig'](undefined)).to.be.undefined;
+        });
+
+        it('falls back to a host-based config when the pick has no device config', () => {
+            expect(command['resolveDeviceConfig']({ host: '1.1.1.1' } as any)).to.eql({ host: '1.1.1.1' });
+        });
+    });
+
+    describe('describeDevice', () => {
+        it('names devices by whichever address field they carry', () => {
+            expect(command['describeDevice']({ host: '1.1.1.1' })).to.equal('1.1.1.1');
+            expect(command['describeDevice']({ instanceUrl: 'https://rce.example.com', rceToken: 'token' })).to.equal('https://rce.example.com');
+            expect(command['describeDevice']({ id: 83, rceToken: 'token' })).to.equal('83');
+            expect(command['describeDevice']({ esn: 'RCE123', rceToken: 'token' })).to.equal('RCE123');
+            expect(command['describeDevice'](undefined)).to.equal('unknown');
+        });
+    });
+});

--- a/src/commands/RekeyAndPackageCommand.spec.ts
+++ b/src/commands/RekeyAndPackageCommand.spec.ts
@@ -4,6 +4,7 @@ import { createSandbox } from 'sinon';
 import { RekeyAndPackageCommand } from './RekeyAndPackageCommand';
 import { rokuDeploy } from 'roku-deploy';
 import { expect } from 'chai';
+import { util } from '../util';
 
 const sinon = createSandbox();
 
@@ -102,13 +103,28 @@ describe('RekeyAndPackageCommand', () => {
         });
     });
 
-    describe('describeDevice', () => {
-        it('names devices by whichever address field they carry', () => {
-            expect(command['describeDevice']({ host: '1.1.1.1' })).to.equal('1.1.1.1');
-            expect(command['describeDevice']({ instanceUrl: 'https://rce.example.com', rceToken: 'token' })).to.equal('https://rce.example.com');
-            expect(command['describeDevice']({ id: 83, rceToken: 'token' })).to.equal('83');
-            expect(command['describeDevice']({ esn: 'RCE123', rceToken: 'token' })).to.equal('RCE123');
-            expect(command['describeDevice'](undefined)).to.equal('unknown');
+    describe('packageFromLaunchConfig', () => {
+        function selectLaunchConfig(launchConfig: any) {
+            sinon.stub(util, 'getConfiguration').returns({ get: () => [launchConfig] } as any);
+            sinon.stub(vscode.window, 'showQuickPick').resolves(launchConfig.name);
+            return command['packageFromLaunchConfig']({});
+        }
+
+        it('handles a launch config with no host or password (a cloud emulator config)', async () => {
+            const options = await selectLaunchConfig({ name: 'cloud', rootDir: '/proj', device: { id: 83 } });
+            expect(options.host).to.be.undefined;
+            expect(options.password).to.be.undefined;
+        });
+
+        it('prefills the host from a local device config when there is no top-level host', async () => {
+            const options = await selectLaunchConfig({ name: 'lan', rootDir: '/proj', device: { host: '1.1.1.1' } });
+            expect(options.host).to.equal('1.1.1.1');
+        });
+
+        it('ignores placeholder hosts', async () => {
+            const options = await selectLaunchConfig({ name: 'prompt', rootDir: '/proj', host: '${promptForHost}', password: '${promptForPassword}' });
+            expect(options.host).to.be.undefined;
+            expect(options.password).to.be.undefined;
         });
     });
 });

--- a/src/commands/RekeyAndPackageCommand.ts
+++ b/src/commands/RekeyAndPackageCommand.ts
@@ -1,6 +1,7 @@
 import * as vscode from 'vscode';
-import { rokuDeploy } from 'roku-deploy';
-import type { FileEntry } from 'roku-deploy';
+import { rokuDeploy, isLocalDeviceConfig } from 'roku-deploy';
+import type { DeviceConfig, FileEntry } from 'roku-deploy';
+import type { HostWithDeviceInfo } from '../deviceDiscovery/DeviceManager';
 import type { BrightScriptCommands } from '../BrightScriptCommands';
 import * as path from 'path';
 import { readFileSync } from 'fs-extra';
@@ -60,7 +61,7 @@ export class RekeyAndPackageCommand {
         }
 
         await rokuDeploy.rekeyDevice({
-            device: { host: rekeyConfig.host },
+            device: rekeyConfig.device ?? { host: rekeyConfig.host },
             password: rekeyConfig.password,
             signingPassword: rekeyConfig.signingPassword,
             pkg: rekeyConfig.rekeySignedPackage
@@ -105,7 +106,9 @@ export class RekeyAndPackageCommand {
     }
 
     private async getRekeyManualEntries(rekeyConfig: RekeyConfig, defaultValues) {
-        rekeyConfig.host = (await this.userInputManager.promptForHost({ defaultValue: rekeyConfig?.host ?? defaultValues?.host }))?.host;
+        const pickedHost = await this.userInputManager.promptForHost({ defaultValue: rekeyConfig?.host ?? defaultValues?.host });
+        rekeyConfig.host = pickedHost?.host;
+        rekeyConfig.device = this.resolveDeviceConfig(pickedHost);
 
         rekeyConfig.password = await vscode.window.showInputBox({
             title: 'Enter password for the Roku device you want to rekey',
@@ -128,7 +131,7 @@ export class RekeyAndPackageCommand {
         const selection = await vscode.window.showInformationMessage('Rekey info:', {
             modal: true,
             detail: [
-                `host: ${rekeyConfig.host}`,
+                `device: ${this.describeDevice(rekeyConfig.device ?? { host: rekeyConfig.host })}`,
                 `password: ${rekeyConfig.password}`,
                 `signing password: ${rekeyConfig.signingPassword}`,
                 `package: ${rekeyConfig.rekeySignedPackage}`
@@ -139,6 +142,43 @@ export class RekeyAndPackageCommand {
         } else if (selection === 'I want to change something') {
             return this.getRekeyManualEntries(rekeyConfig, rekeyConfig);
         }
+    }
+
+    /**
+     * Convert a host-picker result into the roku-deploy device config the rekey/package flows
+     * should target. A Roku Cloud Emulator pick has no LAN host, so its precomputed device option
+     * (instanceUrl/id plus rceToken) is the only way to address it. Rekeying and packaging also
+     * require the emulator to actually be running, so a stopped pick is rejected here with an
+     * actionable message instead of failing later with a generic roku-deploy error.
+     */
+    private resolveDeviceConfig(pickedHost: HostWithDeviceInfo | undefined): DeviceConfig | undefined {
+        if (!pickedHost) {
+            return undefined;
+        }
+        if (pickedHost.rce && pickedHost.rce.status !== 'running') {
+            throw new Error('The selected cloud emulator device is not running. Start it from the Cloud Emulator panel first.');
+        }
+        return pickedHost.device ?? (pickedHost.host ? { host: pickedHost.host } : undefined);
+    }
+
+    /**
+     * Describe a device config by whichever address field it has, for the confirmation dialogs.
+     * A Roku Cloud Emulator config has no host, so the host cannot be printed directly.
+     */
+    private describeDevice(device: DeviceConfig | undefined): string {
+        if (device && isLocalDeviceConfig(device)) {
+            return device.host;
+        }
+        if (device && 'instanceUrl' in device) {
+            return device.instanceUrl;
+        }
+        if (device && 'id' in device) {
+            return String(device.id);
+        }
+        if (device && 'esn' in device) {
+            return device.esn;
+        }
+        return 'unknown';
     }
 
     private async getSignedPackage(rekeySignedPackage: string) {
@@ -240,7 +280,9 @@ export class RekeyAndPackageCommand {
                     break;
             }
 
-            rokuDeployOptions.host = (await this.userInputManager.promptForHost({ defaultValue: rokuDeployOptions?.host ?? '' }))?.host;
+            const pickedHost = await this.userInputManager.promptForHost({ defaultValue: rokuDeployOptions?.host ?? '' });
+            rokuDeployOptions.host = pickedHost?.host;
+            rokuDeployOptions.device = this.resolveDeviceConfig(pickedHost);
 
             rokuDeployOptions.password = await vscode.window.showInputBox({
                 title: 'Enter password for the Roku device',
@@ -280,7 +322,7 @@ export class RekeyAndPackageCommand {
             const pkgPath = zipPath.replace(/\.zip$/i, '.pkg');
 
             let details = [
-                `host: ${rokuDeployOptions.host}`,
+                `device: ${this.describeDevice(rokuDeployOptions.device ?? { host: rokuDeployOptions.host })}`,
                 `password: ${rokuDeployOptions.password}`,
                 `signing password: ${rokuDeployOptions.signingPassword}`,
                 `outDir: ${rokuDeployOptions.outDir}`,
@@ -301,7 +343,7 @@ export class RekeyAndPackageCommand {
             }, confirmText, changeText);
 
             if (response === confirmText) {
-                const device = { host: rokuDeployOptions.host };
+                const device = rokuDeployOptions.device ?? { host: rokuDeployOptions.host };
 
                 if (rekeyFlag) {
                     //rekey device
@@ -462,8 +504,17 @@ export class RekeyAndPackageCommand {
 interface RekeyConfig {
     signingPassword: string;
     rekeySignedPackage: string;
-    host: string;
+    /**
+     * The raw host loaded from a rekey json file, only used to prefill the host picker. The picked
+     * device is migrated into `device`, which is what the rekey call targets.
+     */
+    host?: string;
     password: string;
+    /**
+     * The roku-deploy device config resolved from the host picker. This is the only way to address
+     * a Roku Cloud Emulator device, which has no LAN host.
+     */
+    device?: DeviceConfig;
 }
 
 interface RokuDeployOptions {
@@ -471,7 +522,16 @@ interface RokuDeployOptions {
     outDir: string;
     outFile: string;
     files?: FileEntry[];
-    host: string;
+    /**
+     * The raw host loaded from a launch config or rokudeploy.json, only used to prefill the host
+     * picker. The picked device is migrated into `device`, which is what the deploy calls target.
+     */
+    host?: string;
+    /**
+     * The roku-deploy device config resolved from the host picker. This is the only way to address
+     * a Roku Cloud Emulator device, which has no LAN host.
+     */
+    device?: DeviceConfig;
     password: string;
     signingPassword: string;
     rekeySignedPackage: string;

--- a/src/commands/RekeyAndPackageCommand.ts
+++ b/src/commands/RekeyAndPackageCommand.ts
@@ -106,9 +106,9 @@ export class RekeyAndPackageCommand {
     }
 
     private async getRekeyManualEntries(rekeyConfig: RekeyConfig, defaultValues) {
-        const pickedHost = await this.userInputManager.promptForHost({ defaultValue: rekeyConfig?.host ?? defaultValues?.host });
-        rekeyConfig.host = pickedHost?.host;
-        rekeyConfig.device = this.resolveDeviceConfig(pickedHost);
+        const pickedDevice = await this.userInputManager.promptForHost({ defaultValue: rekeyConfig?.host ?? defaultValues?.host });
+        rekeyConfig.host = pickedDevice?.host;
+        rekeyConfig.device = this.resolveDeviceConfig(pickedDevice);
 
         rekeyConfig.password = await vscode.window.showInputBox({
             title: 'Enter password for the Roku device you want to rekey',
@@ -131,7 +131,7 @@ export class RekeyAndPackageCommand {
         const selection = await vscode.window.showInformationMessage('Rekey info:', {
             modal: true,
             detail: [
-                `device: ${this.describeDevice(rekeyConfig.device ?? { host: rekeyConfig.host })}`,
+                `device: ${util.describeDevice(rekeyConfig.device ?? { host: rekeyConfig.host })}`,
                 `password: ${rekeyConfig.password}`,
                 `signing password: ${rekeyConfig.signingPassword}`,
                 `package: ${rekeyConfig.rekeySignedPackage}`
@@ -151,34 +151,14 @@ export class RekeyAndPackageCommand {
      * require the emulator to actually be running, so a stopped pick is rejected here with an
      * actionable message instead of failing later with a generic roku-deploy error.
      */
-    private resolveDeviceConfig(pickedHost: HostWithDeviceInfo | undefined): DeviceConfig | undefined {
-        if (!pickedHost) {
+    private resolveDeviceConfig(pickedDevice: HostWithDeviceInfo | undefined): DeviceConfig | undefined {
+        if (!pickedDevice) {
             return undefined;
         }
-        if (pickedHost.rce && pickedHost.rce.status !== 'running') {
+        if (pickedDevice.rce && pickedDevice.rce.status !== 'running') {
             throw new Error('The selected cloud emulator device is not running. Start it from the Cloud Emulator panel first.');
         }
-        return pickedHost.device ?? (pickedHost.host ? { host: pickedHost.host } : undefined);
-    }
-
-    /**
-     * Describe a device config by whichever address field it has, for the confirmation dialogs.
-     * A Roku Cloud Emulator config has no host, so the host cannot be printed directly.
-     */
-    private describeDevice(device: DeviceConfig | undefined): string {
-        if (device && isLocalDeviceConfig(device)) {
-            return device.host;
-        }
-        if (device && 'instanceUrl' in device) {
-            return device.instanceUrl;
-        }
-        if (device && 'id' in device) {
-            return String(device.id);
-        }
-        if (device && 'esn' in device) {
-            return device.esn;
-        }
-        return 'unknown';
+        return pickedDevice.device ?? (pickedDevice.host ? { host: pickedDevice.host } : undefined);
     }
 
     private async getSignedPackage(rekeySignedPackage: string) {
@@ -280,9 +260,9 @@ export class RekeyAndPackageCommand {
                     break;
             }
 
-            const pickedHost = await this.userInputManager.promptForHost({ defaultValue: rokuDeployOptions?.host ?? '' });
-            rokuDeployOptions.host = pickedHost?.host;
-            rokuDeployOptions.device = this.resolveDeviceConfig(pickedHost);
+            const pickedDevice = await this.userInputManager.promptForHost({ defaultValue: rokuDeployOptions?.host ?? '' });
+            rokuDeployOptions.host = pickedDevice?.host;
+            rokuDeployOptions.device = this.resolveDeviceConfig(pickedDevice);
 
             rokuDeployOptions.password = await vscode.window.showInputBox({
                 title: 'Enter password for the Roku device',
@@ -322,7 +302,7 @@ export class RekeyAndPackageCommand {
             const pkgPath = zipPath.replace(/\.zip$/i, '.pkg');
 
             let details = [
-                `device: ${this.describeDevice(rokuDeployOptions.device ?? { host: rokuDeployOptions.host })}`,
+                `device: ${util.describeDevice(rokuDeployOptions.device ?? { host: rokuDeployOptions.host })}`,
                 `password: ${rokuDeployOptions.password}`,
                 `signing password: ${rokuDeployOptions.signingPassword}`,
                 `outDir: ${rokuDeployOptions.outDir}`,
@@ -444,11 +424,17 @@ export class RekeyAndPackageCommand {
         }
         rokuDeployOptions.packageConfig = 'launch.json: ' + selectedConfig.rootDir;
 
-        if (!selectedConfig.host.includes('${')) {
+        //a launch config may address its device through `device` instead of a top-level `host`
+        //(a Roku Cloud Emulator config has no host at all), so host and password can be absent
+        //entirely. Values migrate into `device` through the host picker below; a usable host (or a
+        //local device's host) only prefills that picker.
+        if (selectedConfig.host && !selectedConfig.host.includes('${')) {
             rokuDeployOptions.host = selectedConfig.host;
+        } else if (selectedConfig.device && isLocalDeviceConfig(selectedConfig.device) && !selectedConfig.device.host?.includes('${')) {
+            rokuDeployOptions.host = selectedConfig.device.host;
         }
 
-        if (!selectedConfig.password.includes('${')) {
+        if (selectedConfig.password && !selectedConfig.password.includes('${')) {
             rokuDeployOptions.password = selectedConfig.password;
         }
 

--- a/src/util.spec.ts
+++ b/src/util.spec.ts
@@ -14,6 +14,21 @@ beforeEach(() => {
 
 describe('Util', () => {
 
+    describe('describeDevice', () => {
+        it('names devices by whichever address field they carry', () => {
+            expect(util.describeDevice({ host: '1.1.1.1' })).to.equal('1.1.1.1');
+            expect(util.describeDevice({ instanceUrl: 'https://rce.example.com', rceToken: 'token' })).to.equal('https://rce.example.com');
+            expect(util.describeDevice({ id: 83, rceToken: 'token' })).to.equal('83');
+            expect(util.describeDevice({ esn: 'RCE123', rceToken: 'token' })).to.equal('RCE123');
+        });
+
+        it('falls back to the provided label when there is no recognizable address', () => {
+            expect(util.describeDevice(undefined)).to.equal('unknown');
+            expect(util.describeDevice(undefined, 'the target device')).to.equal('the target device');
+            expect(util.describeDevice({ host: '' }, 'the target device')).to.equal('the target device');
+        });
+    });
+
     describe('removeTrailingNewline', () => {
         it('works', () => {
             expect(util.removeTrailingNewline('\r\n')).to.equal('');

--- a/src/util.ts
+++ b/src/util.ts
@@ -7,7 +7,8 @@ import * as vscode from 'vscode';
 import { Cache } from 'brighterscript/dist/Cache';
 import undent from 'undent';
 import { EXTENSION_ID, ROKU_DEBUG_VERSION } from './constants';
-import type { DeviceInfo } from 'roku-deploy';
+import type { DeviceConfig, DeviceInfo } from 'roku-deploy';
+import { isLocalDeviceConfig, isRceDeviceConfigByUrl, isRceDeviceConfigById, isRceDeviceConfigByEsn } from 'roku-deploy';
 import * as request from 'postman-request';
 import type { Response, CoreOptions } from 'request';
 import * as childProcess from 'child_process';
@@ -670,6 +671,33 @@ class Util {
             }
         }
         return false;
+    }
+
+    /**
+     * Describe a roku-deploy device config (a local `{host}` config, or a Roku Cloud Emulator
+     * config addressed by instanceUrl/id/esn) by whichever address field it has, for dialogs and
+     * error messages. A Roku Cloud Emulator config has no host, so the host cannot be printed
+     * directly.
+     * @param device the device config to describe
+     * @param fallback the label to use when the config carries no recognizable address
+     */
+    public describeDevice(device: DeviceConfig | undefined, fallback = 'unknown'): string {
+        if (!device) {
+            return fallback;
+        }
+        if (isLocalDeviceConfig(device)) {
+            return device.host;
+        }
+        if (isRceDeviceConfigByUrl(device)) {
+            return device.instanceUrl;
+        }
+        if (isRceDeviceConfigById(device)) {
+            return String(device.id);
+        }
+        if (isRceDeviceConfigByEsn(device)) {
+            return device.esn;
+        }
+        return fallback;
     }
 }
 


### PR DESCRIPTION
The Rekey Device and Create Package commands rebuilt their roku-deploy target as `device: { host }` from the host picker result, discarding the rest of the picked device config. A Roku Cloud Emulator pick has no LAN host, so those flows failed with "Device must specify host, esn, id, or instanceUrl" and the confirm dialog showed `host: undefined`.

Both flows now follow the roku-deploy v4 device config addressing the debug flow already uses:
- The picked device config is carried through to `rekeyDevice`/`createSignedPackage` via a new `device` field on `RekeyConfig`/`RokuDeployOptions`, resolved by `resolveDeviceConfig` (with a `{ host }` fallback for plain LAN picks).
- A cloud emulator pick that is not running is rejected up front with an actionable message instead of a generic roku-deploy error later.
- Confirm dialogs print `device: <address>` by whichever address field the config carries (host/instanceUrl/id/esn).
- `host` on those interfaces is now optional and documented: it is the raw value from a rekey json/launch config used to prefill the host picker, and the pick is migrated into `device`, which is what the calls target.
- `packageFromLaunchConfig` no longer crashes on a launch config without a top-level `host` or `password` (a config addressed via `device`); a local `device.host` now prefills the host picker.
- `describeDevice` is now a shared `util` helper built on roku-deploy's device config type guards, used by both these dialogs and DebugConfigurationProvider instead of two private copies.