### PR TITLE
Security enhancements

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1896,11 +1896,6 @@
                 "@types/node": "*"
             }
         },
-        "node_modules/@types/caseless": {
-            "version": "0.12.2",
-            "resolved": "https://registry.npmjs.org/@types/caseless/-/caseless-0.12.2.tgz",
-            "integrity": "sha512-6ckxMjBBD8URvjB6J3NcnuAn5Pkl7t3TizAg+xdlzzQGSPSmBcXf8KoIH0ua/i+tio+ZRUHEXp0HEmvaR4kt0w=="
-        },
         "node_modules/@types/chai": {
             "version": "4.3.4",
             "resolved": "https://registry.npmjs.org/@types/chai/-/chai-4.3.4.tgz",
@@ -2078,18 +2073,6 @@
             "integrity": "sha512-hKormJbkJqzQGhziax5PItDUTMAM9uE2XXQmM37dyd4hVM+5aVl7oVxMVUiVQn2oCQFN/LKCZdvSM0pFRqbSmQ==",
             "license": "MIT"
         },
-        "node_modules/@types/request": {
-            "version": "2.48.13",
-            "resolved": "https://registry.npmjs.org/@types/request/-/request-2.48.13.tgz",
-            "integrity": "sha512-FGJ6udDNUCjd19pp0Q3iTiDkwhYup7J8hpMW9c4k53NrccQFFWKRho6hvtPPEhnXWKvukfwAlB6DbDz4yhH5Gg==",
-            "license": "MIT",
-            "dependencies": {
-                "@types/caseless": "*",
-                "@types/node": "*",
-                "@types/tough-cookie": "*",
-                "form-data": "^2.5.5"
-            }
-        },
         "node_modules/@types/resolve": {
             "version": "1.20.6",
             "resolved": "https://registry.npmjs.org/@types/resolve/-/resolve-1.20.6.tgz",
@@ -2141,11 +2124,6 @@
             "resolved": "https://registry.npmjs.org/@types/sinon/-/sinon-7.0.6.tgz",
             "integrity": "sha512-ldQl2p7kyCXHhr//5sQCu9jWgSiDbYuCD5dUp53r/z8T8jmgKpANpy4vqjbdho9P2ldFaQC/gpW31hch+oQ0IQ==",
             "dev": true
-        },
-        "node_modules/@types/tough-cookie": {
-            "version": "4.0.2",
-            "resolved": "https://registry.npmjs.org/@types/tough-cookie/-/tough-cookie-4.0.2.tgz",
-            "integrity": "sha512-Q5vtl1W5ue16D+nIaW8JWebSSraJVlK+EthKn7e7UcD4KWsaSJ8BqGPXNaPghgtcn/fhvrN17Tv8ksUsQpiplw=="
         },
         "node_modules/@types/vscode": {
             "version": "1.81.0",
@@ -3017,24 +2995,6 @@
                 "url": "https://github.com/sponsors/ljharb"
             }
         },
-        "node_modules/asn1": {
-            "version": "0.2.6",
-            "resolved": "https://registry.npmjs.org/asn1/-/asn1-0.2.6.tgz",
-            "integrity": "sha512-ix/FxPn0MDjeyJ7i/yoHGFt/EX6LyNbxSEhPPXODPL+KB0VPk86UYfL0lMdy+KCnv+fmvIzySwaK5COwqVbWTQ==",
-            "license": "MIT",
-            "dependencies": {
-                "safer-buffer": "~2.1.0"
-            }
-        },
-        "node_modules/assert-plus": {
-            "version": "1.0.0",
-            "resolved": "https://registry.npmjs.org/assert-plus/-/assert-plus-1.0.0.tgz",
-            "integrity": "sha512-NfJ4UzBCcQGLDlQq7nHxH+tv3kyZ0hHQqF5BO6J7tNJeP5do1llPr8dZ8zHonfhAu0PHAdMkSo+8o0wxg9lZWw==",
-            "license": "MIT",
-            "engines": {
-                "node": ">=0.8"
-            }
-        },
         "node_modules/assertion-error": {
             "version": "1.1.0",
             "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-1.1.0.tgz",
@@ -3071,7 +3031,8 @@
         "node_modules/asynckit": {
             "version": "0.4.0",
             "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-            "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+            "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+            "dev": true
         },
         "node_modules/audit-ci": {
             "version": "7.1.0",
@@ -3196,19 +3157,6 @@
                 "node": ">=12"
             }
         },
