### PR TITLE
Add the ability to hide devices from every device list

### DIFF
--- a/package.json
+++ b/package.json
@@ -607,6 +607,16 @@
                     "command": "extension.brightscript.devicesView.deviceMenu.editInWorkspaceSettings",
                     "when": "view == devicesView && viewItem =~ /-inWorkspace\\b/",
                     "group": "5_settings@2"
+                },
+                {
+                    "command": "extension.brightscript.devicesView.deviceMenu.hideDevice",
+                    "when": "view == devicesView && viewItem =~ /-notHidden\\b/",
+                    "group": "6_visibility@1"
+                },
+                {
+                    "command": "extension.brightscript.devicesView.deviceMenu.unhideDevice",
+                    "when": "view == devicesView && viewItem =~ /-isHidden\\b/",
+                    "group": "6_visibility@1"
                 }
             ],
             "explorer/context": [
@@ -732,6 +742,20 @@
                     "command": "extension.brightscript.devicesView.toggleFilter.cloud.active",
                     "when": "brightscript.devicesView.filter.cloud && brightscript.experimental.rokuCloudEmulator",
                     "group": "5_kind@2"
+                },
+                {
+                    "command": "extension.brightscript.devicesView.toggleFilter.hidden",
+                    "when": "!brightscript.devicesView.filter.hidden",
+                    "group": "6_hidden@1"
+                },
+                {
+                    "command": "extension.brightscript.devicesView.toggleFilter.hidden.active",
+                    "when": "brightscript.devicesView.filter.hidden",
+                    "group": "6_hidden@1"
+                },
+                {
+                    "command": "extension.brightscript.devicesView.unhideAllDevices",
+                    "group": "6_hidden@2"
                 },
                 {
                     "command": "extension.brightscript.devicesView.resetFilters",
@@ -905,6 +929,22 @@
                 },
                 {
                     "command": "extension.brightscript.devicesView.deviceMenu.editInWorkspaceSettings",
+                    "when": "false"
+                },
+                {
+                    "command": "extension.brightscript.devicesView.deviceMenu.hideDevice",
+                    "when": "false"
+                },
+                {
+                    "command": "extension.brightscript.devicesView.deviceMenu.unhideDevice",
+                    "when": "false"
+                },
+                {
+                    "command": "extension.brightscript.devicesView.toggleFilter.hidden",
+                    "when": "false"
+                },
+                {
+                    "command": "extension.brightscript.devicesView.toggleFilter.hidden.active",
                     "when": "false"
                 }
             ]
@@ -2832,6 +2872,12 @@
                         "default": true,
                         "description": "Show Roku Cloud Emulator devices in the Devices view.",
                         "scope": "application"
+                    },
+                    "brightscript.devicesView.filters.hidden": {
+                        "type": "boolean",
+                        "default": false,
+                        "description": "Show devices you have hidden in the Devices view. Hide a device by right-clicking it and choosing \"Hide Device\".",
+                        "scope": "application"
                     }
                 }
             },
@@ -2903,6 +2949,12 @@
                         "type": "boolean",
                         "default": true,
                         "description": "Show Roku Cloud Emulator devices in the device quick pick.",
+                        "scope": "application"
+                    },
+                    "brightscript.deviceQuickPick.filters.hidden": {
+                        "type": "boolean",
+                        "default": false,
+                        "description": "Show devices you have hidden in the device quick pick. Hide a device by right-clicking it in the Devices view and choosing \"Hide Device\".",
                         "scope": "application"
                     }
                 }
