### PR TITLE
Add roku-test-automation to local dev scripts and workspace

### DIFF
--- a/scripts/create-vsix.ts
+++ b/scripts/create-vsix.ts
@@ -20,8 +20,11 @@ const projects = [{
     name: 'brighterscript-formatter',
     dependencies: ['brighterscript']
 }, {
+    name: 'roku-test-automation',
+    dependencies: ['roku-deploy']
+}, {
     name: 'vscode-brightscript-language',
-    dependencies: ['brighterscript', 'roku-debug', 'brighterscript-formatter', 'roku-deploy']
+    dependencies: ['brighterscript', 'roku-debug', 'brighterscript-formatter', 'roku-deploy', 'roku-test-automation']
 }] as Project[];
 
 async function main() {

--- a/scripts/install-local.ts
+++ b/scripts/install-local.ts
@@ -81,12 +81,19 @@ class InstallLocalRunner {
             ]
         },
         {
+            name: 'roku-test-automation',
+            dependencies: [
+                'roku-deploy'
+            ]
+        },
+        {
             name: 'vscode-brightscript-language',
             dependencies: [
                 'roku-deploy',
                 'brighterscript',
                 'roku-debug',
-                'brighterscript-formatter'
+                'brighterscript-formatter',
+                'roku-test-automation'
             ]
         }
     ];

--- a/scripts/package-local.js
+++ b/scripts/package-local.js
@@ -18,7 +18,8 @@ var projectNames = [
     'roku-deploy',
     'brighterscript',
     'brighterscript-formatter',
-    'roku-debug'
+    'roku-debug',
+    'roku-test-automation'
 ];
 var projects = {};
 

--- a/scripts/uninstall-local.js
+++ b/scripts/uninstall-local.js
@@ -5,7 +5,8 @@ let packages = [
     'roku-debug',
     'roku-deploy',
     'brighterscript',
-    'brighterscript-formatter'
+    'brighterscript-formatter',
+    'roku-test-automation'
 ];
 
 console.log('Loading original package.json from git');

--- a/scripts/watch-all.ts
+++ b/scripts/watch-all.ts
@@ -55,12 +55,18 @@ const projects = [{
         'brighterscript'
     ]
 }, {
+    name: 'roku-test-automation',
+    dependencies: [
+        'roku-deploy'
+    ]
+}, {
     name: path.basename(path.resolve(__dirname, '..')),
     dependencies: [
         'roku-deploy',
         'brighterscript',
         'roku-debug',
-        'brighterscript-formatter'
+        'brighterscript-formatter',
+        'roku-test-automation'
     ]
 }].map(x => {
     return {

--- a/workspace.code-workspace
+++ b/workspace.code-workspace
@@ -19,6 +19,10 @@
 		{
             "name": "➰brighterscript-formatter",
 			"path": "../brighterscript-formatter"
+		},
+		{
+            "name": "🧪roku-test-automation",
+			"path": "../roku-test-automation"
 		}
 	],
     "settings": {


### PR DESCRIPTION
`roku-test-automation` is a dependency of the extension but was missing from the local-development tooling. This adds it so it can be developed locally alongside the other rokucommunity projects.

- `install-local` clones/builds `roku-test-automation` and links the local copy into the extension
- `watch-all`, `create-vsix`, `package-local`, and `uninstall-local` include it in their project lists
- `workspace.code-workspace` adds the `roku-test-automation` folder

`roku-test-automation` depends only on `roku-deploy`, reflected in each script's dependency list.