-        "node_modules/aws-sign2": {
-            "version": "0.7.0",
-            "resolved": "https://registry.npmjs.org/aws-sign2/-/aws-sign2-0.7.0.tgz",
-            "integrity": "sha512-08kcGqnYf/YmjoRhfxyu+CLxBjUtHLXLXX/vUfx9l2LYzG3c1m61nrpyFUZI6zeS+Li/wWMMidD9KgrqtGq3mA==",
-            "engines": {
-                "node": "*"
-            }
-        },
-        "node_modules/aws4": {
-            "version": "1.12.0",
-            "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.12.0.tgz",
-            "integrity": "sha512-NmWvPnx0F1SfrQbYwOi7OeaNGokp9XhzNioJ/CSBs8Qa4vxug81mhJEAVZwxXuBmYB5KDRfMq/F3RR0BIU7sWg=="
-        },
         "node_modules/axe-core": {
             "version": "4.5.2",
             "resolved": "https://registry.npmjs.org/axe-core/-/axe-core-4.5.2.tgz",
@@ -3272,15 +3220,6 @@
             },
             "engines": {
                 "node": ">=6.0.0"
-            }
-        },
-        "node_modules/bcrypt-pbkdf": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/bcrypt-pbkdf/-/bcrypt-pbkdf-1.0.2.tgz",
-            "integrity": "sha512-qeFIXtP4MSoi6NLqO12WfqARWWuCKi2Rn/9hJLEmtB5yTNr9DqFWkJRCf2qShWzPeAMRnOgCrq0sg/KLv5ES9w==",
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "tweetnacl": "^0.14.3"
             }
         },
         "node_modules/binary-extensions": {
@@ -3437,12 +3376,13 @@
             }
         },
         "node_modules/brighterscript": {
-            "version": "0.73.0",
-            "resolved": "https://registry.npmjs.org/brighterscript/-/brighterscript-0.73.0.tgz",
-            "integrity": "sha512-7QjLmTd0x/PMvxrlCixWNVXv5P/1GcAKSIA85DiS+DZYXQ/sN98SqfBuRHG+jxMy5HFoare3j5K0H6Y860unoQ==",
+            "version": "0.73.3",
+            "resolved": "https://registry.npmjs.org/brighterscript/-/brighterscript-0.73.3.tgz",
+            "integrity": "sha512-CjnPk9iZSntbgwM2uNwoqMGWY5CK1FpWGnBpR1NLK3TMsGHGKp5cV7whEZA7lp1D34vXSqxoOC1Jy1ozeOu79A==",
+            "license": "MIT",
             "dependencies": {
                 "@rokucommunity/bslib": "^0.1.1",
-                "@rokucommunity/logger": "^0.4.0",
+                "@rokucommunity/logger": "^0.4.2",
                 "@xml-tools/parser": "^1.0.7",
                 "chalk": "^2.4.2",
                 "chevrotain": "^7.0.1",
@@ -3456,7 +3396,7 @@
                 "lodash.isequal": "^4.5.0",
                 "micromatch": "^4.0.4",
                 "require-relative": "^0.8.7",
-                "roku-deploy": "^3.17.6",
+                "roku-deploy": "^3.18.4",
                 "semver": "^7.7.3",
                 "source-map": "^0.7.4",
                 "thenby": "^1.3.4",
@@ -3694,12 +3634,12 @@
             }
         },
         "node_modules/brighterscript/node_modules/roku-deploy": {
-            "version": "3.18.2",
-            "resolved": "https://registry.npmjs.org/roku-deploy/-/roku-deploy-3.18.2.tgz",
-            "integrity": "sha512-O0nO/hzhax6nhcwsk40Vdoq7RKm4n3OCJfc+Vr5OcV1YfSg5qeFt6gY3RG74QjZ+KrTO1A51XO0Oe1e4qV4O8w==",
+            "version": "3.18.4",
+            "resolved": "https://registry.npmjs.org/roku-deploy/-/roku-deploy-3.18.4.tgz",
+            "integrity": "sha512-Wi8C+f3sCfJb1SgdkBUYWuWf7GKJr88AzdFUiPrBUfkNZxFoGoAW8iCMg0jtPdku5bge6eyoi91iao3d9UMjTA==",
             "license": "MIT",
             "dependencies": {
-                "@rokucommunity/logger": "^0.4.1",
+                "@rokucommunity/logger": "^0.4.2",
                 "chalk": "^2.4.2",
                 "fast-glob": "^3.2.12",
                 "fs-extra": "^7.0.1",
@@ -3998,11 +3938,6 @@
             ],
             "license": "CC-BY-4.0"
         },