@@ -4201,6 +4253,21 @@
                 "category": "BrightScript"
             },
             {
+                "command": "extension.brightscript.devicesView.toggleFilter.hidden",
+                "title": "☐ Hidden",
+                "category": "BrightScript"
+            },
+            {
+                "command": "extension.brightscript.devicesView.toggleFilter.hidden.active",
+                "title": "☑ Hidden",
+                "category": "BrightScript"
+            },
+            {
+                "command": "extension.brightscript.devicesView.unhideAllDevices",
+                "title": "Unhide All Devices",
+                "category": "BrightScript"
+            },
+            {
                 "command": "extension.brightscript.devicesView.resetFilters",
                 "title": "Reset Filters",
                 "category": "BrightScript"
@@ -4353,6 +4420,16 @@
             {
                 "command": "extension.brightscript.devicesView.deviceMenu.editInWorkspaceSettings",
                 "title": "📁 Edit in Workspace Settings",
+                "category": "BrightScript"
+            },
+            {
+                "command": "extension.brightscript.devicesView.deviceMenu.hideDevice",
+                "title": "🙈 Hide Device",
+                "category": "BrightScript"
+            },
+            {
+                "command": "extension.brightscript.devicesView.deviceMenu.unhideDevice",
+                "title": "👁 Unhide Device",
                 "category": "BrightScript"
             },
             {

--- a/src/BrightScriptCommands.ts
+++ b/src/BrightScriptCommands.ts
@@ -1152,6 +1152,7 @@ export class BrightScriptCommands {
             this.registerCommand(`devicesView.toggleFilter.${key}.active`, handler);
         }
         this.registerCommand('devicesView.resetFilters', () => devicesViewProvider.resetFilters());
+        this.registerCommand('devicesView.unhideAllDevices', () => this.deviceManager.unhideAllDevices());
         // These also appear in the command palette, where there's no tree element; resolving
         // a missing/unknown key to undefined lets `restartDevice`/`checkForUpdates` fall back
         // to the active device or device picker.
@@ -1235,6 +1236,12 @@ export class BrightScriptCommands {
         });
         this.registerCommand('devicesView.deviceMenu.editInWorkspaceSettings', (element?: { key?: string }) => {
             return vscode.commands.executeCommand('extension.brightscript.editDeviceInWorkspaceSettings', element);
+        });
+        this.registerCommand('devicesView.deviceMenu.hideDevice', (element?: { key?: string }) => {
+            return element?.key ? this.deviceManager.hideDevice(element.key) : undefined;
+        });
+        this.registerCommand('devicesView.deviceMenu.unhideDevice', (element?: { key?: string }) => {
+            return element?.key ? this.deviceManager.unhideDevice(element.key) : undefined;
         });
     }
 

--- a/src/GlobalStateManager.spec.ts
+++ b/src/GlobalStateManager.spec.ts
@@ -402,4 +402,61 @@ describe('GlobalStateManager', () => {
             expect(manager.getSerialNumberForIp('10.0.1.100', networkA)).to.equal('LOCAL123');
         });
     });
+
+    describe('hidden device keys', () => {
+        it('returns an empty list when nothing has been hidden', () => {
+            expect(manager.getHiddenDeviceKeys()).to.deep.equal([]);
+        });
+
+        it('ignores a stored value that is not an array of strings', () => {
+            storage['hiddenDeviceKeys'] = 'not-an-array';
+            expect(manager.getHiddenDeviceKeys()).to.deep.equal([]);
+
+            storage['hiddenDeviceKeys'] = ['s:GOOD', 42, null, 's:ALSO_GOOD'];
+            expect(manager.getHiddenDeviceKeys()).to.deep.equal(['s:GOOD', 's:ALSO_GOOD']);
+        });
+
+        it('adds keys without duplicating them', async () => {
+            await manager.addHiddenDeviceKey('s:ONE');
+            await manager.addHiddenDeviceKey('s:TWO');
+            await manager.addHiddenDeviceKey('s:ONE');
+            expect(manager.getHiddenDeviceKeys()).to.deep.equal(['s:ONE', 's:TWO']);
+        });
+
+        it('removes a single key and leaves the rest', async () => {
+            await manager.setHiddenDeviceKeys(['s:ONE', 's:TWO', 's:THREE']);
+            await manager.removeHiddenDeviceKey('s:TWO');
+            expect(manager.getHiddenDeviceKeys()).to.deep.equal(['s:ONE', 's:THREE']);
+        });
+
+        it('clears the stored key entirely when the list becomes empty', async () => {
+            await manager.setHiddenDeviceKeys(['s:ONE']);
+            await manager.setHiddenDeviceKeys([]);
+            expect(storage['hiddenDeviceKeys']).to.be.undefined;
+            expect(manager.getHiddenDeviceKeys()).to.deep.equal([]);
+        });
+
+        it('dedupes on write', async () => {
+            await manager.setHiddenDeviceKeys(['s:ONE', 's:ONE', 's:TWO']);
+            expect(manager.getHiddenDeviceKeys()).to.deep.equal(['s:ONE', 's:TWO']);
+        });
+
+        it('migrates an ip-based key to the serial key once the serial resolves', async () => {
+            await manager.setHiddenDeviceKeys(['i:192.168.1.5', 's:OTHER']);
+            await manager.migrateHiddenDeviceKey('i:192.168.1.5', 's:RESOLVED');
+            expect(manager.getHiddenDeviceKeys()).to.deep.equal(['s:RESOLVED', 's:OTHER']);
+        });
+
+        it('leaves the list alone when migrating a key that is not hidden', async () => {
+            await manager.setHiddenDeviceKeys(['s:ONE']);
+            await manager.migrateHiddenDeviceKey('i:10.0.0.1', 's:TWO');
+            expect(manager.getHiddenDeviceKeys()).to.deep.equal(['s:ONE']);
+        });
+
+        it('is a no-op when the old and new key are the same', async () => {
+            await manager.setHiddenDeviceKeys(['s:ONE']);
+            await manager.migrateHiddenDeviceKey('s:ONE', 's:ONE');
+            expect(manager.getHiddenDeviceKeys()).to.deep.equal(['s:ONE']);
+        });
+    });
 });

