### PR TITLE
Update roku-deploy to 4.0.0-alpha.6

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -36,7 +36,7 @@
                 "pretty-bytes": "^5.6.0",
                 "resolve": "^1.22.8",
                 "roku-debug": "^0.24.1",
-                "roku-deploy": "^4.0.0-alpha.5",
+                "roku-deploy": "^4.0.0-alpha.6",
                 "roku-test-automation": "^3.0.0-alpha.1",
                 "semver": "^7.1.3",
                 "source-map": "^0.7.3",
@@ -1348,9 +1348,10 @@
             "license": "MIT"
         },
         "node_modules/@rokucommunity/logger": {
-            "version": "0.4.1",
-            "resolved": "https://registry.npmjs.org/@rokucommunity/logger/-/logger-0.4.1.tgz",
-            "integrity": "sha512-uONayZFyryEWTAm2BIs9sKZnVmA4DN/7/cV5s+ahNlhR7vUF4WKjfRANzxYVPLHgEoXqjjGS06g29zkMkWRB+g==",
+            "version": "0.4.2",
+            "resolved": "https://registry.npmjs.org/@rokucommunity/logger/-/logger-0.4.2.tgz",
+            "integrity": "sha512-LGhzyZ10XAqgNezPYk7O7oXuU2/hO2FqjYdapMgk6axVxjvvq4i/mVZosSNa5POCBZOZNnGUt+PRIcGK6BicXg==",
+            "license": "MIT",
             "dependencies": {
                 "chalk": "^4.1.2"
             }
@@ -10433,12 +10434,12 @@
             }
         },
         "node_modules/roku-deploy": {
-            "version": "4.0.0-alpha.5",
-            "resolved": "https://registry.npmjs.org/roku-deploy/-/roku-deploy-4.0.0-alpha.5.tgz",
-            "integrity": "sha512-JKyNGpGJbLGkbXmIDUotTuLJGXRhiWMEg/ZB9CDDsSlBSUSw8Kt9Y6F3wL+TxxromNF+A4scTV3UbiIOJfru6w==",
+            "version": "4.0.0-alpha.6",
+            "resolved": "https://registry.npmjs.org/roku-deploy/-/roku-deploy-4.0.0-alpha.6.tgz",
+            "integrity": "sha512-BAZpI/X5HBJuTsyshC2bNnqORLXzFe7NVcXpdcmw7NABzfv3wU+8Ozc18KGsmopjwJphuWXs0P00r9bWgOew+Q==",
             "license": "MIT",
             "dependencies": {
-                "@rokucommunity/logger": "^0.4.1",
+                "@rokucommunity/logger": "^0.4.2",
                 "chalk": "^2.4.2",
                 "fast-glob": "^3.2.12",
                 "fs-extra": "^7.0.1",

--- a/package.json
+++ b/package.json
@@ -80,7 +80,7 @@
         "pretty-bytes": "^5.6.0",
         "resolve": "^1.22.8",
         "roku-debug": "^0.24.1",
-        "roku-deploy": "^4.0.0-alpha.5",
+        "roku-deploy": "^4.0.0-alpha.6",
         "roku-test-automation": "^3.0.0-alpha.1",
         "semver": "^7.1.3",
         "source-map": "^0.7.3",

--- a/src/BrightScriptCommands.spec.ts
+++ b/src/BrightScriptCommands.spec.ts
@@ -286,8 +286,8 @@ describe('BrightScriptFileUtils ', () => {
         let spinAsyncStub: sinon.SinonStub;
         let showTimedNotificationStub: sinon.SinonStub;
         let resolveActiveDeviceConfigStub: sinon.SinonStub;
-        let queryAppsStub: sinon.SinonStub;
-        let queryActiveAppStub: sinon.SinonStub;
+        let getAppsStub: sinon.SinonStub;
+        let getActiveAppStub: sinon.SinonStub;
         let launchAppStub: sinon.SinonStub;
         let exitAppStub: sinon.SinonStub;
         let showErrorStub: sinon.SinonStub;
@@ -304,8 +304,8 @@ describe('BrightScriptFileUtils ', () => {
             spinAsyncStub = sinon.stub(utilProto, 'spinAsync').callsFake((_message: string, callback: () => Promise<any>) => callback());
             sleepStub = sinon.stub(utilProto, 'sleep').resolves();
             showTimedNotificationStub = sinon.stub(utilProto, 'showTimedNotification').resolves();
-            queryAppsStub = sinon.stub(rokuDeploy, 'queryApps').resolves(appsWithDev as any);
-            queryActiveAppStub = sinon.stub(rokuDeploy, 'queryActiveApp').resolves(activeAppDev as any);
+            getAppsStub = sinon.stub(rokuDeploy, 'getApps').resolves(appsWithDev as any);
+            getActiveAppStub = sinon.stub(rokuDeploy, 'getActiveApp').resolves(activeAppDev as any);
             launchAppStub = sinon.stub(rokuDeploy, 'launchApp').resolves();
             exitAppStub = sinon.stub(rokuDeploy, 'exitApp').resolves();
             showErrorStub = sinon.stub(vscode.window, 'showErrorMessage').resolves();
@@ -317,8 +317,8 @@ describe('BrightScriptFileUtils ', () => {
             spinAsyncStub.restore();
             sleepStub.restore();
             showTimedNotificationStub.restore();
-            queryAppsStub.restore();
-            queryActiveAppStub.restore();
+            getAppsStub.restore();
+            getActiveAppStub.restore();
             launchAppStub.restore();
             exitAppStub.restore();
             showErrorStub.restore();
@@ -340,7 +340,7 @@ describe('BrightScriptFileUtils ', () => {
         });
 
         it('shows an error and skips launch when no dev channel is sideloaded', async () => {
-            queryAppsStub.resolves([{ id: '12345', title: 'Netflix' }] as any);
+            getAppsStub.resolves([{ id: '12345', title: 'Netflix' }] as any);
 
             await commands.restartDevApplication();
 
@@ -350,7 +350,7 @@ describe('BrightScriptFileUtils ', () => {
         });
 
         it('warns when the dev app is not foregrounded after launch', async () => {
-            queryActiveAppStub.resolves({ id: '12345', title: 'Netflix' } as any);
+            getActiveAppStub.resolves({ id: '12345', title: 'Netflix' } as any);
 
             await commands.restartDevApplication();
 
@@ -365,7 +365,7 @@ describe('BrightScriptFileUtils ', () => {
 
             assert.isTrue(showErrorStub.calledOnce);
             assert.include(showErrorStub.firstCall.args[0], 'device unreachable');
-            assert.isFalse(queryActiveAppStub.called, 'should not verify the active app after a failed launch');
+            assert.isFalse(getActiveAppStub.called, 'should not verify the active app after a failed launch');
         });
 
         it('resolves the active device config and forwards a cloud device to rokuDeploy', async () => {
@@ -374,10 +374,10 @@ describe('BrightScriptFileUtils ', () => {
 
             await commands.restartDevApplication();
 
-            assert.deepEqual(queryAppsStub.firstCall.args[0], { device: cloudDevice });
+            assert.deepEqual(getAppsStub.firstCall.args[0], { device: cloudDevice });
             assert.deepEqual(exitAppStub.firstCall.args[0], { device: cloudDevice, appId: 'dev', force: true });
             assert.deepEqual(launchAppStub.firstCall.args[0], { device: cloudDevice, appId: 'dev' });
-            assert.deepEqual(queryActiveAppStub.firstCall.args[0], { device: cloudDevice });
+            assert.deepEqual(getActiveAppStub.firstCall.args[0], { device: cloudDevice });
         });
 
         it('does nothing when no device can be resolved', async () => {
@@ -385,7 +385,7 @@ describe('BrightScriptFileUtils ', () => {
 
             await commands.restartDevApplication();
 
-            assert.isFalse(queryAppsStub.called);
+            assert.isFalse(getAppsStub.called);
             assert.isFalse(showErrorStub.called);
         });
     });

--- a/src/BrightScriptCommands.ts
+++ b/src/BrightScriptCommands.ts
@@ -399,7 +399,7 @@ export class BrightScriptCommands {
             }
 
             const apps = await util.spinAsync('Fetching app list', async () => {
-                return rokuDeploy.queryApps({ device: deviceConfig });
+                return rokuDeploy.getApps({ device: deviceConfig });
             });
 
             //convert the items to QuickPick items
@@ -751,7 +751,7 @@ export class BrightScriptCommands {
         const deviceLabel = isLocalDeviceConfig(device) ? device.host : 'the active device';
 
         await util.spinAsync('Restarting dev app', async () => {
-            const apps = await rokuDeploy.queryApps({ device: device });
+            const apps = await rokuDeploy.getApps({ device: device });
             const hasDev = apps.some(app => app.id === 'dev');
             if (!hasDev) {
                 await vscode.window.showErrorMessage(`No dev channel sideloaded on ${deviceLabel}. Sideload your project before restarting.`);
@@ -772,7 +772,7 @@ export class BrightScriptCommands {
 
             // give a little bit of time to let the app boot up before checking its status
             await util.sleep(1000);
-            const activeApp = await rokuDeploy.queryActiveApp({ device: device });
+            const activeApp = await rokuDeploy.getActiveApp({ device: device });
             if (activeApp.id === 'dev') {
                 void util.showTimedNotification('Dev app restarted', 2000);
             } else {

--- a/src/LogDocumentLinkProvider.spec.ts
+++ b/src/LogDocumentLinkProvider.spec.ts
@@ -36,7 +36,7 @@ describe('LogDocumentLinkProvider', () => {
 
     describe('setLaunchConfig', () => {
         it('properly generates pkg paths', async () => {
-            sinon.stub(l.rokuDeploy, 'getFilePaths').returns(Promise.resolve([{
+            sinon.stub(l.rokuDeploy, 'resolveFilesArray').returns(Promise.resolve([{
                 src: path.normalize('C:/project/manifest'),
                 dest: path.normalize('C:/project/out/manifest')
             }, {

--- a/src/LogDocumentLinkProvider.ts
+++ b/src/LogDocumentLinkProvider.ts
@@ -42,7 +42,7 @@ export class LogDocumentLinkProvider implements vscode.DocumentLinkProvider {
         let sourceRootDir = launchConfig.sourceDirs ? launchConfig.sourceDirs : [launchConfig.rootDir];
         let paths = [];
         for (const rootDir of sourceRootDir) {
-            let pathsFromRoot = await this.rokuDeploy.getFilePaths({ files: launchConfig.files, rootDir: rootDir });
+            let pathsFromRoot = await this.rokuDeploy.resolveFilesArray({ files: launchConfig.files, rootDir: rootDir });
             paths = paths.concat(pathsFromRoot);
         }
         //get every file used in this project

--- a/src/commands/CaptureScreenshotCommand.spec.ts
+++ b/src/commands/CaptureScreenshotCommand.spec.ts
@@ -40,7 +40,7 @@ describe('CaptureScreenshotCommand', () => {
 
     it('passes the reference through to the resolver and the resolved device to rokuDeploy', async () => {
         const { resolveTarget, resolvePassword } = stubResolution();
-        const stub = sinon.stub(rokuDeploy, 'captureScreenshot').returns(Promise.resolve({ buffer: Buffer.alloc(0), filePath: 'screenshot.png' }));
+        const stub = sinon.stub(rokuDeploy, 'captureScreenshot').returns(Promise.resolve({ buffer: Buffer.alloc(0), filePath: 'screenshot.png', format: 'jpg' }));
 
         await command['captureScreenshot']({ key: 's:SN1' });
 
@@ -52,7 +52,7 @@ describe('CaptureScreenshotCommand', () => {
     it('captures from a cloud emulator device through its device config', async () => {
         const cloudDevice = { instanceUrl: 'https://rce.example.com/instance', rceToken: 'token' };
         stubResolution(cloudDevice, 'Chris (cloud emulator)');
-        const stub = sinon.stub(rokuDeploy, 'captureScreenshot').returns(Promise.resolve({ buffer: Buffer.alloc(0), filePath: 'screenshot.png' }));
+        const stub = sinon.stub(rokuDeploy, 'captureScreenshot').returns(Promise.resolve({ buffer: Buffer.alloc(0), filePath: 'screenshot.png', format: 'jpg' }));
 
         await command['captureScreenshot']({ key: 'rce:83' });
 
@@ -91,7 +91,7 @@ describe('CaptureScreenshotCommand', () => {
 
     it('uses temp dir when screenshotDir is not defined', async () => {
         stubResolution();
-        const stub = sinon.stub(rokuDeploy, 'captureScreenshot').returns(Promise.resolve({ buffer: Buffer.alloc(0), filePath: 'screenshot.png' }));
+        const stub = sinon.stub(rokuDeploy, 'captureScreenshot').returns(Promise.resolve({ buffer: Buffer.alloc(0), filePath: 'screenshot.png', format: 'jpg' }));
 
         await command['captureScreenshot']();
 
@@ -100,7 +100,7 @@ describe('CaptureScreenshotCommand', () => {
 
     it('uses screenshotDir with single workspace', async () => {
         stubResolution();
-        const stub = sinon.stub(rokuDeploy, 'captureScreenshot').returns(Promise.resolve({ buffer: Buffer.alloc(0), filePath: 'screenshot.png' }));
+        const stub = sinon.stub(rokuDeploy, 'captureScreenshot').returns(Promise.resolve({ buffer: Buffer.alloc(0), filePath: 'screenshot.png', format: 'jpg' }));
         workspace._configuration = {
             'brightscript.screenshotDir': '${workspaceFolder}/screenshots'
         };
@@ -119,7 +119,7 @@ describe('CaptureScreenshotCommand', () => {
 
     it('uses relative screenshotDir with single workspace', async () => {
         stubResolution();
-        const stub = sinon.stub(rokuDeploy, 'captureScreenshot').returns(Promise.resolve({ buffer: Buffer.alloc(0), filePath: 'screenshot.png' }));
+        const stub = sinon.stub(rokuDeploy, 'captureScreenshot').returns(Promise.resolve({ buffer: Buffer.alloc(0), filePath: 'screenshot.png', format: 'jpg' }));
         workspace._configuration = {
             'brightscript.screenshotDir': 'screenshots'
         };
@@ -138,7 +138,7 @@ describe('CaptureScreenshotCommand', () => {
 
     it('uses screenshotDir with multiple workspace', async () => {
         stubResolution();
-        const stub = sinon.stub(rokuDeploy, 'captureScreenshot').returns(Promise.resolve({ buffer: Buffer.alloc(0), filePath: 'screenshot.png' }));
+        const stub = sinon.stub(rokuDeploy, 'captureScreenshot').returns(Promise.resolve({ buffer: Buffer.alloc(0), filePath: 'screenshot.png', format: 'jpg' }));
         const workspaceFolders = [
             {
                 uri: URI.file(s`${cwd}/workspace1`),
@@ -164,7 +164,7 @@ describe('CaptureScreenshotCommand', () => {
 
     it('uses relative screenshotDir with multiple workspace', async () => {
         stubResolution();
-        const stub = sinon.stub(rokuDeploy, 'captureScreenshot').returns(Promise.resolve({ buffer: Buffer.alloc(0), filePath: 'screenshot.png' }));
+        const stub = sinon.stub(rokuDeploy, 'captureScreenshot').returns(Promise.resolve({ buffer: Buffer.alloc(0), filePath: 'screenshot.png', format: 'jpg' }));
         const workspaceFolders = [
             {
                 uri: URI.file(s`${cwd}/workspace1`),

--- a/src/deviceDiscovery/DeviceManager.spec.ts
+++ b/src/deviceDiscovery/DeviceManager.spec.ts
@@ -1328,25 +1328,23 @@ describe('DeviceManager', () => {
         });
     });
 
-    /* eslint-disable camelcase -- the RCE management api uses snake_case fields */
     describe('cloud emulator devices', () => {
         function rceDevice(overrides: Record<string, any> = {}) {
             return {
                 id: 83,
                 name: 'Chris',
-                device_type: 'tv',
-                serial_number: 'XY020078HH5S',
+                deviceType: 'tv',
+                serialNumber: 'XY020078HH5S',
                 status: 'running',
-                created_at: '2026-01-01',
-                running_device: {
-                    instance_api_url: 'https://device.rce.roku.com/instance/abc',
-                    firmware_version_id: 'rce-fw:15.2.4-tv_prod',
-                    instance_uuid: 'uuid-1',
-                    created_at: '2026-01-01',
-                    snapshot_id: 1,
+                createdAt: '2026-01-01',
+                runningDevice: {
+                    instanceApiUrl: 'https://device.rce.roku.com/instance/abc',
+                    firmwareVersionId: 'rce-fw:15.2.4-tv_prod',
+                    instanceUuid: 'uuid-1',
+                    createdAt: '2026-01-01',
+                    snapshotId: 1,
                     id: 1,
-                    device_id: 83,
-                    max_runtime: 3600
+                    maxRuntime: 3600
                 },
                 ...overrides
             };
@@ -1373,7 +1371,7 @@ describe('DeviceManager', () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
             manager['onRceDevices']([
                 rceDevice(),
-                rceDevice({ id: 86, serial_number: 'ESN86', device_type: 'stb', running_device: null })
+                rceDevice({ id: 86, serialNumber: 'ESN86', deviceType: 'stb', runningDevice: null })
             ] as any);
 
             const tvDevice = manager.getAllDevices().find(x => x.key === 's:XY020078HH5S');
@@ -1388,8 +1386,8 @@ describe('DeviceManager', () => {
         it('maps shutdown and pending statuses, and keys by id when the esn is missing', () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
             manager['onRceDevices']([
-                rceDevice({ id: 84, serial_number: null, status: 'shutdown', running_device: null }),
-                rceDevice({ id: 85, serial_number: 'ESN85', status: 'pending', running_device: null })
+                rceDevice({ id: 84, serialNumber: null, status: 'shutdown', runningDevice: null }),
+                rceDevice({ id: 85, serialNumber: 'ESN85', status: 'pending', runningDevice: null })
             ] as any);
 
             const devices = manager.getAllDevices().filter(x => x.rce);
@@ -1419,7 +1417,7 @@ describe('DeviceManager', () => {
             expect(manager.getDevice('s:XY020078HH5S')?.rce?.id).to.equal(83);
             expect(manager.getDevice({ serialNumber: 'XY020078HH5S' })?.rce?.id).to.equal(83);
 
-            manager['onRceDevices']([rceDevice({ serial_number: null })] as any);
+            manager['onRceDevices']([rceDevice({ serialNumber: null })] as any);
             expect(manager.getDevice('rce:83')?.rce?.id).to.equal(83);
         });
 
@@ -1450,7 +1448,7 @@ describe('DeviceManager', () => {
             manager = new DeviceManager(vscode.context, mockGlobalStateManager, undefined, fakeFinder);
 
             //a just-booted device that has not reported an esn yet (keyed rce:83)
-            manager['onRceDevices']([rceDevice({ serial_number: null })] as any);
+            manager['onRceDevices']([rceDevice({ serialNumber: null })] as any);
             const device = manager.getAllDevices().find(x => x.rce);
             expect(device.key).to.equal('rce:83');
 
@@ -1458,7 +1456,7 @@ describe('DeviceManager', () => {
             expect(fakeFinder.scan.called).to.be.true;
 
             //the same check reports unhealthy once the rescan shows the device stopped
-            manager['onRceDevices']([rceDevice({ serial_number: null, status: 'shutdown', running_device: null })] as any);
+            manager['onRceDevices']([rceDevice({ serialNumber: null, status: 'shutdown', runningDevice: null })] as any);
             expect(await manager.healthCheckDevice(device)).to.be.false;
         });
 
@@ -1575,8 +1573,8 @@ describe('DeviceManager', () => {
             const getDeviceInfoStub = sinon.stub(rokuDeploy, 'getDeviceInfo').resolves({} as any);
             manager = new DeviceManager(vscode.context, mockGlobalStateManager);
             manager['onRceDevices']([
-                rceDevice({ status: 'shutdown', running_device: null }),
-                rceDevice({ id: 99, serial_number: null })
+                rceDevice({ status: 'shutdown', runningDevice: null }),
+                rceDevice({ id: 99, serialNumber: null })
             ] as any);
 
             await manager['resolveRceDevices']();
@@ -1606,7 +1604,7 @@ describe('DeviceManager', () => {
             fakeFinder.getCachedToken = () => 'secret';
             manager = new DeviceManager(vscode.context, mockGlobalStateManager, undefined, fakeFinder);
 
-            manager['onRceDevices']([rceDevice({ id: 84, status: 'shutdown', running_device: null })] as any);
+            manager['onRceDevices']([rceDevice({ id: 84, status: 'shutdown', runningDevice: null })] as any);
 
             const device = manager.getAllDevices().find(x => x.rce);
             expect(device.device).to.eql({ id: 84, rceToken: 'secret' });
@@ -1643,7 +1641,7 @@ describe('DeviceManager', () => {
                 const testManager = new DeviceManager(vscode.context, mockGlobalStateManager, undefined, fakeFinder);
                 testManager['onRceDevices']([
                     rceDevice(),
-                    rceDevice({ id: 84, serial_number: 'ESN84', status: 'shutdown', running_device: null })
+                    rceDevice({ id: 84, serialNumber: 'ESN84', status: 'shutdown', runningDevice: null })
                 ] as any);
                 return testManager;
             }
@@ -1689,7 +1687,6 @@ describe('DeviceManager', () => {
             });
         });
     });
-    /* eslint-enable camelcase */
 
     describe('getDevice', () => {
         it('returns full device with deviceInfo when found', () => {

--- a/src/deviceDiscovery/DeviceManager.ts
+++ b/src/deviceDiscovery/DeviceManager.ts
@@ -52,7 +52,7 @@ export class DeviceManager {
         //so the cached token is expected to be set here
         const rceToken = this.rceFinder?.getCachedToken();
         this.rceDevices = devices.map(device => {
-            const instanceUrl = device.running_device?.instance_api_url ?? undefined;
+            const instanceUrl = device.runningDevice?.instanceApiUrl ?? undefined;
             //same preference order as RceFinder.getDeviceConfig: a live instance url first, then the
             //management-api device id
             const deviceConfig: RceDeviceConfig = instanceUrl
@@ -61,11 +61,11 @@ export class DeviceManager {
             return {
                 id: device.id,
                 name: device.name,
-                esn: device.serial_number ?? undefined,
+                esn: device.serialNumber ?? undefined,
                 status: device.status ?? 'shutdown',
                 instanceUrl: instanceUrl,
-                deviceType: device.device_type,
-                firmwareVersion: device.running_device?.firmware_version_id ?? device.firmware_version_id ?? undefined,
+                deviceType: device.deviceType,
+                firmwareVersion: device.runningDevice?.firmwareVersionId ?? device.firmwareVersionId ?? undefined,
                 device: deviceConfig
             };
         });

--- a/src/managers/RceManager.spec.ts
+++ b/src/managers/RceManager.spec.ts
@@ -239,9 +239,7 @@ describe('RceManager', () => {
 
         it('throws the typed not-running error, carrying the device status, when the device is not running', async () => {
             await manager.addAccount('work', 'token-work');
-            /* eslint-disable camelcase -- the RCE management api uses snake_case fields */
             manager.devices = [{ id: 5, name: 'my-device', status: 'shutdown' }];
-            /* eslint-enable camelcase */
 
             let caughtError: Error;
             try {
@@ -269,10 +267,9 @@ describe('RceManager', () => {
             expect((caughtError as RceDeviceNotRunningError).deviceStatus).to.equal('pending');
         });
 
-        it('throws when a running device has no janus_websocket_url or no janus_id', async () => {
+        it('throws when a running device has no janusWebsocketUrl or no janusId', async () => {
             await manager.addAccount('work', 'token-work');
-            /* eslint-disable camelcase -- the RCE management api uses snake_case fields */
-            manager.devices = [{ id: 5, name: 'my-device', status: 'running', running_device: {} }];
+            manager.devices = [{ id: 5, name: 'my-device', status: 'running', runningDevice: {} }];
 
             let caughtError: Error;
             try {
@@ -282,8 +279,7 @@ describe('RceManager', () => {
             }
             expect(caughtError.message).to.contain('must be running');
 
-            manager.devices = [{ id: 5, name: 'my-device', status: 'running', running_device: { janus_websocket_url: 'wss://x/janus', janus_id: null } }];
-            /* eslint-enable camelcase */
+            manager.devices = [{ id: 5, name: 'my-device', status: 'running', runningDevice: { janusWebsocketUrl: 'wss://x/janus', janusId: null } }];
             caughtError = undefined;
             try {
                 await manager.resolveStreamRequest(5);
@@ -293,23 +289,21 @@ describe('RceManager', () => {
             expect(caughtError.message).to.contain('must be running');
         });
 
-        it('resolves the full stream config for a running device, treating a janus_id of 0 as valid', async () => {
+        it('resolves the full stream config for a running device, treating a janusId of 0 as valid', async () => {
             await manager.addAccount('work', 'token-work');
-            /* eslint-disable camelcase -- the RCE management api uses snake_case fields */
             manager.devices = [{
                 id: 5,
                 name: 'my-device',
-                device_type: 'tv',
+                deviceType: 'tv',
                 status: 'running',
-                running_device: {
-                    janus_websocket_url: 'wss://device.rce.roku.com/instance/abc/janus',
-                    janus_id: 0,
-                    janus_pin: '1234',
-                    janus_token: 'janus-secret',
-                    janus_ice_servers: [{ urls: ['stun:stun.example.com'] }]
+                runningDevice: {
+                    janusWebsocketUrl: 'wss://device.rce.roku.com/instance/abc/janus',
+                    janusId: 0,
+                    janusPin: '1234',
+                    janusToken: 'janus-secret',
+                    janusIceServers: [{ urls: ['stun:stun.example.com'] }]
                 }
             }];
-            /* eslint-enable camelcase */
 
             const streamRequest = await manager.resolveStreamRequest(5);
             expect(streamRequest).to.eql({

--- a/src/managers/RceManager.ts
+++ b/src/managers/RceManager.ts
@@ -248,25 +248,23 @@ export class RceManager {
         if (device.status !== 'running') {
             throw new RceDeviceNotRunningError(`Device '${device.name}' is not running`, device.status);
         }
-        const runningDevice = device.running_device;
-        //janus_id can legitimately be 0 (a valid stream id), so its presence must be checked
+        const runningDevice = device.runningDevice;
+        //janusId can legitimately be 0 (a valid stream id), so its presence must be checked
         //with a nullish check rather than a truthiness check
-        if (!runningDevice?.janus_websocket_url || runningDevice?.janus_id === undefined || runningDevice?.janus_id === null) {
+        if (!runningDevice?.janusWebsocketUrl || runningDevice?.janusId === undefined || runningDevice?.janusId === null) {
             throw new RceDeviceNotRunningError(`Device '${device.name}' must be running and expose a video stream to watch it`, device.status);
         }
 
-        /* eslint-disable camelcase -- the RCE management api uses snake_case fields */
         return {
             deviceId: device.id,
             deviceName: device.name,
-            deviceType: device.device_type,
-            websocketUrl: runningDevice.janus_websocket_url,
-            streamId: runningDevice.janus_id,
-            pin: runningDevice.janus_pin ?? undefined,
-            janusToken: runningDevice.janus_token ?? undefined,
-            iceServers: runningDevice.janus_ice_servers ?? []
+            deviceType: device.deviceType,
+            websocketUrl: runningDevice.janusWebsocketUrl,
+            streamId: runningDevice.janusId,
+            pin: runningDevice.janusPin ?? undefined,
+            janusToken: runningDevice.janusToken ?? undefined,
+            iceServers: runningDevice.janusIceServers ?? []
         };
-        /* eslint-enable camelcase */
     }
 
     /**

--- a/src/viewProviders/RceManagementViewContract.ts
+++ b/src/viewProviders/RceManagementViewContract.ts
@@ -5,7 +5,6 @@ import type { DeviceStatus, DeviceType } from 'roku-deploy';
  * RceStateDevice without pulling the provider's extension-side import graph into its typecheck program.
  */
 
-/* eslint-disable camelcase -- the RCE management api uses snake_case fields */
 /**
  * The device fields the management webview renders - a projection of roku-deploy's RceDevice that
  * leaves the instance's stream credentials behind (see projectDeviceForWebview).
@@ -14,17 +13,16 @@ export interface RceStateDevice {
     id: number;
     name: string;
     note?: string | null;
-    device_type: DeviceType;
+    deviceType: DeviceType;
     status?: DeviceStatus;
-    serial_number?: string | null;
-    created_at: string;
-    last_snapshot_id?: number | null;
-    last_snapshot_name?: string | null;
+    serialNumber?: string | null;
+    createdAt: string;
+    lastSnapshotId?: number | null;
+    lastSnapshotName?: string | null;
     snapshots?: number[];
-    firmware_version_id?: string | null;
-    running_device?: {
-        started_at?: string | null;
-        max_runtime: number;
+    firmwareVersionId?: string | null;
+    runningDevice?: {
+        startedAt?: string | null;
+        maxRuntime: number;
     } | null;
 }
-/* eslint-enable camelcase */

--- a/src/viewProviders/RceManagementViewProvider.spec.ts
+++ b/src/viewProviders/RceManagementViewProvider.spec.ts
@@ -32,9 +32,7 @@ afterEach(() => {
 
 function createFakeManagementClient() {
     return {
-        /* eslint-disable camelcase -- the RCE management api uses snake_case fields */
-        getUserInfo: sinon.stub().resolves({ organisation: { max_project_runtime: 172800 } }),
-        /* eslint-enable camelcase */
+        getUserInfo: sinon.stub().resolves({ organisation: { maxProjectRuntime: 172800 } }),
         listDevices: sinon.stub(),
         createDevice: sinon.stub(),
         startDevice: sinon.stub(),
@@ -130,25 +128,23 @@ describe('RceManagementViewProvider', () => {
         it('projects devices to the fields the webview renders, leaving the stream credentials behind', async () => {
             rceManager = new TestRceManager(vscode.context as any);
             await rceManager.addAccount('work', 'token-work');
-            /* eslint-disable camelcase -- the RCE management api uses snake_case fields */
             rceManager.fakeManagementClient.listDevices.resolves([{
                 id: 5,
                 name: 'my-device',
-                device_type: 'tv',
+                deviceType: 'tv',
                 status: 'running',
-                created_at: '2026-01-01',
-                firmware_version_id: 'rce-fw:1',
-                running_device: {
-                    started_at: '2026-01-02',
-                    max_runtime: 3600,
-                    janus_token: 'janus-secret',
-                    janus_pin: '1234',
-                    janus_websocket_url: 'wss://device.rce.roku.com/instance/abc/janus',
-                    janus_ice_servers: [{ urls: ['turn:ice.rce.roku.com'], username: 'turn-user', credential: 'turn-secret' }],
-                    instance_api_url: 'https://device.rce.roku.com/instance/abc'
+                createdAt: '2026-01-01',
+                firmwareVersionId: 'rce-fw:1',
+                runningDevice: {
+                    startedAt: '2026-01-02',
+                    maxRuntime: 3600,
+                    janusToken: 'janus-secret',
+                    janusPin: '1234',
+                    janusWebsocketUrl: 'wss://device.rce.roku.com/instance/abc/janus',
+                    janusIceServers: [{ urls: ['turn:ice.rce.roku.com'], username: 'turn-user', credential: 'turn-secret' }],
+                    instanceApiUrl: 'https://device.rce.roku.com/instance/abc'
                 }
             }]);
-            /* eslint-enable camelcase */
 
             createProvider();
 
@@ -157,10 +153,8 @@ describe('RceManagementViewProvider', () => {
 
             const responseMessage = findResponseMessage(ViewProviderCommand.getRceState);
             const device = responseMessage.response.devices[0];
-            /* eslint-disable camelcase -- the RCE management api uses snake_case fields */
-            expect(device).to.include({ id: 5, name: 'my-device', status: 'running', firmware_version_id: 'rce-fw:1' });
-            expect(device.running_device).to.eql({ started_at: '2026-01-02', max_runtime: 3600 });
-            /* eslint-enable camelcase */
+            expect(device).to.include({ id: 5, name: 'my-device', status: 'running', firmwareVersionId: 'rce-fw:1' });
+            expect(device.runningDevice).to.eql({ startedAt: '2026-01-02', maxRuntime: 3600 });
             for (const secret of ['janus-secret', '1234', 'turn-user', 'turn-secret', 'instance/abc']) {
                 expect(JSON.stringify(responseMessage)).not.to.contain(secret);
             }
@@ -200,11 +194,9 @@ describe('RceManagementViewProvider', () => {
             rceManager = new TestRceManager(vscode.context as any);
             await rceManager.addAccount('work', 'token-work');
             rceManager.fakeManagementClient.listDevices.resolves([]);
-            /* eslint-disable camelcase -- the RCE management api uses snake_case fields */
             rceManager.fakeManagementClient.listFirmwareVersions.resolves([
-                { firmware_version_id: 'rce-fw:1', device_type: 'tv', display_name: '15.2.4 TV' }
+                { firmwareVersionId: 'rce-fw:1', deviceType: 'tv', displayName: '15.2.4 TV' }
             ]);
-            /* eslint-enable camelcase */
 
             createProvider();
 
@@ -213,11 +205,9 @@ describe('RceManagementViewProvider', () => {
             await provider['messageCommandCallbacks'][ViewProviderCommand.getRceState](message);
 
             const responseMessage = findResponseMessage(ViewProviderCommand.getRceState);
-            /* eslint-disable camelcase -- the RCE management api uses snake_case fields */
             expect(responseMessage.response.firmwareVersions).to.eql([
-                { firmware_version_id: 'rce-fw:1', device_type: 'tv', display_name: '15.2.4 TV' }
+                { firmwareVersionId: 'rce-fw:1', deviceType: 'tv', displayName: '15.2.4 TV' }
             ]);
-            /* eslint-enable camelcase */
             expect(rceManager.fakeManagementClient.listFirmwareVersions.callCount).to.equal(1);
         });
 
@@ -242,11 +232,9 @@ describe('RceManagementViewProvider', () => {
             await rceManager.addAccount('work', 'token-work');
             await rceManager.addAccount('personal', 'token-personal');
             rceManager.fakeManagementClient.listDevices.resolves([]);
-            /* eslint-disable camelcase -- the RCE management api uses snake_case fields */
             rceManager.fakeManagementClient.listFirmwareVersions.resolves([
-                { firmware_version_id: 'rce-fw:1', device_type: 'tv', display_name: '15.2.4 TV' }
+                { firmwareVersionId: 'rce-fw:1', deviceType: 'tv', displayName: '15.2.4 TV' }
             ]);
-            /* eslint-enable camelcase */
 
             createProvider();
 
@@ -284,19 +272,17 @@ describe('RceManagementViewProvider', () => {
         it('responds with an error when no snapshotId is sent, without resolving a fallback snapshot itself', async () => {
             rceManager = new TestRceManager(vscode.context as any);
             await rceManager.addAccount('work', 'token-work');
-            //a remembered pick, a live snapshot, and last_snapshot_id all exist, but the picker
+            //a remembered pick, a live snapshot, and lastSnapshotId all exist, but the picker
             //is the single source of truth, so none of them get resolved here
             await vscode.context.workspaceState.update(WorkspaceStateKey.rceLastSnapshotByDevice, { 5: 20 });
-            /* eslint-disable camelcase -- the RCE management api uses snake_case fields */
             rceManager.fakeManagementClient.listDevices.resolves([
-                { id: 5, name: 'my-device', device_type: 'tv', last_snapshot_id: 10, snapshots: [10, 20, 30], firmware_version_id: 'rce-fw:1' }
+                { id: 5, name: 'my-device', deviceType: 'tv', lastSnapshotId: 10, snapshots: [10, 20, 30], firmwareVersionId: 'rce-fw:1' }
             ]);
             rceManager.fakeManagementClient.listSnapshots.resolves([
-                { id: 10, created_at: '2026-01-01', firmware_version_id: 'rce-fw:1', live: false },
-                { id: 20, created_at: '2026-01-02', firmware_version_id: 'rce-fw:2', live: false },
-                { id: 30, created_at: '2026-01-03', firmware_version_id: 'rce-fw:3', live: true }
+                { id: 10, createdAt: '2026-01-01', firmwareVersionId: 'rce-fw:1', live: false },
+                { id: 20, createdAt: '2026-01-02', firmwareVersionId: 'rce-fw:2', live: false },
+                { id: 30, createdAt: '2026-01-03', firmwareVersionId: 'rce-fw:3', live: true }
             ]);
-            /* eslint-enable camelcase */
 
             createProvider();
 
@@ -311,15 +297,13 @@ describe('RceManagementViewProvider', () => {
         it('starts the device with the picker-sent snapshotId and remembers it as the device\'s last-used pick', async () => {
             rceManager = new TestRceManager(vscode.context as any);
             await rceManager.addAccount('work', 'token-work');
-            /* eslint-disable camelcase -- the RCE management api uses snake_case fields */
             rceManager.fakeManagementClient.listDevices.resolves([
-                { id: 5, name: 'my-device', device_type: 'tv', last_snapshot_id: 10, snapshots: [10, 20], firmware_version_id: 'rce-fw:1' }
+                { id: 5, name: 'my-device', deviceType: 'tv', lastSnapshotId: 10, snapshots: [10, 20], firmwareVersionId: 'rce-fw:1' }
             ]);
             rceManager.fakeManagementClient.listSnapshots.resolves([
-                { id: 10, created_at: '2026-01-01', firmware_version_id: 'rce-fw:1' },
-                { id: 20, created_at: '2026-01-02', firmware_version_id: 'rce-fw:2' }
+                { id: 10, createdAt: '2026-01-01', firmwareVersionId: 'rce-fw:1' },
+                { id: 20, createdAt: '2026-01-02', firmwareVersionId: 'rce-fw:2' }
             ]);
-            /* eslint-enable camelcase */
             rceManager.fakeManagementClient.startDevice.resolves({ id: 5 });
 
             createProvider();
@@ -329,8 +313,8 @@ describe('RceManagementViewProvider', () => {
 
             const startDeviceArgs = rceManager.fakeManagementClient.startDevice.getCall(0).args;
             expect(startDeviceArgs[0].deviceId).to.equal(5);
-            expect(startDeviceArgs[0].start.snapshot_id).to.equal(20);
-            expect(startDeviceArgs[0].start.firmware_version_id).to.equal('rce-fw:2');
+            expect(startDeviceArgs[0].start.snapshotId).to.equal(20);
+            expect(startDeviceArgs[0].start.firmwareVersionId).to.equal('rce-fw:2');
 
             const remembered = vscode.context.workspaceState.get(WorkspaceStateKey.rceLastSnapshotByDevice);
             expect(remembered[5]).to.equal(20);
@@ -339,11 +323,9 @@ describe('RceManagementViewProvider', () => {
         it('starts the device with the picker-sent firmware version without resolving one itself', async () => {
             rceManager = new TestRceManager(vscode.context as any);
             await rceManager.addAccount('work', 'token-work');
-            /* eslint-disable camelcase -- the RCE management api uses snake_case fields */
             rceManager.fakeManagementClient.listDevices.resolves([
-                { id: 5, name: 'my-device', device_type: 'tv', last_snapshot_id: 10, snapshots: [10], firmware_version_id: 'rce-fw:1' }
+                { id: 5, name: 'my-device', deviceType: 'tv', lastSnapshotId: 10, snapshots: [10], firmwareVersionId: 'rce-fw:1' }
             ]);
-            /* eslint-enable camelcase */
             rceManager.fakeManagementClient.startDevice.resolves({ id: 5 });
 
             createProvider();
@@ -352,7 +334,7 @@ describe('RceManagementViewProvider', () => {
             await provider['messageCommandCallbacks'][ViewProviderCommand.startRceDevice](message);
 
             const startDeviceArgs = rceManager.fakeManagementClient.startDevice.getCall(0).args;
-            expect(startDeviceArgs[0].start.firmware_version_id).to.equal('rce-fw:9');
+            expect(startDeviceArgs[0].start.firmwareVersionId).to.equal('rce-fw:9');
             //the fallback resolution never runs when the picker sent a firmware (it always consults
             //the snapshot list first)
             expect(rceManager.fakeManagementClient.listSnapshots.called).to.be.false;
@@ -361,14 +343,12 @@ describe('RceManagementViewProvider', () => {
         it('passes the webview-selected max runtime through to startDevice', async () => {
             rceManager = new TestRceManager(vscode.context as any);
             await rceManager.addAccount('work', 'token-work');
-            /* eslint-disable camelcase -- the RCE management api uses snake_case fields */
             rceManager.fakeManagementClient.listDevices.resolves([
-                { id: 5, name: 'my-device', device_type: 'tv', last_snapshot_id: 10, snapshots: [10], firmware_version_id: 'rce-fw:1' }
+                { id: 5, name: 'my-device', deviceType: 'tv', lastSnapshotId: 10, snapshots: [10], firmwareVersionId: 'rce-fw:1' }
             ]);
             rceManager.fakeManagementClient.listSnapshots.resolves([
-                { id: 10, created_at: '2026-01-01', firmware_version_id: 'rce-fw:1' }
+                { id: 10, createdAt: '2026-01-01', firmwareVersionId: 'rce-fw:1' }
             ]);
-            /* eslint-enable camelcase */
             rceManager.fakeManagementClient.startDevice.resolves({ id: 5 });
 
             createProvider();
@@ -377,20 +357,18 @@ describe('RceManagementViewProvider', () => {
             await provider['messageCommandCallbacks'][ViewProviderCommand.startRceDevice](message);
 
             const startDeviceArgs = rceManager.fakeManagementClient.startDevice.getCall(0).args;
-            expect(startDeviceArgs[0].start.max_runtime).to.equal(8 * 3600);
+            expect(startDeviceArgs[0].start.maxRuntime).to.equal(8 * 3600);
         });
 
         it('defaults max runtime to one hour when the message does not carry one', async () => {
             rceManager = new TestRceManager(vscode.context as any);
             await rceManager.addAccount('work', 'token-work');
-            /* eslint-disable camelcase -- the RCE management api uses snake_case fields */
             rceManager.fakeManagementClient.listDevices.resolves([
-                { id: 5, name: 'my-device', device_type: 'tv', last_snapshot_id: 10, snapshots: [10], firmware_version_id: 'rce-fw:1' }
+                { id: 5, name: 'my-device', deviceType: 'tv', lastSnapshotId: 10, snapshots: [10], firmwareVersionId: 'rce-fw:1' }
             ]);
             rceManager.fakeManagementClient.listSnapshots.resolves([
-                { id: 10, created_at: '2026-01-01', firmware_version_id: 'rce-fw:1' }
+                { id: 10, createdAt: '2026-01-01', firmwareVersionId: 'rce-fw:1' }
             ]);
-            /* eslint-enable camelcase */
             rceManager.fakeManagementClient.startDevice.resolves({ id: 5 });
 
             createProvider();
@@ -399,7 +377,7 @@ describe('RceManagementViewProvider', () => {
             await provider['messageCommandCallbacks'][ViewProviderCommand.startRceDevice](message);
 
             const startDeviceArgs = rceManager.fakeManagementClient.startDevice.getCall(0).args;
-            expect(startDeviceArgs[0].start.max_runtime).to.equal(3600);
+            expect(startDeviceArgs[0].start.maxRuntime).to.equal(3600);
         });
     });
 
@@ -408,10 +386,8 @@ describe('RceManagementViewProvider', () => {
             rceManager = new TestRceManager(vscode.context as any);
             await rceManager.addAccount('work', 'token-work');
             await vscode.context.workspaceState.update(WorkspaceStateKey.rceLastSnapshotByDevice, { 5: 20 });
-            /* eslint-disable camelcase -- the RCE management api uses snake_case fields */
-            rceManager.fakeManagementClient.listSnapshots.resolves([{ id: 20, created_at: '2026-01-01' }]);
-            rceManager.fakeManagementClient.getDeviceRuns.resolves([{ id: 1, instance_id: 1, status: 'completed' }]);
-            /* eslint-enable camelcase */
+            rceManager.fakeManagementClient.listSnapshots.resolves([{ id: 20, createdAt: '2026-01-01' }]);
+            rceManager.fakeManagementClient.getDeviceRuns.resolves([{ id: 1, instanceId: 1, status: 'completed' }]);
 
             createProvider();
 
@@ -447,11 +423,9 @@ describe('RceManagementViewProvider', () => {
         it('does not call deleteSnapshot when the confirmation modal is cancelled', async () => {
             rceManager = new TestRceManager(vscode.context as any);
             await rceManager.addAccount('work', 'token-work');
-            /* eslint-disable camelcase -- the RCE management api uses snake_case fields */
             rceManager.fakeManagementClient.listSnapshots.resolves([
-                { id: 20, name: 'my-snapshot', created_at: '2026-01-01', live: false, base: false }
+                { id: 20, name: 'my-snapshot', createdAt: '2026-01-01', live: false, base: false }
             ]);
-            /* eslint-enable camelcase */
             sinon.stub(vscode.window, 'showWarningMessage').resolves(undefined);
 
             createProvider();
@@ -467,11 +441,9 @@ describe('RceManagementViewProvider', () => {
         it('calls deleteSnapshot when the deletion is confirmed', async () => {
             rceManager = new TestRceManager(vscode.context as any);
             await rceManager.addAccount('work', 'token-work');
-            /* eslint-disable camelcase -- the RCE management api uses snake_case fields */
             rceManager.fakeManagementClient.listSnapshots.resolves([
-                { id: 20, name: 'my-snapshot', created_at: '2026-01-01', live: false, base: false }
+                { id: 20, name: 'my-snapshot', createdAt: '2026-01-01', live: false, base: false }
             ]);
-            /* eslint-enable camelcase */
             sinon.stub(vscode.window, 'showWarningMessage').resolves('Delete');
             rceManager.fakeManagementClient.deleteSnapshot.resolves();
 
@@ -486,11 +458,9 @@ describe('RceManagementViewProvider', () => {
         it('refuses to delete the live snapshot without showing the confirm modal', async () => {
             rceManager = new TestRceManager(vscode.context as any);
             await rceManager.addAccount('work', 'token-work');
-            /* eslint-disable camelcase -- the RCE management api uses snake_case fields */
             rceManager.fakeManagementClient.listSnapshots.resolves([
-                { id: 20, name: 'my-snapshot', created_at: '2026-01-01', live: true, base: false }
+                { id: 20, name: 'my-snapshot', createdAt: '2026-01-01', live: true, base: false }
             ]);
-            /* eslint-enable camelcase */
             const showWarningMessage = sinon.stub(vscode.window, 'showWarningMessage').resolves('Delete');
 
             createProvider();
@@ -508,11 +478,9 @@ describe('RceManagementViewProvider', () => {
         it('refuses to delete the base snapshot without showing the confirm modal', async () => {
             rceManager = new TestRceManager(vscode.context as any);
             await rceManager.addAccount('work', 'token-work');
-            /* eslint-disable camelcase -- the RCE management api uses snake_case fields */
             rceManager.fakeManagementClient.listSnapshots.resolves([
-                { id: 20, name: 'my-snapshot', created_at: '2026-01-01', live: false, base: true }
+                { id: 20, name: 'my-snapshot', createdAt: '2026-01-01', live: false, base: true }
             ]);
-            /* eslint-enable camelcase */
             const showWarningMessage = sinon.stub(vscode.window, 'showWarningMessage').resolves('Delete');
 
             createProvider();
@@ -549,11 +517,9 @@ describe('RceManagementViewProvider', () => {
         it('responds with an error and sends nothing when the device is not running', async () => {
             rceManager = new TestRceManager(vscode.context as any);
             await rceManager.addAccount('work', 'token-work');
-            /* eslint-disable camelcase -- the RCE management api uses snake_case fields */
             rceManager.fakeManagementClient.listDevices.resolves([
-                { id: 5, name: 'my-device', device_type: 'tv', status: 'shutdown' }
+                { id: 5, name: 'my-device', deviceType: 'tv', status: 'shutdown' }
             ]);
-            /* eslint-enable camelcase */
             const sendDeveloperSettingsCombo = sinon.stub(rokuDeploy, 'sendDeveloperSettingsCombo').resolves();
 
             createProvider();
@@ -566,14 +532,12 @@ describe('RceManagementViewProvider', () => {
             expect(sendDeveloperSettingsCombo.called).to.be.false;
         });
 
-        it('responds with an error and sends nothing when a running device has no instance_api_url', async () => {
+        it('responds with an error and sends nothing when a running device has no instanceApiUrl', async () => {
             rceManager = new TestRceManager(vscode.context as any);
             await rceManager.addAccount('work', 'token-work');
-            /* eslint-disable camelcase -- the RCE management api uses snake_case fields */
             rceManager.fakeManagementClient.listDevices.resolves([
-                { id: 5, name: 'my-device', device_type: 'tv', status: 'running', running_device: {} }
+                { id: 5, name: 'my-device', deviceType: 'tv', status: 'running', runningDevice: {} }
             ]);
-            /* eslint-enable camelcase */
             const sendDeveloperSettingsCombo = sinon.stub(rokuDeploy, 'sendDeveloperSettingsCombo').resolves();
 
             createProvider();
@@ -589,17 +553,15 @@ describe('RceManagementViewProvider', () => {
         it('sends the developer-settings combo to a running device with an instance api url', async () => {
             rceManager = new TestRceManager(vscode.context as any);
             await rceManager.addAccount('work', 'token-work');
-            /* eslint-disable camelcase -- the RCE management api uses snake_case fields */
             rceManager.fakeManagementClient.listDevices.resolves([
                 {
                     id: 5,
                     name: 'my-device',
-                    device_type: 'tv',
+                    deviceType: 'tv',
                     status: 'running',
-                    running_device: { instance_api_url: 'https://device.rce.roku.com/instance/abc' }
+                    runningDevice: { instanceApiUrl: 'https://device.rce.roku.com/instance/abc' }
                 }
             ]);
-            /* eslint-enable camelcase */
             const sendDeveloperSettingsCombo = sinon.stub(rokuDeploy, 'sendDeveloperSettingsCombo').resolves();
 
             createProvider();
@@ -691,21 +653,19 @@ describe('RceManagementViewProvider', () => {
         it('registers rceWatchDeviceById as an internal command that resolves and shows the same stream config', async () => {
             rceManager = new TestRceManager(vscode.context as any);
             await rceManager.addAccount('work', 'token-work');
-            /* eslint-disable camelcase -- the RCE management api uses snake_case fields */
             rceManager.fakeManagementClient.listDevices.resolves([
                 {
                     id: 5,
                     name: 'my-device',
-                    device_type: 'tv',
+                    deviceType: 'tv',
                     status: 'running',
-                    running_device: {
-                        janus_websocket_url: 'wss://device.rce.roku.com/instance/abc/janus',
-                        janus_id: 7,
-                        janus_ice_servers: []
+                    runningDevice: {
+                        janusWebsocketUrl: 'wss://device.rce.roku.com/instance/abc/janus',
+                        janusId: 7,
+                        janusIceServers: []
                     }
                 }
             ]);
-            /* eslint-enable camelcase */
             const registeredCommands = new Map<string, (...args: any[]) => any>();
             (sinon.stub(vscode.commands, 'registerCommand') as sinon.SinonStub).callsFake((commandId: string, callback: any) => {
                 registeredCommands.set(commandId, callback);
@@ -726,11 +686,9 @@ describe('RceManagementViewProvider', () => {
         it('rejects from rceWatchDeviceById when the device is not running, without posting a response', async () => {
             rceManager = new TestRceManager(vscode.context as any);
             await rceManager.addAccount('work', 'token-work');
-            /* eslint-disable camelcase -- the RCE management api uses snake_case fields */
             rceManager.fakeManagementClient.listDevices.resolves([
-                { id: 5, name: 'my-device', device_type: 'tv', status: 'shutdown' }
+                { id: 5, name: 'my-device', deviceType: 'tv', status: 'shutdown' }
             ]);
-            /* eslint-enable camelcase */
             const registeredCommands = new Map<string, (...args: any[]) => any>();
             (sinon.stub(vscode.commands, 'registerCommand') as sinon.SinonStub).callsFake((commandId: string, callback: any) => {
                 registeredCommands.set(commandId, callback);
@@ -807,11 +765,9 @@ describe('RceManagementViewProvider', () => {
 
             createProvider();
 
-            /* eslint-disable camelcase -- the RCE management api uses snake_case fields */
             const emittedDevices: RceDevice[] = [
-                { id: 5, name: 'my-device', device_type: 'tv', status: 'running', created_at: '2026-01-01' }
+                { id: 5, name: 'my-device', deviceType: 'tv', status: 'running', createdAt: '2026-01-01' }
             ];
-            /* eslint-enable camelcase */
             rceFinder.emit('devices', emittedDevices);
             await flushMicrotasks();
 
@@ -819,9 +775,7 @@ describe('RceManagementViewProvider', () => {
             expect(eventMessages.length).to.be.greaterThan(0);
             const pushedDevices = eventMessages[eventMessages.length - 1].context.devices;
             expect(pushedDevices).to.have.length(1);
-            /* eslint-disable camelcase -- the RCE management api uses snake_case fields */
-            expect(pushedDevices[0]).to.include({ id: 5, name: 'my-device', device_type: 'tv', status: 'running', created_at: '2026-01-01' });
-            /* eslint-enable camelcase */
+            expect(pushedDevices[0]).to.include({ id: 5, name: 'my-device', deviceType: 'tv', status: 'running', createdAt: '2026-01-01' });
             expect(rceManager.fakeManagementClient.listDevices.called).to.be.false;
         });
     });
@@ -832,14 +786,12 @@ describe('RceManagementViewProvider', () => {
             try {
                 rceManager = new TestRceManager(vscode.context as any);
                 await rceManager.addAccount('work', 'token-work');
-                /* eslint-disable camelcase -- the RCE management api uses snake_case fields */
                 rceManager.fakeManagementClient.listDevices.resolves([
-                    { id: 5, name: 'my-device', device_type: 'tv', last_snapshot_id: 10, snapshots: [10], firmware_version_id: 'rce-fw:1' }
+                    { id: 5, name: 'my-device', deviceType: 'tv', lastSnapshotId: 10, snapshots: [10], firmwareVersionId: 'rce-fw:1' }
                 ]);
                 rceManager.fakeManagementClient.listSnapshots.resolves([
-                    { id: 10, created_at: '2026-01-01', firmware_version_id: 'rce-fw:1' }
+                    { id: 10, createdAt: '2026-01-01', firmwareVersionId: 'rce-fw:1' }
                 ]);
-                /* eslint-enable camelcase */
                 rceManager.fakeManagementClient.startDevice.resolves({ id: 5 });
 
                 createProvider();
@@ -871,9 +823,7 @@ describe('RceManagementViewProvider', () => {
 
                 //stopTransitionWatchIfSettled runs synchronously inside handleFinderDevices, so the
                 //watch is already stopped by the time this call returns; no need to await anything
-                /* eslint-disable camelcase -- the RCE management api uses snake_case fields */
-                provider['handleFinderDevices']([{ id: 5, name: 'my-device', device_type: 'tv', status: 'running', created_at: '2026-01-01' }]);
-                /* eslint-enable camelcase */
+                provider['handleFinderDevices']([{ id: 5, name: 'my-device', deviceType: 'tv', status: 'running', createdAt: '2026-01-01' }]);
 
                 clock.tick(RceManagementViewProvider['transitionWatchIntervalMs'] * 2);
                 expect(rceFinder.scan.callCount).to.equal(1);
@@ -892,9 +842,7 @@ describe('RceManagementViewProvider', () => {
                 clock.tick(RceManagementViewProvider['transitionWatchIntervalMs']);
                 expect(rceFinder.scan.callCount).to.equal(1);
 
-                /* eslint-disable camelcase -- the RCE management api uses snake_case fields */
-                provider['handleFinderDevices']([{ id: 5, name: 'my-device', device_type: 'tv', status: 'pending', created_at: '2026-01-01' }]);
-                /* eslint-enable camelcase */
+                provider['handleFinderDevices']([{ id: 5, name: 'my-device', deviceType: 'tv', status: 'pending', createdAt: '2026-01-01' }]);
 
                 clock.tick(RceManagementViewProvider['transitionWatchIntervalMs']);
                 expect(rceFinder.scan.callCount).to.equal(2);
@@ -948,9 +896,7 @@ describe('RceManagementViewProvider', () => {
 
                 postOrQueueMessage.resetHistory();
                 //dispose() already removed the 'devices' listener, so this emit reaches no handler at all
-                /* eslint-disable camelcase -- the RCE management api uses snake_case fields */
-                rceFinder.emit('devices', [{ id: 5, name: 'my-device', device_type: 'tv', status: 'running', created_at: '2026-01-01' }]);
-                /* eslint-enable camelcase */
+                rceFinder.emit('devices', [{ id: 5, name: 'my-device', deviceType: 'tv', status: 'running', createdAt: '2026-01-01' }]);
 
                 expect(postOrQueueMessage.called).to.be.false;
             } finally {

--- a/src/viewProviders/RceManagementViewProvider.ts
+++ b/src/viewProviders/RceManagementViewProvider.ts
@@ -68,15 +68,13 @@ export class RceManagementViewProvider extends BaseWebviewViewProvider {
                     throw new Error('No active Cloud Emulator account is configured');
                 }
                 const { name, deviceType, note } = message.context;
-                /* eslint-disable camelcase -- the RCE management api uses snake_case fields */
                 const createdDevice = await managementClient.createDevice({
                     device: {
                         name: name,
-                        device_type: deviceType,
+                        deviceType: deviceType,
                         note: note
                     }
                 });
-                /* eslint-enable camelcase */
                 this.postOrQueueMessage(this.createResponseMessage(message, { device: createdDevice }));
                 this.startTransitionWatch();
             } catch (error) {
@@ -114,26 +112,24 @@ export class RceManagementViewProvider extends BaseWebviewViewProvider {
                 if (!firmwareVersionId) {
                     const snapshots = await managementClient.listSnapshots({ deviceId: deviceId });
                     const chosenSnapshot = snapshots.find((snapshot) => snapshot.id === snapshotId);
-                    firmwareVersionId = chosenSnapshot?.firmware_version_id ?? device.firmware_version_id;
+                    firmwareVersionId = chosenSnapshot?.firmwareVersionId ?? device.firmwareVersionId;
                     if (!firmwareVersionId) {
                         const firmwareVersions = await managementClient.listFirmwareVersions();
-                        firmwareVersionId = firmwareVersions.find((firmwareVersion) => firmwareVersion.device_type === device.device_type)?.firmware_version_id;
+                        firmwareVersionId = firmwareVersions.find((firmwareVersion) => firmwareVersion.deviceType === device.deviceType)?.firmwareVersionId;
                     }
                 }
                 if (!firmwareVersionId) {
-                    throw new Error(`No firmware version is available for device type '${device.device_type}'`);
+                    throw new Error(`No firmware version is available for device type '${device.deviceType}'`);
                 }
 
-                /* eslint-disable camelcase -- the RCE management api uses snake_case fields */
                 const startedDevice = await managementClient.startDevice({
                     deviceId: deviceId,
                     start: {
-                        snapshot_id: snapshotId,
-                        firmware_version_id: firmwareVersionId,
-                        max_runtime: maxRuntimeSeconds
+                        snapshotId: snapshotId,
+                        firmwareVersionId: firmwareVersionId,
+                        maxRuntime: maxRuntimeSeconds
                     }
                 });
-                /* eslint-enable camelcase */
                 //every start records its snapshot as the device's last-used pick, which the picker
                 //pre-selects next time, ahead of the live snapshot
                 await this.rememberSnapshotId(deviceId, snapshotId);
@@ -312,7 +308,7 @@ export class RceManagementViewProvider extends BaseWebviewViewProvider {
             throw new Error(`Device ${deviceId} was not found`);
         }
 
-        const instanceApiUrl = device.running_device?.instance_api_url;
+        const instanceApiUrl = device.runningDevice?.instanceApiUrl;
         if (device.status !== 'running' || !instanceApiUrl) {
             throw new Error(`Device '${device.name}' must be running to ${actionDescription}`);
         }
@@ -441,28 +437,26 @@ export class RceManagementViewProvider extends BaseWebviewViewProvider {
         return state;
     }
 
-    //the webview gets only the fields it renders; RceDevice's running_device otherwise carries the
+    //the webview gets only the fields it renders; RceDevice's runningDevice otherwise carries the
     //instance's stream credentials
     private projectDeviceForWebview(device: RceDevice): RceStateDevice {
-        /* eslint-disable camelcase -- the RCE management api uses snake_case fields */
         return {
             id: device.id,
             name: device.name,
             note: device.note,
-            device_type: device.device_type,
+            deviceType: device.deviceType,
             status: device.status,
-            serial_number: device.serial_number,
-            created_at: device.created_at,
-            last_snapshot_id: device.last_snapshot_id,
-            last_snapshot_name: device.last_snapshot_name,
+            serialNumber: device.serialNumber,
+            createdAt: device.createdAt,
+            lastSnapshotId: device.lastSnapshotId,
+            lastSnapshotName: device.lastSnapshotName,
             snapshots: device.snapshots,
-            firmware_version_id: device.firmware_version_id,
-            running_device: device.running_device ? {
-                started_at: device.running_device.started_at,
-                max_runtime: device.running_device.max_runtime
-            } : device.running_device
+            firmwareVersionId: device.firmwareVersionId,
+            runningDevice: device.runningDevice ? {
+                startedAt: device.runningDevice.startedAt,
+                maxRuntime: device.runningDevice.maxRuntime
+            } : device.runningDevice
         };
-        /* eslint-enable camelcase */
     }
 
     /**
@@ -476,7 +470,7 @@ export class RceManagementViewProvider extends BaseWebviewViewProvider {
         if (this.cachedMaxProjectRuntimeSeconds === undefined) {
             try {
                 const userInfo = await managementClient.getUserInfo();
-                this.cachedMaxProjectRuntimeSeconds = userInfo.organisation?.max_project_runtime;
+                this.cachedMaxProjectRuntimeSeconds = userInfo.organisation?.maxProjectRuntime;
             } catch {
                 //the cap is presentation-only (the api enforces it server-side), so a failed fetch
                 //should never block the rest of the state payload
@@ -538,7 +532,7 @@ export class RceManagementViewProvider extends BaseWebviewViewProvider {
     /**
      * The snapshot id this device was last started with, remembered per workspace so the picker
      * pre-selects it across VS Code reloads. This is the extension's own record; the api's
-     * last_snapshot_id is deliberately not consulted anywhere.
+     * lastSnapshotId is deliberately not consulted anywhere.
      */
     private getRememberedSnapshotId(deviceId: number): number | undefined {
         const remembered = this.extensionContext.workspaceState.get<Record<number, number>>(WorkspaceStateKey.rceLastSnapshotByDevice) ?? {};

--- a/webviews/src/views/RceManagementView/RceManagementView.svelte
+++ b/webviews/src/views/RceManagementView/RceManagementView.svelte
@@ -238,12 +238,12 @@
     }
 
     function runtimeInfo(device: RceStateDevice, currentTimestamp: number): { label: string; percent: number } | undefined {
-        const runningDevice = device.running_device;
-        if (!runningDevice?.started_at || !runningDevice?.max_runtime) {
+        const runningDevice = device.runningDevice;
+        if (!runningDevice?.startedAt || !runningDevice?.maxRuntime) {
             return undefined;
         }
-        const elapsedSeconds = Math.max(0, (currentTimestamp - new Date(runningDevice.started_at).getTime()) / 1000);
-        const maxRuntimeSeconds = runningDevice.max_runtime;
+        const elapsedSeconds = Math.max(0, (currentTimestamp - new Date(runningDevice.startedAt).getTime()) / 1000);
+        const maxRuntimeSeconds = runningDevice.maxRuntime;
         return {
             label: formatRuntimeLabel(elapsedSeconds, maxRuntimeSeconds),
             percent: Math.min(100, (elapsedSeconds / maxRuntimeSeconds) * 100)
@@ -279,8 +279,8 @@
         if (typeof run.runtime === 'number') {
             return formatDurationFromSeconds(run.runtime);
         }
-        if (run.started_at && run.ended_at) {
-            const durationSeconds = (new Date(run.ended_at as string).getTime() - new Date(run.started_at as string).getTime()) / 1000;
+        if (run.startedAt && run.endedAt) {
+            const durationSeconds = (new Date(run.endedAt as string).getTime() - new Date(run.startedAt as string).getTime()) / 1000;
             return formatDurationFromSeconds(durationSeconds);
         }
         return 'Unknown';
@@ -291,8 +291,8 @@
             return [];
         }
         return [...runs].sort((firstRun, secondRun) => {
-            const firstTimestamp = firstRun.started_at ? new Date(firstRun.started_at as string).getTime() : 0;
-            const secondTimestamp = secondRun.started_at ? new Date(secondRun.started_at as string).getTime() : 0;
+            const firstTimestamp = firstRun.startedAt ? new Date(firstRun.startedAt as string).getTime() : 0;
+            const secondTimestamp = secondRun.startedAt ? new Date(secondRun.startedAt as string).getTime() : 0;
             return secondTimestamp - firstTimestamp;
         });
     }
@@ -335,7 +335,7 @@
      * actually started from (the run history is the authoritative cross-window record of "last one
      * used"), otherwise the extension's own remembered last-start (covers a missing or lagging run
      * record), otherwise the device's live snapshot, otherwise the first ready snapshot, otherwise
-     * undefined. The api's last_snapshot_id (last CREATED, not last used) is deliberately not
+     * undefined. The api's lastSnapshotId (last CREATED, not last used) is deliberately not
      * consulted. Whatever this lands on is exactly what Start sends: the picker is the single source
      * of truth, the provider never resolves a snapshot itself.
      *
@@ -383,7 +383,7 @@
         });
 
         const preferredSnapshotId = existingUserPickedSnapshotId ? existingSelection : undefined;
-        const latestRunSnapshotId = sortedRuns(details.runs)[0]?.snapshot_id;
+        const latestRunSnapshotId = sortedRuns(details.runs)[0]?.snapshotId;
         const resolvedSnapshotId = resolveSelectedSnapshotId(details.snapshots, preferredSnapshotId, latestRunSnapshotId, details.lastUsedSnapshotId);
         //the pick flag only survives while the picked snapshot is what actually stays selected
         const pickSurvived = preferredSnapshotId !== undefined && resolvedSnapshotId === preferredSnapshotId;
@@ -449,9 +449,9 @@
         device: RceStateDevice,
         firmwareOptions: FirmwareVersion[]
     ): string | undefined {
-        const availableFirmwareIds = firmwareOptions.map((firmwareVersion) => firmwareVersion.firmware_version_id);
+        const availableFirmwareIds = firmwareOptions.map((firmwareVersion) => firmwareVersion.firmwareVersionId);
         const selectedSnapshot = (detailsState?.snapshots ?? []).find((snapshot) => snapshot.id === detailsState?.selectedSnapshotId);
-        const candidateFirmwareIds = [pickedFirmwareVersionId, selectedSnapshot?.firmware_version_id, device.firmware_version_id];
+        const candidateFirmwareIds = [pickedFirmwareVersionId, selectedSnapshot?.firmwareVersionId, device.firmwareVersionId];
         for (const candidateFirmwareId of candidateFirmwareIds) {
             if (candidateFirmwareId && availableFirmwareIds.includes(candidateFirmwareId)) {
                 return candidateFirmwareId;
@@ -969,7 +969,7 @@
                                 <span class="statusDot {statusDotClass(device.status)}" title={device.status ?? 'unknown'}></span>
                                 {device.name}
                             </span>
-                            <span class="deviceMeta">{device.device_type} &middot; {device.status ?? 'unknown'} &middot; {device.last_snapshot_name ?? 'no snapshot'}</span>
+                            <span class="deviceMeta">{device.deviceType} &middot; {device.status ?? 'unknown'} &middot; {device.lastSnapshotName ?? 'no snapshot'}</span>
                             {#if runtime}
                                 <span class="deviceRuntime">{runtime.label}</span>
                                 <div class="runtimeBarTrack">
@@ -978,7 +978,7 @@
                             {/if}
                         </div>
                         {#if device.status === 'shutdown'}
-                            {@const firmwareOptions = (firmwareVersions ?? []).filter((firmwareVersion) => firmwareVersion.device_type === device.device_type)}
+                            {@const firmwareOptions = (firmwareVersions ?? []).filter((firmwareVersion) => firmwareVersion.deviceType === device.deviceType)}
                             <div class="startControl">
                                 <VscodeDropdown
                                     bind:this={snapshotDropdownsByDeviceId[device.id]}
@@ -1008,8 +1008,8 @@
                                         <vscode-option value="">Firmware unavailable</vscode-option>
                                     {:else}
                                         {#each firmwareOptions as firmwareVersion}
-                                            <vscode-option value={firmwareVersion.firmware_version_id}>
-                                                {firmwareVersion.display_name ?? firmwareVersion.firmware_version_id}
+                                            <vscode-option value={firmwareVersion.firmwareVersionId}>
+                                                {firmwareVersion.displayName ?? firmwareVersion.firmwareVersionId}
                                             </vscode-option>
                                         {/each}
                                     {/if}
@@ -1068,9 +1068,9 @@
                                 {/if}
 
                                 <div class="detailsMeta">
-                                    <span>Created: {formatDateTime(device.created_at)}</span>
-                                    {#if device.serial_number}
-                                        <span>Serial number: {device.serial_number}</span>
+                                    <span>Created: {formatDateTime(device.createdAt)}</span>
+                                    {#if device.serialNumber}
+                                        <span>Serial number: {device.serialNumber}</span>
                                     {/if}
                                 </div>
 
@@ -1130,9 +1130,9 @@
                                                         {/if}
                                                     </span>
                                                     <span class="snapshotMeta">
-                                                        {formatDateTime(snapshot.created_at)}
-                                                        {#if snapshot.firmware_version_display_name}
-                                                            &middot; {snapshot.firmware_version_display_name}
+                                                        {formatDateTime(snapshot.createdAt)}
+                                                        {#if snapshot.firmwareVersionDisplayName}
+                                                            &middot; {snapshot.firmwareVersionDisplayName}
                                                         {/if}
                                                         {#if snapshot.note}
                                                             &middot; {snapshot.note}
@@ -1165,8 +1165,8 @@
                                             {#each sortedRuns(detailsState.runs).slice(0, 10) as run}
                                                 <div class="historyRow">
                                                     <div class="historyInfo">
-                                                        <span>{run.creator_username ?? 'Unknown user'} &middot; {run.snapshot_name ?? 'Unknown snapshot'}</span>
-                                                        <span class="historyMeta">{formatDateTime(run.started_at as string)} &middot; {runDuration(run)}</span>
+                                                        <span>{run.creatorUsername ?? 'Unknown user'} &middot; {run.snapshotName ?? 'Unknown snapshot'}</span>
+                                                        <span class="historyMeta">{formatDateTime(run.startedAt as string)} &middot; {runDuration(run)}</span>
                                                     </div>
                                                 </div>
                                             {/each}


### PR DESCRIPTION
Updates roku-deploy to `4.0.0-alpha.6` and adopts its API changes:

- RceManagementClient types are now camelCase (it converts to the snake_case wire format at the boundary), so DeviceManager, RceManager, RceManagementViewProvider, the RceManagementView contract/webview, and their specs now read and send camelCase fields (`runningDevice`, `instanceApiUrl`, `deviceType`, `snapshotId`, `firmwareVersionId`, `maxRuntime`, `janus*`, ...), dropping the eslint camelcase carve-outs
- `queryApps` -> `getApps` and `queryActiveApp` -> `getActiveApp` in BrightScriptCommands
- `getFilePaths` -> `resolveFilesArray` in LogDocumentLinkProvider
- CaptureScreenshotCommand spec mocks carry the new required `CaptureScreenshotResult.format` field

alpha.6 also carries the renamed Roku Cloud Emulator instance routes (`/api/v0/input` key input and the `/api/v0/ports/8060/http` ECP proxy), which RCE devices need now that Roku is removing the old `/ecp1` paths.