-        "node_modules/caseless": {
-            "version": "0.12.0",
-            "resolved": "https://registry.npmjs.org/caseless/-/caseless-0.12.0.tgz",
-            "integrity": "sha512-4tYFyifaFfGacoiObjJegolkwSU4xQNGbVgUiNYVUxbQ2x2lUsFvY4hVgVzGiIe6WLOPqycWXA40l+PWsxthUw=="
-        },
         "node_modules/chai": {
             "version": "4.3.7",
             "resolved": "https://registry.npmjs.org/chai/-/chai-4.3.7.tgz",
@@ -4294,6 +4229,7 @@
             "version": "1.0.8",
             "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
             "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+            "dev": true,
             "dependencies": {
                 "delayed-stream": "~1.0.0"
             },
@@ -4453,18 +4389,6 @@
             "resolved": "https://registry.npmjs.org/damerau-levenshtein/-/damerau-levenshtein-1.0.8.tgz",
             "integrity": "sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==",
             "dev": true
-        },
-        "node_modules/dashdash": {
-            "version": "1.14.1",
-            "resolved": "https://registry.npmjs.org/dashdash/-/dashdash-1.14.1.tgz",
-            "integrity": "sha512-jRFi8UDGo6j+odZiEpjazZaWqEal3w/basFjQHQEwVtZJGDpxbH1MeYluwCS8Xq5wmLJooDlMgvVarmWfGM44g==",
-            "license": "MIT",
-            "dependencies": {
-                "assert-plus": "^1.0.0"
-            },
-            "engines": {
-                "node": ">=0.10"
-            }
         },
         "node_modules/dayjs": {
             "version": "1.11.12",
@@ -4671,6 +4595,7 @@
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
             "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+            "dev": true,
             "engines": {
                 "node": ">=0.4.0"
             }
@@ -4818,16 +4743,6 @@
             "resolved": "https://registry.npmjs.org/duplexer/-/duplexer-0.1.2.tgz",
             "integrity": "sha512-jtD6YG370ZCIi/9GTaJKQxWTZD045+4R4hTk/x1UyoqadyJ9x9CgSi1RlVDQF8U2sxLLSnFkCaMihqljHIWgMg==",
             "dev": true
-        },
-        "node_modules/ecc-jsbn": {
-            "version": "0.1.2",
-            "resolved": "https://registry.npmjs.org/ecc-jsbn/-/ecc-jsbn-0.1.2.tgz",
-            "integrity": "sha512-eh9O+hwRHNbG4BLTjEl3nw044CkGm5X6LoaCf7LPp7UU8Qrt47JYNi6nPX8xjW97TKGKm1ouctg0QSpZe9qrnw==",
-            "license": "MIT",
-            "dependencies": {
-                "jsbn": "~0.1.0",
-                "safer-buffer": "^2.1.0"
-            }
         },
         "node_modules/ecdsa-sig-formatter": {
             "version": "1.0.11",
@@ -5003,6 +4918,7 @@
             "version": "2.1.0",
             "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
             "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "es-errors": "^1.3.0",
@@ -5798,15 +5714,6 @@
             "resolved": "https://registry.npmjs.org/extend/-/extend-3.0.2.tgz",
             "integrity": "sha512-fjquC59cD7CyW6urNXK0FBufkZcoiGG80wTuPujX590cB5Ttln20E2UB4S/WARVqhXffZl2LNgS+gQdPIIim/g=="
         },
-        "node_modules/extsprintf": {
-            "version": "1.3.0",
-            "resolved": "https://registry.npmjs.org/extsprintf/-/extsprintf-1.3.0.tgz",
-            "integrity": "sha512-11Ndz7Nv+mvAC1j0ktTa7fAb0vLyGGX+rMHNBYQviQDGU0Hw7lhctJANqbPhu9nV9/izT/IntTgZ7Im/9LJs9g==",
-            "engines": [
-                "node >=0.6.0"
-            ],
-            "license": "MIT"
-        },
         "node_modules/eyes": {
             "version": "0.1.8",
             "resolved": "https://registry.npmjs.org/eyes/-/eyes-0.1.8.tgz",
@@ -6061,18 +5968,11 @@
                 "node": ">=8.0.0"
             }
         },
-        "node_modules/forever-agent": {
-            "version": "0.6.1",
-            "resolved": "https://registry.npmjs.org/forever-agent/-/forever-agent-0.6.1.tgz",
-            "integrity": "sha512-j0KLYPhm6zeac4lz3oJ3o65qvgQCcPubiyotZrXqEaG4hNagNYO8qdlUrX5vwqv9ohqeT/Z3j6+yW067yWWdUw==",
-            "engines": {
-                "node": "*"
-            }
-        },
         "node_modules/form-data": {
             "version": "2.5.6",
             "resolved": "https://registry.npmjs.org/form-data/-/form-data-2.5.6.tgz",
             "integrity": "sha512-Ogz/E85h9tlfJzpI6TuFpGcHZFhLrb9Gw8wq9v40CxSCPnv7ahKr6Xgtkn0KYCDQJ8DNn5VoMO8EXr9V5PadyA==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "asynckit": "^0.4.0",
@@ -6307,15 +6207,6 @@
             "integrity": "sha512-Ln0UQDlxH1BapMu3GPtf7CuYNwRZf2gwCuPqbyG6pB8WfmFpzqcy4xtAaAMUhnNqjMKTiCPZG2oMT3YSx8U2NA==",
             "engines": {
                 "node": ">=0.10.0"
-            }
-        },
-        "node_modules/getpass": {
-            "version": "0.1.7",
-            "resolved": "https://registry.npmjs.org/getpass/-/getpass-0.1.7.tgz",
-            "integrity": "sha512-0fzj9JxOLfJ+XGLhR8ze3unN0KZCgZwiSSDz168VERjK8Wl8kVSdcu2kspd4s4wtAa1y/qrVRiAA0WclVsu0ng==",
-            "license": "MIT",
-            "dependencies": {
-                "assert-plus": "^1.0.0"
             }
         },
         "node_modules/github-from-package": {
@@ -6629,29 +6520,6 @@
             "integrity": "sha512-+xGQY0YyAWCnqy7Cd++hc2JqMYzlm0dG30Jd0beaA64sROr8C4nt8Yc9V5Ro3avlSUDTN0ulqP/VBKi1/lLygw==",
             "dev": true
         },