--- a/src/GlobalStateManager.ts
+++ b/src/GlobalStateManager.ts
@@ -18,7 +18,8 @@ export class GlobalStateManager {
         lastSeenDevicesByNetwork: 'lastSeenDevicesByNetwork',
         deviceCache: 'deviceCache',
         serialNumberByIpForNetwork: 'serialNumberByIpForNetwork',
-        lastAliveTimestamp: 'lastAliveTimestamp'
+        lastAliveTimestamp: 'lastAliveTimestamp',
+        hiddenDeviceKeys: 'hiddenDeviceKeys'
     };
     private remoteTextHistoryLimit: number;
     private remoteTextHistoryEnabled: boolean;
@@ -309,6 +310,53 @@ export class GlobalStateManager {
         const map = this.context.globalState.get<Record<string, number>>(this.keys.lastAliveTimestamp) || {};
         map[key] = timestamp;
         void this.context.globalState.update(this.keys.lastAliveTimestamp, map);
+    }
+
+    /**
+     * The device keys the user has chosen to hide. This backs the `hidden` device filter facet,
+     * which is the one facet not derived from the device itself. It lives here rather than in
+     * settings because it's a machine-wide note about which devices are noise, not project config.
+     */
+    public getHiddenDeviceKeys(): string[] {
+        const value = this.context.globalState.get<string[]>(this.keys.hiddenDeviceKeys);
+        return Array.isArray(value) ? value.filter(key => typeof key === 'string') : [];
+    }
+
+    public async setHiddenDeviceKeys(keys: string[]): Promise<void> {
+        const unique = [...new Set(keys)];
+        //store `undefined` for an empty list so the key disappears entirely instead of holding []
+        await Promise.resolve(
+            this.context.globalState.update(this.keys.hiddenDeviceKeys, unique.length > 0 ? unique : undefined)
+        );
+    }
+
+    public async addHiddenDeviceKey(key: string): Promise<void> {
+        const keys = this.getHiddenDeviceKeys();
+        if (!keys.includes(key)) {
+            await this.setHiddenDeviceKeys([...keys, key]);
+        }
+    }
+
+    public async removeHiddenDeviceKey(key: string): Promise<void> {
+        const keys = this.getHiddenDeviceKeys();
+        if (keys.includes(key)) {
+            await this.setHiddenDeviceKeys(keys.filter(existing => existing !== key));
+        }
+    }
+
+    /**
+     * A device discovered before its serial number is known is keyed by ip (`i:{ip}`) and later
+     * re-keyed to its stable serial key (`s:{serial}`). Move any hidden entry along with it so the
+     * device doesn't silently reappear once its serial resolves.
+     */
+    public async migrateHiddenDeviceKey(oldKey: string, newKey: string): Promise<void> {
+        const keys = this.getHiddenDeviceKeys();
+        if (!keys.includes(oldKey) || oldKey === newKey) {
+            return;
+        }
+        await this.setHiddenDeviceKeys(keys.map(key => {
+            return key === oldKey ? newKey : key;
+        }));
     }
 
     /**

--- a/src/deviceDiscovery/DeviceManager.spec.ts
+++ b/src/deviceDiscovery/DeviceManager.spec.ts
@@ -141,7 +141,12 @@ describe('DeviceManager', () => {
             clearSerialNumberByIpForNetwork: sinon.stub().callsFake(() => {
                 ipToSerialMap.clear();
             }),
-            clearExpiredEntriesSerialNumberByIpForNetwork: sinon.stub()
+            clearExpiredEntriesSerialNumberByIpForNetwork: sinon.stub(),
+            getHiddenDeviceKeys: sinon.stub().returns([]),
+            setHiddenDeviceKeys: sinon.stub().resolves(),
+            addHiddenDeviceKey: sinon.stub().resolves(),
+            removeHiddenDeviceKey: sinon.stub().resolves(),
+            migrateHiddenDeviceKey: sinon.stub().resolves()
         };
 
         // Mock vscode configuration

--- a/src/deviceDiscovery/DeviceManager.ts
+++ b/src/deviceDiscovery/DeviceManager.ts
@@ -787,6 +787,43 @@ export class DeviceManager {
         this.lastUsedDeviceKey = value;
     }
 
+    /**
+     * The keys of devices the user has hidden, in the shape `applyDeviceFilters` wants.
+     * Backs the `hidden` filter facet.
+     */
+    public getHiddenDeviceKeys(): ReadonlySet<string> {
+        return new Set(this.globalStateManager.getHiddenDeviceKeys());
+    }
+
+    /**
+     * Hide a device from every device list (the Devices view, the device quick pick, ...).
+     * Persisted globally, so it survives restarts and applies in every window.
+     */
+    public async hideDevice(key: string): Promise<void> {
+        await this.globalStateManager.addHiddenDeviceKey(key);
+        this.emitter.emit('devices-changed');
+    }
+
+    /**
+     * Unhide a single previously-hidden device.
+     */
+    public async unhideDevice(key: string): Promise<void> {
+        await this.globalStateManager.removeHiddenDeviceKey(key);
+        this.emitter.emit('devices-changed');
+    }
+
+    /**
+     * Unhide every hidden device at once.
+     */
+    public async unhideAllDevices(): Promise<void> {
+        await this.globalStateManager.setHiddenDeviceKeys([]);
+        this.emitter.emit('devices-changed');
+    }
+
+    public isDeviceHidden(key: string): boolean {
+        return this.globalStateManager.getHiddenDeviceKeys().includes(key);
+    }
+
     public dispose() {
         this.deactivateMonitoring();
         this.systemSleepMonitor?.dispose?.();
@@ -1255,6 +1292,8 @@ export class DeviceManager {
                 if (this.lastUsedDeviceKey === `i:${oldIp}`) {
                     this.lastUsedDeviceKey = `s:${serialNumber}`;
                 }
+                //a device hidden while it was only known by ip stays hidden under its serial key
+                void this.globalStateManager.migrateHiddenDeviceKey(`i:${oldIp}`, `s:${serialNumber}`);
                 this.discoveredDevices.splice(oldIdx, 1);
             }
         }

