### PR TITLE
Security enhancements

### DIFF
--- a/audit-ci.jsonc
+++ b/audit-ci.jsonc
@@ -15,7 +15,7 @@
             "GHSA-w5hq-g745-h8pq": {
                 // Added: 2026-05-22
                 "active": true,
-                "notes": "`uuid` <11.1.1 (via direct dep, `postman-request`, `node-notifier`, and dev-only `nyc>istanbul-lib-processinfo`): vulnerable code path is `v3()`/`v5()`/`v6()` when a caller-provided buffer is passed. Every consumer (including our own `src/viewProviders/RokuAppOverlaysViewViewProvider.ts`) calls only `v4()` with no buffer arg, so the vulnerable path is unreachable. Cannot bump past uuid@9 without also bumping `typescript` past ^4.7.4, since uuid@11's bundled .d.ts uses `export type *` syntax requiring TS 5.0+."
+                "notes": "`uuid` <11.1.1 (via our direct `^9.0.1` dep and `postman-request`; the `node-notifier` and `nyc>istanbul-lib-processinfo` copies are pinned to ^11.1.1 by scoped overrides): vulnerable code path is `v3()`/`v5()`/`v6()` when a caller-provided buffer is passed. Every remaining consumer calls only `v4()` with no buffer arg — ours at `src/viewProviders/RokuAppOverlaysViewViewProvider.ts`, and postman-request's in lib/auth.js, lib/multipart.js and lib/oauth.js — so the vulnerable path is unreachable. Cannot bump the direct dep past uuid@9 without also bumping `typescript` past ^4.7.4 (uuid@11's bundled .d.ts uses `export type *`, needing TS 5.0+), and cannot override `postman-request`'s copy at all: it does `require('uuid/v4')`, a subpath uuid@11 no longer exports."
             }
         }
     ]