-        "node_modules/har-schema": {
-            "version": "2.0.0",
-            "resolved": "https://registry.npmjs.org/har-schema/-/har-schema-2.0.0.tgz",
-            "integrity": "sha512-Oqluz6zhGX8cyRaTQlFMPw80bSJVG2x/cFb8ZPhUILGgHka9SsokCCOQgpveePerqidZOrT14ipqfJb7ILcW5Q==",
-            "license": "ISC",
-            "engines": {
-                "node": ">=4"
-            }
-        },
-        "node_modules/har-validator": {
-            "version": "5.1.5",
-            "resolved": "https://registry.npmjs.org/har-validator/-/har-validator-5.1.5.tgz",
-            "integrity": "sha512-nmT2T0lljbxdQZfspsno9hgrG3Uir6Ks5afism62poxqBM6sDnMEuPmzTq8XN0OEwqKLLdh1jQI3qyE66Nzb3w==",
-            "deprecated": "this library is no longer supported",
-            "license": "MIT",
-            "dependencies": {
-                "ajv": "^6.12.3",
-                "har-schema": "^2.0.0"
-            },
-            "engines": {
-                "node": ">=6"
-            }
-        },
         "node_modules/has": {
             "version": "1.0.3",
             "resolved": "https://registry.npmjs.org/has/-/has-1.0.3.tgz",
@@ -6709,6 +6577,7 @@
             "version": "1.0.2",
             "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
             "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+            "dev": true,
             "license": "MIT",
             "dependencies": {
                 "has-symbols": "^1.0.3"
@@ -6923,21 +6792,6 @@
             "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
             "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
             "license": "MIT"
-        },
-        "node_modules/http-signature": {
-            "version": "1.2.0",
-            "resolved": "https://registry.npmjs.org/http-signature/-/http-signature-1.2.0.tgz",
-            "integrity": "sha512-CAbnr6Rz4CYQkLYUtSNXxQPUH2gK8f3iWexVlsnMeD+GjlsQ0Xsy1cOX+mN3dtxYomRy21CiOzU8Uhw6OwncEQ==",
-            "license": "MIT",
-            "dependencies": {
-                "assert-plus": "^1.0.0",
-                "jsprim": "^1.2.2",
-                "sshpk": "^1.7.0"
-            },
-            "engines": {
-                "node": ">=0.8",
-                "npm": ">=1.3.7"
-            }
         },
         "node_modules/https-proxy-agent": {
             "version": "7.0.6",
@@ -7424,7 +7278,8 @@
         "node_modules/is-typedarray": {
             "version": "1.0.0",
             "resolved": "https://registry.npmjs.org/is-typedarray/-/is-typedarray-1.0.0.tgz",
-            "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA=="
+            "integrity": "sha512-cyA56iCMHAh5CdzjJIa4aohJyeO1YbwLi3Jc35MmRU6poroFjIGZzUzupGiRPOjgHg9TLu43xbpwXk523fMxKA==",
+            "dev": true
         },
         "node_modules/is-unicode-supported": {
             "version": "0.1.0",
@@ -7492,7 +7347,8 @@
         "node_modules/isstream": {
             "version": "0.1.2",
             "resolved": "https://registry.npmjs.org/isstream/-/isstream-0.1.2.tgz",
-            "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g=="
+            "integrity": "sha512-Yljz7ffyPbrLpLngrMtZ7NduUgVvi6wG9RJ9IUcyCd59YQ911PBJphODUcbOVbqYfxe1wuYf/LJ8PauMRwsM/g==",
+            "dev": true
         },
         "node_modules/istanbul-lib-coverage": {
             "version": "3.2.0",
@@ -7747,12 +7603,6 @@
                 "js-yaml": "bin/js-yaml.js"
             }
         },
-        "node_modules/jsbn": {
-            "version": "0.1.1",
-            "resolved": "https://registry.npmjs.org/jsbn/-/jsbn-0.1.1.tgz",
-            "integrity": "sha512-UVU9dibq2JcFWxQPA6KCqj5O42VOmAY3zQUfEKxU0KpTGXwNoCjkX1e13eHNvw/xPynt6pU0rZ1htjWTNTSXsg==",
-            "license": "MIT"
-        },
         "node_modules/jsesc": {
             "version": "3.1.0",
             "resolved": "https://registry.npmjs.org/jsesc/-/jsesc-3.1.0.tgz",
@@ -7765,12 +7615,6 @@
             "engines": {
                 "node": ">=6"
             }
-        },
-        "node_modules/json-schema": {
-            "version": "0.4.0",
-            "resolved": "https://registry.npmjs.org/json-schema/-/json-schema-0.4.0.tgz",
-            "integrity": "sha512-es94M3nTIfsEPisRafak+HDLfHXnKBhV3vU5eqPcS3flIWqcxJWgXHXiey3YrpaNsanY5ei1VoYEbOzijuq9BA==",
-            "license": "(AFL-2.1 OR BSD-3-Clause)"
         },
         "node_modules/json-schema-traverse": {
             "version": "0.4.1",
@@ -7794,11 +7638,6 @@
             "resolved": "https://registry.npmjs.org/json-stable-stringify-without-jsonify/-/json-stable-stringify-without-jsonify-1.0.1.tgz",
             "integrity": "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw==",
             "dev": true
-        },
-        "node_modules/json-stringify-safe": {
-            "version": "5.0.1",
-            "resolved": "https://registry.npmjs.org/json-stringify-safe/-/json-stringify-safe-5.0.1.tgz",
-            "integrity": "sha512-ZClg6AaYvamvYEE82d3Iyd3vSSIjQ+odgjaTzRuO3s7toCdFKczob2i0zCh7JE8kWn17yvAWhUVxvqGwUalsRA=="
         },
         "node_modules/json5": {
             "version": "2.2.3",
@@ -7883,21 +7722,6 @@
             "engines": {
                 "node": ">=12",
                 "npm": ">=6"
-            }
-        },
-        "node_modules/jsprim": {
-            "version": "1.4.2",
-            "resolved": "https://registry.npmjs.org/jsprim/-/jsprim-1.4.2.tgz",
-            "integrity": "sha512-P2bSOMAc/ciLz6DzgjVlGJP9+BrJWu5UDGK70C2iweC5QBIeFf0ZXRvGjEj2uYgrY2MkAAhsSWHDWlFtEroZWw==",
-            "license": "MIT",
-            "dependencies": {
-                "assert-plus": "1.0.0",
-                "extsprintf": "1.3.0",
-                "json-schema": "0.4.0",
-                "verror": "1.10.0"
-            },
-            "engines": {
-                "node": ">=0.6.0"
             }
         },
         "node_modules/jsx-ast-utils": {
@@ -9079,14 +8903,6 @@
                 "node": ">=6"
             }
         },
-        "node_modules/oauth-sign": {
-            "version": "0.9.0",
-            "resolved": "https://registry.npmjs.org/oauth-sign/-/oauth-sign-0.9.0.tgz",
-            "integrity": "sha512-fexhUFFPTGV8ybAtSIGbV6gOkSv8UtRbDBnAyLQw4QPKkgNlsH2ByPGtMUqdWkos6YCRmAqViwgZrJc/mRDzZQ==",
-            "engines": {
-                "node": "*"
-            }
-        },
         "node_modules/object-inspect": {
             "version": "1.13.4",
             "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.4.tgz",
@@ -9507,12 +9323,6 @@
             "dev": true,
             "license": "MIT"
         },
-        "node_modules/performance-now": {
-            "version": "2.1.0",
-            "resolved": "https://registry.npmjs.org/performance-now/-/performance-now-2.1.0.tgz",
-            "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow==",
-            "license": "MIT"
-        },
         "node_modules/picocolors": {
             "version": "1.1.1",
             "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
@@ -9639,55 +9449,6 @@
                     "optional": true
                 }
             }