--- a/src/deviceFilters.spec.ts
+++ b/src/deviceFilters.spec.ts
@@ -171,4 +171,42 @@ describe('deviceFilters', () => {
             expect(result.online).to.equal(DEFAULT_DEVICE_FILTERS.online);
         });
     });
+
+    describe('hidden facet', () => {
+        const devices = [
+            { key: 's:VISIBLE', deviceState: 'online', isConfigured: false, deviceInfo: {} },
+            { key: 's:HIDDEN', deviceState: 'online', isConfigured: false, deviceInfo: {} }
+        ] as any[];
+
+        it('excludes hidden devices by default', () => {
+            expect(
+                applyDeviceFilters(devices, DEFAULT_DEVICE_FILTERS, new Set(['s:HIDDEN'])).map(d => d.key)
+            ).to.deep.equal(['s:VISIBLE']);
+        });
+
+        it('includes hidden devices when the hidden facet is on', () => {
+            expect(
+                applyDeviceFilters(devices, { ...DEFAULT_DEVICE_FILTERS, hidden: true }, new Set(['s:HIDDEN'])).map(d => d.key)
+            ).to.deep.equal(['s:VISIBLE', 's:HIDDEN']);
+        });
+
+        it('is a no-op when no hidden keys are supplied', () => {
+            expect(applyDeviceFilters(devices, DEFAULT_DEVICE_FILTERS).map(d => d.key)).to.deep.equal(['s:VISIBLE', 's:HIDDEN']);
+            expect(applyDeviceFilters(devices, DEFAULT_DEVICE_FILTERS, new Set()).map(d => d.key)).to.deep.equal(['s:VISIBLE', 's:HIDDEN']);
+        });
+
+        it('still applies the other facets to a hidden device that is being shown', () => {
+            //hidden is strict-AND with the rest: revealing hidden devices doesn't bypass the offline facet
+            const offlineHidden = [
+                { key: 's:HIDDEN', deviceState: 'offline', isConfigured: false, deviceInfo: {} }
+            ] as any[];
+            expect(
+                applyDeviceFilters(offlineHidden, { ...DEFAULT_DEVICE_FILTERS, hidden: true }, new Set(['s:HIDDEN']))
+            ).to.be.empty;
+        });
+
+        it('defaults the hidden facet to off', () => {
+            expect(DEFAULT_DEVICE_FILTERS.hidden).to.be.false;
+        });
+    });
 });