--- a/package-lock.json
+++ b/package-lock.json
@@ -5856,9 +5856,9 @@
             "dev": true
         },
         "node_modules/fast-uri": {
-            "version": "3.1.5",
-            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.5.tgz",
-            "integrity": "sha512-gHwA1O9LDIcKunMKhObS/HimwtehO1nPUECKAu5TpKgaO19fcWEl4bliWe1jWxVFvIXztJjjQ4L8XQ1EU9f7Jw==",
+            "version": "3.1.7",
+            "resolved": "https://registry.npmjs.org/fast-uri/-/fast-uri-3.1.7.tgz",
+            "integrity": "sha512-dOvZVzjdZdz7phd9v6jCbwxrBW3fK6n8Rc0CtdmM4bumzMnxywBYhuph6J819RRw/ku+rLbelwfMunktuzVVHg==",
             "dev": true,
             "funding": [
                 {
@@ -7558,12 +7558,17 @@
             }
         },
         "node_modules/istanbul-lib-processinfo/node_modules/uuid": {
-            "version": "8.3.2",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+            "version": "11.1.1",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+            "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
             "dev": true,
+            "funding": [
+                "https://github.com/sponsors/broofa",
+                "https://github.com/sponsors/ctavan"
+            ],
+            "license": "MIT",
             "bin": {
-                "uuid": "dist/bin/uuid"
+                "uuid": "dist/esm/bin/uuid"
             }
         },
         "node_modules/istanbul-lib-report": {
@@ -8660,12 +8665,17 @@
             }
         },
         "node_modules/node-notifier/node_modules/uuid": {
-            "version": "8.3.2",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.3.2.tgz",
-            "integrity": "sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==",
+            "version": "11.1.1",
+            "resolved": "https://registry.npmjs.org/uuid/-/uuid-11.1.1.tgz",
+            "integrity": "sha512-vIYxrBCC/N/K+Js3qSN88go7kIfNPssr/hHCesKCQNAjmgvYS2oqr69kIufEG+O4+PfezOH4EbIeHCfFov8ZgQ==",
             "dev": true,
+            "funding": [
+                "https://github.com/sponsors/broofa",
+                "https://github.com/sponsors/ctavan"
+            ],
+            "license": "MIT",
             "bin": {
-                "uuid": "dist/bin/uuid"
+                "uuid": "dist/esm/bin/uuid"
             }
         },
         "node_modules/node-preload": {
@@ -9822,9 +9832,9 @@
             }
         },
         "node_modules/qs": {
-            "version": "6.15.3",
-            "resolved": "https://registry.npmjs.org/qs/-/qs-6.15.3.tgz",
-            "integrity": "sha512-O9gl3zCl5h5blw1KGUzQKhA5oUXSl8rwUIM5o0S3nCXMliSvy5Dzx7/DJcI+SwgICv+IneSZwhBh1oSyEHA71A==",
+            "version": "6.16.0",
+            "resolved": "https://registry.npmjs.org/qs/-/qs-6.16.0.tgz",
+            "integrity": "sha512-h6fhOIaRrID2CbEY2fqs+7t+UXZo+MLAnU5gRIq85uFtdiUPCdsApMlHhXogKVM4HM2DVbIjGNTTYH2OcmP1vA==",
             "license": "BSD-3-Clause",
             "dependencies": {
                 "es-define-property": "^1.0.1",
@@ -9836,6 +9846,12 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
+        },
+        "node_modules/querystringify": {
+            "version": "2.2.0",
+            "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
+            "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
+            "license": "MIT"
         },
         "node_modules/queue-microtask": {
             "version": "1.2.3",
@@ -11920,16 +11936,27 @@
             }
         },
         "node_modules/tough-cookie": {
-            "version": "2.5.0",
-            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-2.5.0.tgz",
-            "integrity": "sha512-nlLsUzgm1kfLXSXfRZMc1KLAugd4hqJHDTvc2hDIwS3mZAfMEuMbc03SujMF+GEcpaX/qboeycw6iO8JwVv2+g==",
+            "version": "4.1.4",
+            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
+            "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
             "license": "BSD-3-Clause",
             "dependencies": {
-                "psl": "^1.1.28",
-                "punycode": "^2.1.1"
+                "psl": "^1.1.33",
+                "punycode": "^2.1.1",
+                "universalify": "^0.2.0",
+                "url-parse": "^1.5.3"
             },
             "engines": {
-                "node": ">=0.8"
+                "node": ">=6"
+            }
+        },
+        "node_modules/tough-cookie/node_modules/universalify": {
+            "version": "0.2.0",
+            "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
+            "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
+            "license": "MIT",
+            "engines": {
+                "node": ">= 4.0.0"
             }
         },
         "node_modules/traverse-chain": {
@@ -12356,6 +12383,16 @@
             "resolved": "https://registry.npmjs.org/url-join/-/url-join-4.0.1.tgz",
             "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
             "dev": true
+        },
+        "node_modules/url-parse": {
+            "version": "1.5.10",
+            "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
+            "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
+            "license": "MIT",
+            "dependencies": {
+                "querystringify": "^2.1.1",
+                "requires-port": "^1.0.0"
+            }
         },
         "node_modules/util": {
             "version": "0.10.4",

--- a/package.json
+++ b/package.json
@@ -152,10 +152,17 @@
         "brace-expansion": "^2.1.4",
         "js-yaml": "^4.3.1",
         "@babel/core": "^7.29.7",
-        "fast-uri": "^3.1.5",
+        "fast-uri": "^3.1.7",
         "body-parser": "^1.20.6",
-        "qs": "^6.15.3",
-        "ip-address": "^10.4.0"
+        "qs": "^6.16.0",
+        "ip-address": "^10.4.0",
+        "tough-cookie": "^4.1.3",
+        "node-notifier": {
+            "uuid": "^11.1.1"
+        },
+        "istanbul-lib-processinfo": {
+            "uuid": "^11.1.1"
+        }
     },
     "optionalDependencies": {
         "fsevents": "~2.3.2"


### PR DESCRIPTION
Clears 10 of 13 audit advisories. The gate now passes (root + `webviews`).

`npm audit --omit=dev`: **3 vulnerabilities**, down from 13 — all three allowlisted with no fix available.

## Ships to consumers

N/A — this extension ships as a bundled `.vsix`, so nothing resolves it as an npm dependency. `overrides` are a real fix here, not a workaround.

| Package | Change | Advisory |
|---|---|---|
| `qs` | `^6.15.3` → `^6.16.0` | array-limit bypass, isBuffer DoS |
| `tough-cookie` | new `^4.1.3` | prototype pollution (via `postman-request`'s 2.5.0) |
| `fast-uri` | `^3.1.5` → `^3.1.7` | 4 high advisories |
| `uuid` | `^11.1.1`, scoped to `node-notifier` + `istanbul-lib-processinfo` | missing buffer bounds check |

## Notes for the reviewer

- The `uuid` overrides are deliberately **scoped per-parent, not global**. A global pin breaks the build: `postman-request` does `require('uuid/v4')` and uuid@11 dropped that subpath export. Our direct `uuid` dep also stays on `^9` — uuid@11's bundled types need TS 5.0+ and we're on `typescript@^4.7.4`.
- `GHSA-w5hq-g745-h8pq` (uuid) must stay allowlisted for the direct dep and `postman-request`. I confirmed every remaining call site uses `v4()` with no buffer arg — ours in `RokuAppOverlaysViewViewProvider.ts`, postman-request's in `lib/auth.js`, `lib/multipart.js`, `lib/oauth.js` — so the vulnerable path is unreachable. Note updated to say so.
- `GHSA-2p57-rm9w-gvfp` (`ip` via `node-ssdp`) remains unfixable: no patched `ip` release exists and npm's only "fix" is a downgrade to `node-ssdp@1.0.0`. Recommend leaving it.
- The `fast-uri` override was added by an earlier sweep pinning `^3.1.5`; advisories were later filed against that exact version. Worth assuming other repos carrying this override are stale too.
- `webviews` needed no changes (already 0).

## Verification

`npm run preversion` (build + lint + check-webviews + 1304 tests + audit) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