-        },
-        "node_modules/postman-request": {
-            "version": "2.88.1-postman.8-beta.1",
-            "resolved": "https://registry.npmjs.org/postman-request/-/postman-request-2.88.1-postman.8-beta.1.tgz",
-            "integrity": "sha512-deC5UZlM1VimFhQdPN1NcbQMvLEtpUCTHZHMXWNv6vyNW7H98O3MJGTlk2xTlzB9BOpU2MCCgXNOPeNP2SU6iA==",
-            "license": "Apache-2.0",
-            "dependencies": {
-                "aws-sign2": "~0.7.0",
-                "aws4": "^1.8.0",
-                "caseless": "~0.12.0",
-                "combined-stream": "~1.0.6",
-                "extend": "~3.0.2",
-                "forever-agent": "~0.6.1",
-                "form-data": "~2.3.2",
-                "har-validator": "~5.1.3",
-                "http-signature": "~1.2.0",
-                "is-typedarray": "~1.0.0",
-                "isstream": "~0.1.2",
-                "json-stringify-safe": "~5.0.1",
-                "mime-types": "~2.1.19",
-                "oauth-sign": "~0.9.0",
-                "performance-now": "^2.1.0",
-                "postman-url-encoder": "1.0.1",
-                "qs": "~6.5.2",
-                "safe-buffer": "^5.1.2",
-                "stream-length": "^1.0.2",
-                "tough-cookie": "~2.5.0",
-                "tunnel-agent": "^0.6.0",
-                "uuid": "^3.3.2"
-            },
-            "engines": {
-                "node": ">= 6"
-            }
-        },
-        "node_modules/postman-request/node_modules/uuid": {
-            "version": "3.4.0",
-            "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-            "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-            "deprecated": "uuid@10 and below is no longer supported.  For ESM codebases, update to uuid@latest.  For CommonJS codebases, use uuid@11 (but be aware this version will likely be deprecated in 2028).",
-            "license": "MIT",
-            "bin": {
-                "uuid": "bin/uuid"
-            }
-        },
-        "node_modules/postman-url-encoder": {
-            "version": "1.0.1",
-            "resolved": "https://registry.npmjs.org/postman-url-encoder/-/postman-url-encoder-1.0.1.tgz",
-            "integrity": "sha512-ned2lpcMpEG+n3ce2LEoGqUJeZsKNRYkViqKfJXe7rUQhLxjrrcp/lQ8TLycvX74lQZm52gkNVVgczmcJBOJ8w==",
-            "license": "MIT"
         },
         "node_modules/prebuild-install": {
             "version": "7.1.1",
@@ -9824,18 +9585,6 @@
                 "node": ">= 0.10"
             }
         },