--- a/src/deviceFilters.ts
+++ b/src/deviceFilters.ts
@@ -17,6 +17,7 @@ export interface DeviceFilters {
     autoDetected: boolean;
     local: boolean;
     cloud: boolean;
+    hidden: boolean;
 }
 
 export const DEVICE_FILTER_KEYS: Array<keyof DeviceFilters> = [
@@ -30,7 +31,8 @@ export const DEVICE_FILTER_KEYS: Array<keyof DeviceFilters> = [
     'userDefined',
     'autoDetected',
     'local',
-    'cloud'
+    'cloud',
+    'hidden'
 ];
 
 /**
@@ -48,7 +50,8 @@ export const DEVICE_FILTER_LABELS: Record<keyof DeviceFilters, string> = {
     userDefined: 'User Defined',
     autoDetected: 'Auto Detected',
     local: 'Local',
-    cloud: 'Cloud'
+    cloud: 'Cloud',
+    hidden: 'Hidden'
 };
 
 /**
@@ -60,7 +63,8 @@ export const DEVICE_FILTER_GROUPS: Array<Array<keyof DeviceFilters>> = [
     ['tv', 'setTopBox', 'stick'],
     ['online', 'offline'],
     ['userDefined', 'autoDetected'],
-    ['local', 'cloud']
+    ['local', 'cloud'],
+    ['hidden']
 ];
 
 export const DEFAULT_DEVICE_FILTERS: DeviceFilters = {
@@ -74,7 +78,10 @@ export const DEFAULT_DEVICE_FILTERS: DeviceFilters = {
     userDefined: true,
     autoDetected: true,
     local: true,
-    cloud: true
+    cloud: true,
+    //the only facet that defaults to off: a device the user explicitly hid stays out of the
+    //list until they turn this on to go find it again
+    hidden: false
 };
 
 /**
@@ -97,9 +104,18 @@ export function loadDeviceFilters(section: string): DeviceFilters {
  * Strict-AND filter: a device must satisfy every enabled facet to be retained.
  * Pending devices stay visible to the online facet only when their last known
  * state was online; otherwise they fall under the offline facet.
+ *
+ * `hiddenDeviceKeys` holds the devices the user explicitly hid. Unlike every other facet, this
+ * list isn't derived from the device itself, so it's passed in by the caller (it lives in global
+ * state rather than settings — see GlobalStateManager.getHiddenDeviceKeys).
  */
-export function applyDeviceFilters(devices: RokuDevice[], filters: DeviceFilters): RokuDevice[] {
+export function applyDeviceFilters(devices: RokuDevice[], filters: DeviceFilters, hiddenDeviceKeys?: ReadonlySet<string>): RokuDevice[] {
     return devices.filter(device => {
+        //an explicitly-hidden device is only listed when the `hidden` facet is turned on
+        if (!filters.hidden && hiddenDeviceKeys?.has(device.key)) {
+            return false;
+        }
+
         const info = device.deviceInfo ?? {};
         const isTv = info['is-tv'] === 'true';
         const isStick = info['is-stick'] === 'true';

--- a/src/managers/UserInputManager.ts
+++ b/src/managers/UserInputManager.ts
@@ -353,7 +353,7 @@ export class UserInputManager {
         const refreshList = () => {
             const filters = loadDeviceFilters(DEVICE_QUICK_PICK_FILTERS_SECTION);
             const items = this.createHostQuickPickList(
-                applyDeviceFilters(this.deviceManager.getAllDevices(), filters),
+                applyDeviceFilters(this.deviceManager.getAllDevices(), filters, this.deviceManager.getHiddenDeviceKeys()),
                 this.deviceManager.getLastUsedDeviceKey(),
                 itemCache
             );

--- a/src/viewProviders/DevicesViewProvider.spec.ts
+++ b/src/viewProviders/DevicesViewProvider.spec.ts
@@ -87,7 +87,8 @@ describe('DevicesViewProvider', () => {
         } as any;
     }
 
-    function createProvider(devices: any[], options?: { storedPasswords?: Record<string, string> }) {
+    function createProvider(devices: any[], options?: { storedPasswords?: Record<string, string>; hiddenDeviceKeys?: string[] }) {
+        let hiddenKeys = [...(options?.hiddenDeviceKeys ?? [])];
         const emitter = new EventEmitter();
         const deviceManager: any = {
             on: (event: string, handler: any) => emitter.on(event, handler),
@@ -99,14 +100,38 @@ describe('DevicesViewProvider', () => {
             getIconPath: () => undefined,
             hasDeviceCache: () => false,
             refresh: () => undefined,
-            healthCheckDevice: () => Promise.resolve()
+            healthCheckDevice: () => Promise.resolve(),
+            getHiddenDeviceKeys: () => new Set(hiddenKeys),
+            isDeviceHidden: (key: string) => hiddenKeys.includes(key),
+            hideDevice: (key: string) => {
+                if (!hiddenKeys.includes(key)) {
+                    hiddenKeys.push(key);
+                }
+                emitter.emit('devices-changed');
+                return Promise.resolve();
+            },
+            unhideDevice: (key: string) => {
+                hiddenKeys = hiddenKeys.filter(existing => existing !== key);
+                emitter.emit('devices-changed');
+                return Promise.resolve();
+            },
+            unhideAllDevices: () => {
+                hiddenKeys = [];
+                emitter.emit('devices-changed');
+                return Promise.resolve();
+            }
         };
         const credentialStore: any = {
             on: () => undefined,
             getPassword: (serialNumber: string) => Promise.resolve(options?.storedPasswords?.[serialNumber])
         };
         const provider = new DevicesViewProvider(deviceManager, credentialStore, vscode.context as any);
-        return { provider: provider, deviceManager: deviceManager, emitter: emitter };
+        return {
+            provider: provider,
+            deviceManager: deviceManager,
+            emitter: emitter,
+            getHiddenKeys: () => [...hiddenKeys]
+        };
     }
 
     beforeEach(async () => {
@@ -216,21 +241,21 @@ describe('DevicesViewProvider', () => {
             const devices = [makeDevice({ key: 'tv1', isTv: true, softwareVersion: '15.3.4', serialNumber: 'SERIAL1' })];
             const { provider } = createProvider(devices);
             const items = await provider.getChildren();
-            expect(items[0].contextValue).to.equal('device-local-notInUser-notInWorkspace-noPassword-isTv-canViewRegistry-canRestart-notActive');
+            expect(items[0].contextValue).to.equal('device-local-notInUser-notInWorkspace-noPassword-isTv-canViewRegistry-canRestart-notActive-notHidden');
         });
 
         it('includes hasPassword and configured-in tokens, and gates version-specific tokens', async () => {
             const devices = [makeDevice({ key: 'stb1', softwareVersion: '12.0.0', serialNumber: 'SERIAL2', configuredIn: ['user', 'workspace'] })];
             const { provider } = createProvider(devices, { storedPasswords: { SERIAL2: 'secret' } });
             const items = await provider.getChildren();
-            expect(items[0].contextValue).to.equal('device-local-inUser-inWorkspace-hasPassword-canViewRegistry-notActive');
+            expect(items[0].contextValue).to.equal('device-local-inUser-inWorkspace-hasPassword-canViewRegistry-notActive-notHidden');
         });
 
         it('omits password and version-gated tokens when serial number and software version are unknown', async () => {
             const devices = [makeDevice({ key: 'stb1' })];
             const { provider } = createProvider(devices);
             const items = await provider.getChildren();
-            expect(items[0].contextValue).to.equal('device-local-notInUser-notInWorkspace-notActive');
+            expect(items[0].contextValue).to.equal('device-local-notInUser-notInWorkspace-notActive-notHidden');
         });
 
         it('builds a cloud contextValue without the settings tokens', async () => {
@@ -239,7 +264,7 @@ describe('DevicesViewProvider', () => {
             const devices = [makeDevice({ key: 's:ESN1', isRce: true, isTv: true, softwareVersion: '15.2.4', serialNumber: 'ESN1' })];
             const { provider } = createProvider(devices);
             const items = await provider.getChildren();
-            expect(items[0].contextValue).to.equal('device-cloud-noPassword-isTv-canViewRegistry-canRestart-notActive');
+            expect(items[0].contextValue).to.equal('device-cloud-noPassword-isTv-canViewRegistry-canRestart-notActive-notHidden');
         });
 
         it('lists the cloud action items for an rce device', async () => {
@@ -531,6 +556,77 @@ describe('DevicesViewProvider', () => {
             });
 
             expect(treeChanged.called).to.be.false;
+        });
+    });
+
+    describe('hidden devices', () => {
+        it('omits hidden devices from the tree by default', async () => {
+            const devices = [makeDevice({ key: 'a' }), makeDevice({ key: 'b' })];
+            const { provider } = createProvider(devices, { hiddenDeviceKeys: ['b'] });
+
+            const items = await provider.getChildren();
+            expect(items.map(item => (item as any).key)).to.deep.equal(['a']);
+        });
+
+        it('includes hidden devices when the hidden filter facet is on', async () => {
+            seedFilters({ hidden: true });
+            const devices = [makeDevice({ key: 'a' }), makeDevice({ key: 'b' })];
+            const { provider } = createProvider(devices, { hiddenDeviceKeys: ['b'] });
+
+            const items = await provider.getChildren();
+            expect(items.map(item => (item as any).key)).to.deep.equal(['a', 'b']);
+            //the revealed row offers Unhide rather than Hide
+            expect(items[0].contextValue).to.contain('-notHidden');
+            expect(items[1].contextValue).to.contain('-isHidden');
+        });
+
+        it('toggling the hidden facet reveals and re-hides devices', async () => {
+            const devices = [makeDevice({ key: 'a' }), makeDevice({ key: 'b' })];
+            const { provider } = createProvider(devices, { hiddenDeviceKeys: ['b'] });
+
+            await provider.toggleFilter('hidden');
+            expect((await provider.getChildren()).map(item => (item as any).key)).to.deep.equal(['a', 'b']);
+
+            await provider.toggleFilter('hidden');
+            expect((await provider.getChildren()).map(item => (item as any).key)).to.deep.equal(['a']);
+        });
+
+        it('drops a device from the tree once it is hidden through the device manager', async () => {
+            const devices = [makeDevice({ key: 'a' }), makeDevice({ key: 'b' })];
+            const { provider, deviceManager, getHiddenKeys } = createProvider(devices);
+
+            await deviceManager.hideDevice('b');
+
+            expect(getHiddenKeys()).to.deep.equal(['b']);
+            expect((await provider.getChildren()).map(item => (item as any).key)).to.deep.equal(['a']);
+        });
+
+        it('restores a device to the tree once it is unhidden', async () => {
+            const devices = [makeDevice({ key: 'a' }), makeDevice({ key: 'b' })];
+            const { provider, deviceManager } = createProvider(devices, { hiddenDeviceKeys: ['b'] });
+
+            await deviceManager.unhideDevice('b');
+
+            expect((await provider.getChildren()).map(item => (item as any).key)).to.deep.equal(['a', 'b']);
+        });
+
+        it('fires a tree change when the hidden list changes', async () => {
+            const { provider, deviceManager } = createProvider([makeDevice({ key: 'a' })]);
+            const treeChanged = sinon.spy();
+            provider.onDidChangeTreeData(treeChanged);
+
+            await deviceManager.hideDevice('a');
+
+            expect(treeChanged.called).to.be.true;
+        });
+
+        it('a hidden device stays excluded when another facet would have shown it', async () => {
+            //hidden is strict-AND with the rest, so turning on the offline facet doesn't reveal it
+            seedFilters({ offline: true });
+            const devices = [makeDevice({ key: 'a' }), makeDevice({ key: 'b', deviceState: 'offline' })];
+            const { provider } = createProvider(devices, { hiddenDeviceKeys: ['b'] });
+
+            expect((await provider.getChildren()).map(item => (item as any).key)).to.deep.equal(['a']);
         });
     });
 });

--- a/src/viewProviders/DevicesViewProvider.ts
+++ b/src/viewProviders/DevicesViewProvider.ts
@@ -63,6 +63,7 @@ export class DevicesViewProvider implements vscode.TreeDataProvider<vscode.TreeI
             this.handleDevicesChanged();
         });
 
+
         // Re-render when the active device changes so the indicator moves to the correct row
         const unsubscribeContextChange = vscodeContextManager.onChange((key) => {
             if (key === 'activeDeviceKey') {
@@ -466,6 +467,8 @@ export class DevicesViewProvider implements vscode.TreeDataProvider<vscode.TreeI
             tokens.push('canRestart');
         }
         tokens.push(this.isActiveDevice(device) ? 'isActive' : 'notActive');
+        //`isHidden` rows are only rendered while the `hidden` filter facet is on, where they offer Unhide
+        tokens.push(this.deviceManager.isDeviceHidden(device.key) ? 'isHidden' : 'notHidden');
         return tokens.join('-');
     }
 
@@ -573,7 +576,7 @@ export class DevicesViewProvider implements vscode.TreeDataProvider<vscode.TreeI
     }
 
     private applyFilters(devices: RokuDevice[]): RokuDevice[] {
-        return applyDeviceFilters(devices, this.filters);
+        return applyDeviceFilters(devices, this.filters, this.deviceManager.getHiddenDeviceKeys());
     }
 
     private loadFilters(): DeviceFilters {


### PR DESCRIPTION
I have CI/CD-allocated Roku devices that are also marked as dev devices, so no existing filter separates them from my real dev devices. This adds an explicit per-device hide.

Implemented as a new `hidden` filter facet rather than Devices-view-only logic, so hiding applies everywhere devices are listed — side panel, quick pick, both filter submenus, both settings sections.

**What changed**
- `deviceFilters.ts`: new `hidden` facet. It's the only facet defaulting to `false`, which is what makes hiding actually hide.
- `applyDeviceFilters` takes an optional third arg, `hiddenDeviceKeys`. Every other facet is derived from the device itself; this one can't be, so the caller supplies it.
- `GlobalStateManager`: stores the hidden device keys, including migration of an `i:{ip}` key to `s:{serial}` — without it a hidden device reappears once its serial resolves.
- `DeviceManager`: `hideDevice`/`unhideDevice`/`unhideAllDevices`, each emitting `devices-changed` so open views refresh with no new event plumbing.
- Context menu: 🙈 Hide Device / 👁 Unhide Device, gated on a new `isHidden`/`notHidden` `contextValue` token. Unhide All Devices sits in the filter submenu.

`hidden` is strict-AND with the other facets, like all of them — so turning it on reveals hidden devices *that still pass the other filters*. A hidden offline device stays out while `offline` is off. There's a test pinning this.

Verified: `npm test` 1325 passing / 0 failing (21 new), plus `tsc --noEmit` and `npm run lint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
