### PR TITLE
chore: Security enhancements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7685,9 +7685,9 @@
             "dev": true
         },
         "node_modules/js-yaml": {
-            "version": "4.3.1",
-            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.1.tgz",
-            "integrity": "sha512-CY6crGq313MX8GkwvB7tzgp99vjQxY1++5y10/BKN/GUfHqWaOGQMNZkBvqSzsZKWk/ijwHlWzzkLulsGHhjWQ==",
+            "version": "4.3.2",
+            "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-4.3.2.tgz",
+            "integrity": "sha512-SFNOvSJ+Dgf/9An904Yx+CgSlIPCkIpao4qo51lpee25TIRejdH3rhR4EZMGoNx3/TP3O+wzWuiTFl4sqbltzA==",
             "dev": true,
             "funding": [
                 {

--- a/package.json
+++ b/package.json
@@ -148,7 +148,7 @@
             "shell-quote": "^1.10.0"
         },
         "brace-expansion": "^2.1.4",
-        "js-yaml": "^4.3.1",
+        "js-yaml": "^4.3.2",
         "@babel/core": "^7.29.7",
         "fast-uri": "^3.1.7",
         "body-parser": "^1.20.6",


### PR DESCRIPTION
Clears GHSA-2883-xcg3-v3hh (js-yaml, high), the advisory that started failing the audit gate.

Gate is green at both levels: root passes, and the nested `webviews` project reports 0 vulnerabilities.

## Ships to consumers
Nothing. This extension ships as a bundled `.vsix` and the only change is dev-scoped anyway.

## Lockfile only (dev deps)
| Override | Before | After | Reached via |
|---|---|---|---|
| `js-yaml` | `^4.3.1` | `^4.3.2` | `eslint`, `mocha`, `nyc` |

## Notes for the reviewer
- The previous `^4.3.1` pin landed exactly inside the new advisory's range (`4.0.0 - 4.3.1`), so the gate went red without anything in this repo changing. 4.3.2 is a patch bump.
- `webviews` needed no change — it has no js-yaml in its graph.
- The remaining `ip` (via `node-ssdp`) and `uuid` advisories are pre-existing and unchanged here: `ip` stays allowlisted in `audit-ci.jsonc`, and `uuid` is moderate, below the `high` floor. Clearing `ip` needs a breaking `node-ssdp@1.0.0`; recommend leaving it.

## Verification
`npm run preversion` (build + lint + check-webviews + test + check-extraneous + audit) passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)