-        "node_modules/psl": {
-            "version": "1.15.0",
-            "resolved": "https://registry.npmjs.org/psl/-/psl-1.15.0.tgz",
-            "integrity": "sha512-JZd3gMVBAVQkSs6HdNZo9Sdo0LNcQeMNP3CozBJb3JYC/QUYZTnKxP+f8oWRX4rHP5EurWxqAHTSwUCjlNKa1w==",
-            "license": "MIT",
-            "dependencies": {
-                "punycode": "^2.3.1"
-            },
-            "funding": {
-                "url": "https://github.com/sponsors/lupomontero"
-            }
-        },
         "node_modules/pump": {
             "version": "3.0.0",
             "resolved": "https://registry.npmjs.org/pump/-/pump-3.0.0.tgz",
@@ -9892,12 +9641,6 @@
             "funding": {
                 "url": "https://github.com/sponsors/ljharb"
             }
-        },
-        "node_modules/querystringify": {
-            "version": "2.2.0",
-            "resolved": "https://registry.npmjs.org/querystringify/-/querystringify-2.2.0.tgz",
-            "integrity": "sha512-FIqgj2EUvTa7R50u0rGsyTftzjYmv/a3hO345bZNrqabNqjtgiDMgmo4mkUjd+nzU5oF3dClKqFIPUKybUyqoQ==",
-            "license": "MIT"
         },
         "node_modules/queue-microtask": {
             "version": "1.2.3",
@@ -10385,16 +10128,15 @@
             }
         },
         "node_modules/roku-debug": {
-            "version": "0.24.1",
-            "resolved": "https://registry.npmjs.org/roku-debug/-/roku-debug-0.24.1.tgz",
-            "integrity": "sha512-b0lswG9afaTpHW559e+WJIw0gcaOQQgq7RThU1xcTP2vcHDdhj3mmJQwNkVLGkxjl1pXIzQapBF+UEWRaPcFTA==",
+            "version": "0.24.3",
+            "resolved": "https://registry.npmjs.org/roku-debug/-/roku-debug-0.24.3.tgz",
+            "integrity": "sha512-KbcNBc5f+WoqZeOgXTlT2/H0l45Th6l2FclLSk+cS7yY0lGll2V8/FhrHyNeUz7/UiNkFeDL6aZShAioPji9IQ==",
             "license": "MIT",
             "dependencies": {
-                "@rokucommunity/logger": "^0.4.1",
-                "@types/request": "^2.48.8",
+                "@rokucommunity/logger": "^0.4.2",
                 "@vscode/debugadapter": "^1.68.0",
                 "@vscode/debugprotocol": "^1.68.0",
-                "brighterscript": "^0.73.0",
+                "brighterscript": "^0.73.3",
                 "dateformat": "^4.6.3",
                 "debounce": "^1.2.1",
                 "eol": "^0.9.1",
@@ -10403,11 +10145,11 @@
                 "find-in-files": "^0.5.0",
                 "fs-extra": "^10.0.0",
                 "natural-orderby": "^2.0.3",
+                "needle": "^3.5.0",
                 "portfinder": "^1.0.32",
-                "postman-request": "^2.88.1-postman.48",
                 "replace-in-file": "^6.3.2",
                 "replace-last": "^1.2.6",
-                "roku-deploy": "^4.0.0-alpha.3",
+                "roku-deploy": "^4.0.0-alpha.6",
                 "semver": "^7.5.4",
                 "serialize-error": "^8.1.0",
                 "smart-buffer": "^4.2.0",
@@ -10448,6 +10190,18 @@
                 "node": ">=12"
             }
         },
