### PR TITLE
[fix] resolve brightscript.bsdk correctly when .code-workspace is not at project root

### DIFF
--- a/src/LanguageServerManager.spec.ts
+++ b/src/LanguageServerManager.spec.ts
@@ -270,6 +270,97 @@ describe('LanguageServerManager', () => {
             );
         });
 
+        it('resolves relative bsdk path from the workspace file directory, not the project root', async () => {
+            // .code-workspace file lives in a subdirectory (.vscode/)
+            vscode.workspace.workspaceFile = URI.file(s`${tempDir}/.vscode/workspace.code-workspace`);
+            vscode.workspace.workspaceFolders.push({
+                index: 0,
+                name: 'SDK',
+                uri: URI.file(s`${tempDir}`)
+            });
+
+            setConfig(vscode.workspace.workspaceFile.fsPath, {
+                'brightscript.bsdk': '../node_modules/brighterscript'
+            });
+
+            expect(
+                s(await languageServerManager['getBsdkVersionInfo']())
+            ).to.eql(
+                // resolves from .vscode/ → one level up → tempDir/node_modules/brighterscript
+                s`${tempDir}/node_modules/brighterscript`
+            );
+        });
+
+        it('expands ${workspaceFolder:name} variable in bsdk path', async () => {
+            vscode.workspace.workspaceFile = URI.file(s`${tempDir}/.vscode/workspace.code-workspace`);
+            vscode.workspace.workspaceFolders.push({
+                index: 0,
+                name: 'SDK',
+                uri: URI.file(s`${tempDir}`)
+            });
+
+            setConfig(vscode.workspace.workspaceFile.fsPath, {
+                'brightscript.bsdk': '${workspaceFolder:SDK}/node_modules/brighterscript'
+            });
+
+            expect(
+                s(await languageServerManager['getBsdkVersionInfo']())
+            ).to.eql(s`${tempDir}/node_modules/brighterscript`);
+        });
+
+        it('expands ${workspaceFolder} variable to the first workspace folder', async () => {
+            vscode.workspace.workspaceFile = URI.file(s`${tempDir}/.vscode/workspace.code-workspace`);
+            vscode.workspace.workspaceFolders.push({
+                index: 0,
+                name: 'SDK',
+                uri: URI.file(s`${tempDir}`)
+            });
+
+            setConfig(vscode.workspace.workspaceFile.fsPath, {
+                'brightscript.bsdk': '${workspaceFolder}/node_modules/brighterscript'
+            });
+
+            expect(
+                s(await languageServerManager['getBsdkVersionInfo']())
+            ).to.eql(s`${tempDir}/node_modules/brighterscript`);
+        });
+
+        it('throws for an unrecognized variable in bsdk path', async () => {
+            vscode.workspace.workspaceFile = URI.file(s`${tempDir}/.vscode/workspace.code-workspace`);
+            vscode.workspace.workspaceFolders.push({
+                index: 0,
+                name: 'SDK',
+                uri: URI.file(s`${tempDir}`)
+            });
+
+            setConfig(vscode.workspace.workspaceFile.fsPath, {
+                'brightscript.bsdk': '${env:MY_VAR}/node_modules/brighterscript'
+            });
+
+            await expectThrowsAsync(
+                () => languageServerManager['getBsdkVersionInfo'](),
+                'brightscript.bsdk: unsupported variable "${env:MY_VAR}"'
+            );
+        });
+
+        it('throws for an unknown workspace folder name in bsdk path', async () => {
+            vscode.workspace.workspaceFile = URI.file(s`${tempDir}/.vscode/workspace.code-workspace`);
+            vscode.workspace.workspaceFolders.push({
+                index: 0,
+                name: 'SDK',
+                uri: URI.file(s`${tempDir}`)
+            });
+
+            setConfig(vscode.workspace.workspaceFile.fsPath, {
+                'brightscript.bsdk': '${workspaceFolder:Unknown}/node_modules/brighterscript'
+            });
+
+            await expectThrowsAsync(
+                () => languageServerManager['getBsdkVersionInfo'](),
+                'brightscript.bsdk: unknown workspace folder name "Unknown"'
+            );
+        });
+
         it('returns folder version when not in a workspace', async () => {
             vscode.workspace.workspaceFolders.push({
                 index: 0,

--- a/src/LanguageServerManager.ts
+++ b/src/LanguageServerManager.ts
@@ -524,7 +524,7 @@ export class LanguageServerManager {
         //use bsdk entry in the code-workspace file
         if (this.workspaceConfigIncludesBsdkKey()) {
             let result = this.parseVersionInfo(
-                util.getConfiguration('brightscript', vscode.workspace.workspaceFile).get<string>('bsdk')?.trim?.(),
+                this.workspaceBsdkPath(),
                 path.dirname(vscode.workspace.workspaceFile.fsPath)
             );
             if (result) {
@@ -555,6 +555,39 @@ export class LanguageServerManager {
             //TODO should we prompt for just these items?
             return languageServerInfoCommand.selectBrighterScriptVersion();
         }
+    }
+
+    /**
+     * Get the `brightscript.bsdk` value from the .code-workspace settings block with workspace
+     * folder variables expanded. `inspect().workspaceValue` returns the unresolved string from
+     * the .code-workspace file — VSCode does not expand variables like ${workspaceFolder} in this
+     * value, so we expand ${workspaceFolder} and ${workspaceFolder:name} ourselves.
+     */
+    private workspaceBsdkPath(): string {
+        const rawValue = util.getConfiguration('brightscript', vscode.workspace.workspaceFile).inspect<string>('bsdk')?.workspaceValue?.trim?.();
+        return this.expandWorkspaceBsdkPath(rawValue);
+    }
+
+    /**
+     * Expand ${workspaceFolder} and ${workspaceFolder:name} variables in a bsdk path string.
+     * VSCode does not expand these variables in inspect().workspaceValue, so we do it ourselves.
+     * Throws if an unrecognized variable is encountered.
+     */
+    private expandWorkspaceBsdkPath(value: string): string {
+        return value?.replace(/\$\{([^}]+)\}/g, (_match, expression) => {
+            const namedFolder = /^workspaceFolder:(.+)$/.exec(expression);
+            if (namedFolder) {
+                const folder = vscode.workspace.workspaceFolders?.find(f => f.name === namedFolder[ 1 ]);
+                if (!folder) {
+                    throw new Error(`brightscript.bsdk: unknown workspace folder name "${namedFolder[ 1 ]}"`);
+                }
+                return folder.uri.fsPath;
+            }
+            if (expression === 'workspaceFolder') {
+                return vscode.workspace.workspaceFolders?.[ 0 ]?.uri.fsPath ?? _match;
+            }
+            throw new Error(`brightscript.bsdk: unsupported variable "\${${expression}}"`);
+        });
     }
 
     private workspaceConfigIncludesBsdkKey() {

--- a/src/LanguageServerManager.ts
+++ b/src/LanguageServerManager.ts
@@ -577,14 +577,14 @@ export class LanguageServerManager {
         return value?.replace(/\$\{([^}]+)\}/g, (_match, expression) => {
             const namedFolder = /^workspaceFolder:(.+)$/.exec(expression);
             if (namedFolder) {
-                const folder = vscode.workspace.workspaceFolders?.find(f => f.name === namedFolder[ 1 ]);
+                const folder = vscode.workspace.workspaceFolders?.find(f => f.name === namedFolder[1]);
                 if (!folder) {
-                    throw new Error(`brightscript.bsdk: unknown workspace folder name "${namedFolder[ 1 ]}"`);
+                    throw new Error(`brightscript.bsdk: unknown workspace folder name "${namedFolder[1]}"`);
                 }
                 return folder.uri.fsPath;
             }
             if (expression === 'workspaceFolder') {
-                return vscode.workspace.workspaceFolders?.[ 0 ]?.uri.fsPath ?? _match;
+                return vscode.workspace.workspaceFolders?.[0]?.uri.fsPath ?? _match;
             }
             throw new Error(`brightscript.bsdk: unsupported variable "\${${expression}}"`);
         });

--- a/src/mockVscode.spec.ts
+++ b/src/mockVscode.spec.ts
@@ -191,7 +191,8 @@ export let vscode = {
                 inspect: (name: string) => {
                     return {
                         key: name,
-                        globalValue: store?.[`${configurationName}.${name}`]
+                        globalValue: store?.[`${configurationName}.${name}`],
+                        workspaceValue: store?.[`${configurationName}.${name}`]
                     } as ReturnType<WorkspaceConfiguration['inspect']>;
                 },
                 update: (name: string, value: any) => {


### PR DESCRIPTION
## Summary

### Context

- `getConfiguration(...).get('bsdk')` pre-resolves relative paths and variables like `${workspaceFolder}` against the wrong base when the `.code-workspace` file is not at the project root

### Changes

- Use `inspect().workspaceValue` to get the raw unresolved string from the workspace file
- Expand `${workspaceFolder}` and `${workspaceFolder:name}` variables ourselves against the correct workspace folders, and throw a clear error for any unrecognized variables
  - VSCode extensions API does not provide any helpers for this 🙁
  - limited scope to `workspaceFolder` and `workspaceFolder:name`
  - any other variables are flagged as unknown

## Test plan

- [ ] Place `.code-workspace` file in a subdirectory (e.g. `.vscode/`) with a relative `brightscript.bsdk` path — language server should resolve correctly
- [ ] Use `${workspaceFolder:FolderName}/node_modules/brighterscript` — should resolve to the named folder's path
- [ ] Use an unrecognized variable like `${env:MY_VAR}` — should surface a clear error in the BrightScript output panel
- [ ] Single-root workspace (no `.code-workspace` file) — behavior unchanged

---

Disclaimers:

- 🤖 used [Claude Code](https://claude.com/claude-code)
  - mostly for the unit tests 😅