+        "node_modules/roku-debug/node_modules/iconv-lite": {
+            "version": "0.6.3",
+            "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+            "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+            "license": "MIT",
+            "dependencies": {
+                "safer-buffer": ">= 2.1.2 < 3.0.0"
+            },
+            "engines": {
+                "node": ">=0.10.0"
+            }
+        },
         "node_modules/roku-debug/node_modules/jsonfile": {
             "version": "6.2.1",
             "resolved": "https://registry.npmjs.org/jsonfile/-/jsonfile-6.2.1.tgz",
@@ -10457,6 +10211,22 @@
             },
             "optionalDependencies": {
                 "graceful-fs": "^4.1.6"
+            }
+        },
+        "node_modules/roku-debug/node_modules/needle": {
+            "version": "3.5.0",
+            "resolved": "https://registry.npmjs.org/needle/-/needle-3.5.0.tgz",
+            "integrity": "sha512-jaQyPKKk2YokHrEg+vFDYxXIHTCBgiZwSHOoVx/8V3GIBS8/VN6NdVRmg8q1ERtPkMvmOvebsgga4sAj5hls/w==",
+            "license": "MIT",
+            "dependencies": {
+                "iconv-lite": "^0.6.3",
+                "sax": "^1.2.4"
+            },
+            "bin": {
+                "needle": "bin/needle"
+            },
+            "engines": {
+                "node": ">= 4.4.x"
             }
         },
         "node_modules/roku-debug/node_modules/universalify": {
@@ -11425,31 +11195,6 @@
                 "node": "*"
             }
         },
-        "node_modules/sshpk": {
-            "version": "1.18.0",
-            "resolved": "https://registry.npmjs.org/sshpk/-/sshpk-1.18.0.tgz",
-            "integrity": "sha512-2p2KJZTSqQ/I3+HX42EpYOa2l3f8Erv8MWKsy2I9uf4wA7yFIkXRffYdsx86y6z4vHtV8u7g+pPlr8/4ouAxsQ==",
-            "license": "MIT",
-            "dependencies": {
-                "asn1": "~0.2.3",
-                "assert-plus": "^1.0.0",
-                "bcrypt-pbkdf": "^1.0.0",
-                "dashdash": "^1.12.0",
-                "ecc-jsbn": "~0.1.1",
-                "getpass": "^0.1.1",
-                "jsbn": "~0.1.0",
-                "safer-buffer": "^2.0.2",
-                "tweetnacl": "~0.14.0"
-            },
-            "bin": {
-                "sshpk-conv": "bin/sshpk-conv",
-                "sshpk-sign": "bin/sshpk-sign",
-                "sshpk-verify": "bin/sshpk-verify"
-            },
-            "engines": {
-                "node": ">=0.10.0"
-            }
-        },
         "node_modules/stack-trace": {
             "version": "0.0.10",
             "resolved": "https://registry.npmjs.org/stack-trace/-/stack-trace-0.0.10.tgz",
@@ -11495,19 +11240,6 @@
                 "duplexer": "~0.1.1",
                 "through": "~2.3.4"
             }
-        },
-        "node_modules/stream-length": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/stream-length/-/stream-length-1.0.2.tgz",
-            "integrity": "sha512-aI+qKFiwoDV4rsXiS7WRoCt+v2RX1nUj17+KJC5r2gfh5xoSJIfP6Y3Do/HtvesFcTSWthIuJ3l1cvKQY/+nZg==",
-            "dependencies": {
-                "bluebird": "^2.6.2"
-            }
-        },
-        "node_modules/stream-length/node_modules/bluebird": {
-            "version": "2.11.0",
-            "resolved": "https://registry.npmjs.org/bluebird/-/bluebird-2.11.0.tgz",
-            "integrity": "sha512-UfFSr22dmHPQqPP9XWHRhq+gWnHCYguQGkXQlbyPtW5qTnhFWA8/iXg765tH0cAjy7l/zPJ1aBTO0g5XgA7kvQ=="
         },
         "node_modules/string_decoder": {
             "version": "1.1.1",
@@ -11981,30 +11713,6 @@
                 "node": ">=0.6"
             }
         },
-        "node_modules/tough-cookie": {
-            "version": "4.1.4",
-            "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-4.1.4.tgz",
-            "integrity": "sha512-Loo5UUvLD9ScZ6jh8beX1T6sO1w2/MpCRpEP7V280GKMVUQ0Jzar2U3UJPsrdbziLEMMhu3Ujnq//rhiFuIeag==",
-            "license": "BSD-3-Clause",
-            "dependencies": {
-                "psl": "^1.1.33",
-                "punycode": "^2.1.1",
-                "universalify": "^0.2.0",
-                "url-parse": "^1.5.3"
-            },
-            "engines": {
-                "node": ">=6"
-            }
-        },
-        "node_modules/tough-cookie/node_modules/universalify": {
-            "version": "0.2.0",
-            "resolved": "https://registry.npmjs.org/universalify/-/universalify-0.2.0.tgz",
-            "integrity": "sha512-CJ1QgKmNg3CwvAv/kOFmtnEN05f0D/cn9QntgNOQlQF9dgvVTHj3t+8JPdjqawCHk7V/KA+fbUqzZ9XWhcqPUg==",
-            "license": "MIT",
-            "engines": {
-                "node": ">= 4.0.0"
-            }
-        },
         "node_modules/traverse-chain": {
             "version": "0.1.0",
             "resolved": "https://registry.npmjs.org/traverse-chain/-/traverse-chain-0.1.0.tgz",
@@ -12147,18 +11855,14 @@
             "version": "0.6.0",
             "resolved": "https://registry.npmjs.org/tunnel-agent/-/tunnel-agent-0.6.0.tgz",
             "integrity": "sha512-McnNiV1l8RYeY8tBgEpuodCC1mLUdbSN+CYBL7kJsJNInOP8UjDDEwdk6Mw60vdLLrr5NHKZhMAOSrR2NZuQ+w==",
+            "dev": true,
+            "optional": true,
             "dependencies": {
                 "safe-buffer": "^5.0.1"
             },
             "engines": {
                 "node": "*"
             }
-        },
-        "node_modules/tweetnacl": {
-            "version": "0.14.5",
-            "resolved": "https://registry.npmjs.org/tweetnacl/-/tweetnacl-0.14.5.tgz",
-            "integrity": "sha512-KXXFFdAbFXY4geFIwoyNK+f5Z1b7swfXABfL7HXCmoIWMKU3dmS26672A4EeQtDzLKy7SXmfBu51JolvEKwtGA==",
-            "license": "Unlicense"
         },
         "node_modules/type": {
             "version": "1.2.0",
@@ -12430,16 +12134,6 @@
             "integrity": "sha512-jk1+QP6ZJqyOiuEI9AEWQfju/nB2Pw466kbA0LEZljHwKeMgd9WrAEgEGxjPDD2+TNbbb37rTyhEfrCXfuKXnA==",
             "dev": true
         },
-        "node_modules/url-parse": {
-            "version": "1.5.10",
-            "resolved": "https://registry.npmjs.org/url-parse/-/url-parse-1.5.10.tgz",
-            "integrity": "sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==",
-            "license": "MIT",
-            "dependencies": {
-                "querystringify": "^2.1.1",
-                "requires-port": "^1.0.0"
-            }
-        },
         "node_modules/util": {
             "version": "0.10.4",
             "resolved": "https://registry.npmjs.org/util/-/util-0.10.4.tgz",
@@ -12504,26 +12198,6 @@
             "engines": {
                 "node": ">= 0.8"
             }
-        },
-        "node_modules/verror": {
-            "version": "1.10.0",
-            "resolved": "https://registry.npmjs.org/verror/-/verror-1.10.0.tgz",
-            "integrity": "sha512-ZZKSmDAEFOijERBLkmYfJ+vmk3w+7hOLYDNkRCuRuMJGEmqYNCNLyBBFwWKVMhfwaEF3WOd0Zlw86U/WC/+nYw==",
-            "engines": [
-                "node >=0.6.0"
-            ],
-            "license": "MIT",
-            "dependencies": {
-                "assert-plus": "^1.0.0",
-                "core-util-is": "1.0.2",
-                "extsprintf": "^1.2.0"
-            }
-        },
-        "node_modules/verror/node_modules/core-util-is": {
-            "version": "1.0.2",
-            "resolved": "https://registry.npmjs.org/core-util-is/-/core-util-is-1.0.2.tgz",
-            "integrity": "sha512-3lqz5YjWTYnW6dlDa5TLaTCcShfar1e40rmcJVwCBJC6mWlFuj0eCHIElmG1g5kyuJ/GD+8Wn4FFCcz4gJPfaQ==",
-            "license": "MIT"
         },
         "node_modules/version-range": {
             "version": "4.15.0",


### PR DESCRIPTION
Clears the `postman-request` > `uuid@3.4.0` advisory chain by refreshing `roku-debug` in the lockfile. 5 advisories -> 3.

`npm audit --omit=dev`: 3 remaining, all pre-existing and allowlisted (see notes). 417 prod deps.

## Ships to consumers

Nothing — no `package.json` change. This is an extension bundled as a `.vsix`, not a published library, so lockfile resolution *is* what ships to users here.

## Lockfile only

| Package | From | To | Advisory cleared |
|---|---|---|---|
| roku-debug | 0.24.1 | 0.24.3 | [GHSA-w5hq-g745-h8pq](https://github.com/advisories/GHSA-w5hq-g745-h8pq) (via transitive) |

## Notes for the reviewer

- `roku-debug@0.24.3` swapped `postman-request` for `needle`, so `uuid@3.4.0` is gone from the tree entirely. This was already permitted by the declared `^0.24.1` range — the lockfile was just stale, so no manifest edit was needed.
- Remaining `ip`/`node-ssdp` highs are unchanged and already allowlisted in `audit-ci.jsonc`; the only fix is a downgrade to `node-ssdp@1.0.0` from `^4.0.0`. Left alone.
- Remaining `uuid` moderate is the direct `^9.0.1` dep. I tried bumping to `^11.1.1` and **reverted it** — `uuid@11`'s `.d.ts` fails this repo's TypeScript (`error TS1383: Only named exports may use 'export type'`). It's also unreachable: the sole usage is `v4` ([RokuAppOverlaysViewViewProvider.ts:4](src/viewProviders/RokuAppOverlaysViewViewProvider.ts#L4)) and the advisory affects `v3/v5/v6` with a `buf` argument. Recommend leaving until a TS upgrade makes `uuid@11` viable.
- Unrelated: the repo's 12 Dependabot alerts are mostly in manifests `npm audit` doesn't cover; not addressed here.

## Verification

`npm run preversion` passed: build, lint, webviews, 1304 tests, check-extraneous, audit gate green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)